### PR TITLE
feat: implement CRAPload reduction (spec 009)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,12 +229,13 @@ Formatters: gofmt, goimports.
 
 ## Active Technologies
 
-- Go 1.24.2 + Cobra (CLI), Bubble Tea/Lipgloss (TUI)
+- Go 1.24+ + `golang.org/x/tools` (go/packages, go/ssa), Cobra (CLI), Bubble Tea/Lipgloss (TUI)
 - Filesystem only (embedded assets via `embed.FS`)
 - GoReleaser v2 (release pipeline, Homebrew cask publishing)
 
 ## Recent Changes
 
+- 009-crapload-reduction: CRAPload reduction — contract-level tests for `docscan.Filter` and `LoadModule`, dependency injection for `runCrap`/`runSelfCheck`, decomposition of `buildContractCoverageFunc` into `resolvePackagePaths`/`analyzePackageCoverage`, and decomposition of `AnalyzeP1Effects`/`AnalyzeP2Effects` into per-node-type handler functions
 - 008-contract-coverage-gaps: Contract coverage gap remediation — direct unit tests for 8 functions with zero contract coverage across `internal/classify/`, `internal/analysis/`, and `cmd/gaze/` (test-only, no production code changes)
 - 007-assertion-mapping-depth: Assertion mapping depth improvements — resolveExprRoot (selector/index/builtin unwinding), two-pass matching (direct 75/indirect 65), helper return value tracing (depth-1 SSA verification). Mapping accuracy improved from 73.8% to 78.8% (ratchet floor 76.0%)
 - 006-agent-quality-report-enhancements: Unmapped assertion reasons, gap hints, discarded return details, ambiguous effects expansion in quality reports

--- a/internal/analysis/p1effects.go
+++ b/internal/analysis/p1effects.go
@@ -20,6 +20,11 @@ import (
 //   - HTTPResponseWrite: calls to http.ResponseWriter methods
 //   - SliceMutation: direct index assignment on slice parameters
 //   - MapMutation: map index assignment on map parameters
+//
+// Internally, the function dispatches to per-node-type handlers:
+// detectAssignEffects, detectIncDecEffects, detectSendEffects, and
+// detectP1CallEffects. The shared seen map preserves deduplication
+// across all handlers.
 func AnalyzeP1Effects(
 	fset *token.FileSet,
 	info *types.Info,
@@ -40,167 +45,230 @@ func AnalyzeP1Effects(
 	ast.Inspect(fd.Body, func(n ast.Node) bool {
 		switch node := n.(type) {
 		case *ast.AssignStmt:
-			// Check for global mutations and map index assignments.
-			for _, lhs := range node.Lhs {
-				// Global mutation: assignment to a package-level var.
-				if ident, ok := lhs.(*ast.Ident); ok {
-					if isGlobalIdent(ident, info, locals) {
-						key := "global:" + ident.Name
-						if !seen[key] {
-							seen[key] = true
-							loc := fset.Position(ident.Pos()).String()
-							effects = append(effects, taxonomy.SideEffect{
-								ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.GlobalMutation), ident.Name),
-								Type:        taxonomy.GlobalMutation,
-								Tier:        taxonomy.TierP1,
-								Location:    loc,
-								Description: fmt.Sprintf("assigns to package-level variable '%s'", ident.Name),
-								Target:      ident.Name,
-							})
-						}
-					}
-				}
-				// Map mutation: m[key] = value.
-				if idx, ok := lhs.(*ast.IndexExpr); ok {
-					if isMapType(info, idx.X) {
-						name := exprName(idx.X)
-						key := "map:" + name
-						if !seen[key] {
-							seen[key] = true
-							loc := fset.Position(idx.Pos()).String()
-							effects = append(effects, taxonomy.SideEffect{
-								ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.MapMutation), name),
-								Type:        taxonomy.MapMutation,
-								Tier:        taxonomy.TierP1,
-								Location:    loc,
-								Description: fmt.Sprintf("writes to map '%s'", name),
-								Target:      name,
-							})
-						}
-					}
-				}
-				// Slice mutation: s[i] = value.
-				if idx, ok := lhs.(*ast.IndexExpr); ok {
-					if isSliceType(info, idx.X) {
-						name := exprName(idx.X)
-						key := "slice:" + name
-						if !seen[key] {
-							seen[key] = true
-							loc := fset.Position(idx.Pos()).String()
-							effects = append(effects, taxonomy.SideEffect{
-								ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.SliceMutation), name),
-								Type:        taxonomy.SliceMutation,
-								Tier:        taxonomy.TierP1,
-								Location:    loc,
-								Description: fmt.Sprintf("writes to slice element '%s'", name),
-								Target:      name,
-							})
-						}
-					}
-				}
-			}
-
+			effects = append(effects,
+				detectAssignEffects(fset, info, node, pkg, funcName, seen, locals)...)
 		case *ast.IncDecStmt:
-			// Global mutation via ++ or --.
-			if ident, ok := node.X.(*ast.Ident); ok {
-				if isGlobalIdent(ident, info, locals) {
-					key := "global:" + ident.Name
-					if !seen[key] {
-						seen[key] = true
-						loc := fset.Position(ident.Pos()).String()
-						effects = append(effects, taxonomy.SideEffect{
-							ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.GlobalMutation), ident.Name),
-							Type:        taxonomy.GlobalMutation,
-							Tier:        taxonomy.TierP1,
-							Location:    loc,
-							Description: fmt.Sprintf("modifies package-level variable '%s'", ident.Name),
-							Target:      ident.Name,
-						})
-					}
-				}
-			}
-
+			effects = append(effects,
+				detectIncDecEffects(fset, info, node, pkg, funcName, seen, locals)...)
 		case *ast.SendStmt:
-			// Channel send: ch <- value.
-			name := exprName(node.Chan)
-			key := "chsend:" + name
-			if !seen[key] {
-				seen[key] = true
-				loc := fset.Position(node.Pos()).String()
-				effects = append(effects, taxonomy.SideEffect{
-					ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.ChannelSend), name),
-					Type:        taxonomy.ChannelSend,
-					Tier:        taxonomy.TierP1,
-					Location:    loc,
-					Description: fmt.Sprintf("sends on channel '%s'", name),
-					Target:      name,
-				})
-			}
-
+			effects = append(effects,
+				detectSendEffects(fset, node, pkg, funcName, seen)...)
 		case *ast.CallExpr:
-			// Channel close: close(ch).
-			if isCloseCall(node, info) && len(node.Args) == 1 {
-				name := exprName(node.Args[0])
-				key := "chclose:" + name
+			effects = append(effects,
+				detectP1CallEffects(fset, info, node, pkg, funcName, seen)...)
+		}
+		return true
+	})
+
+	return effects
+}
+
+// detectAssignEffects handles *ast.AssignStmt nodes, detecting
+// GlobalMutation (assignment to package-level variables),
+// MapMutation (m[key] = value), and SliceMutation (s[i] = value).
+func detectAssignEffects(
+	fset *token.FileSet,
+	info *types.Info,
+	node *ast.AssignStmt,
+	pkg string,
+	funcName string,
+	seen map[string]bool,
+	locals map[string]bool,
+) []taxonomy.SideEffect {
+	var effects []taxonomy.SideEffect
+
+	for _, lhs := range node.Lhs {
+		// Global mutation: assignment to a package-level var.
+		if ident, ok := lhs.(*ast.Ident); ok {
+			if isGlobalIdent(ident, info, locals) {
+				key := "global:" + ident.Name
 				if !seen[key] {
 					seen[key] = true
-					loc := fset.Position(node.Pos()).String()
+					loc := fset.Position(ident.Pos()).String()
 					effects = append(effects, taxonomy.SideEffect{
-						ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.ChannelClose), name),
-						Type:        taxonomy.ChannelClose,
+						ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.GlobalMutation), ident.Name),
+						Type:        taxonomy.GlobalMutation,
 						Tier:        taxonomy.TierP1,
 						Location:    loc,
-						Description: fmt.Sprintf("closes channel '%s'", name),
+						Description: fmt.Sprintf("assigns to package-level variable '%s'", ident.Name),
+						Target:      ident.Name,
+					})
+				}
+			}
+		}
+		// Map or slice mutation: m[key] = value or s[i] = value.
+		if idx, ok := lhs.(*ast.IndexExpr); ok {
+			if isMapType(info, idx.X) {
+				name := exprName(idx.X)
+				key := "map:" + name
+				if !seen[key] {
+					seen[key] = true
+					loc := fset.Position(idx.Pos()).String()
+					effects = append(effects, taxonomy.SideEffect{
+						ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.MapMutation), name),
+						Type:        taxonomy.MapMutation,
+						Tier:        taxonomy.TierP1,
+						Location:    loc,
+						Description: fmt.Sprintf("writes to map '%s'", name),
+						Target:      name,
+					})
+				}
+			} else if isSliceType(info, idx.X) {
+				name := exprName(idx.X)
+				key := "slice:" + name
+				if !seen[key] {
+					seen[key] = true
+					loc := fset.Position(idx.Pos()).String()
+					effects = append(effects, taxonomy.SideEffect{
+						ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.SliceMutation), name),
+						Type:        taxonomy.SliceMutation,
+						Tier:        taxonomy.TierP1,
+						Location:    loc,
+						Description: fmt.Sprintf("writes to slice element '%s'", name),
 						Target:      name,
 					})
 				}
 			}
+		}
+	}
 
-			// Writer output: calls to w.Write(...) where w
-			// implements io.Writer.
-			if sel, ok := node.Fun.(*ast.SelectorExpr); ok {
-				if sel.Sel.Name == "Write" && isWriterType(info, sel.X) {
-					name := exprName(sel.X)
-					key := "writer:" + name
-					if !seen[key] {
-						seen[key] = true
-						loc := fset.Position(node.Pos()).String()
-						effects = append(effects, taxonomy.SideEffect{
-							ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.WriterOutput), name),
-							Type:        taxonomy.WriterOutput,
-							Tier:        taxonomy.TierP1,
-							Location:    loc,
-							Description: fmt.Sprintf("writes to io.Writer '%s'", name),
-							Target:      name,
-						})
-					}
-				}
+	return effects
+}
 
-				// HTTP response writes: calls to
-				// ResponseWriter.Write, .WriteHeader, .Header.
-				if isHTTPResponseWriter(info, sel.X) {
-					method := sel.Sel.Name
-					if method == "Write" || method == "WriteHeader" || method == "Header" {
-						name := exprName(sel.X)
-						key := "http:" + name + ":" + method
-						if !seen[key] {
-							seen[key] = true
-							loc := fset.Position(node.Pos()).String()
-							effects = append(effects, taxonomy.SideEffect{
-								ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.HTTPResponseWrite), name+"."+method),
-								Type:        taxonomy.HTTPResponseWrite,
-								Tier:        taxonomy.TierP1,
-								Location:    loc,
-								Description: fmt.Sprintf("calls %s.%s()", name, method),
-								Target:      name + "." + method,
-							})
-						}
-					}
+// detectIncDecEffects handles *ast.IncDecStmt nodes, detecting
+// GlobalMutation via increment (++) or decrement (--) operators
+// on package-level variables.
+func detectIncDecEffects(
+	fset *token.FileSet,
+	info *types.Info,
+	node *ast.IncDecStmt,
+	pkg string,
+	funcName string,
+	seen map[string]bool,
+	locals map[string]bool,
+) []taxonomy.SideEffect {
+	ident, ok := node.X.(*ast.Ident)
+	if !ok {
+		return nil
+	}
+	if !isGlobalIdent(ident, info, locals) {
+		return nil
+	}
+	key := "global:" + ident.Name
+	if seen[key] {
+		return nil
+	}
+	seen[key] = true
+	loc := fset.Position(ident.Pos()).String()
+	return []taxonomy.SideEffect{{
+		ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.GlobalMutation), ident.Name),
+		Type:        taxonomy.GlobalMutation,
+		Tier:        taxonomy.TierP1,
+		Location:    loc,
+		Description: fmt.Sprintf("modifies package-level variable '%s'", ident.Name),
+		Target:      ident.Name,
+	}}
+}
+
+// detectSendEffects handles *ast.SendStmt nodes, detecting
+// ChannelSend effects (ch <- value).
+func detectSendEffects(
+	fset *token.FileSet,
+	node *ast.SendStmt,
+	pkg string,
+	funcName string,
+	seen map[string]bool,
+) []taxonomy.SideEffect {
+	name := exprName(node.Chan)
+	key := "chsend:" + name
+	if seen[key] {
+		return nil
+	}
+	seen[key] = true
+	loc := fset.Position(node.Pos()).String()
+	return []taxonomy.SideEffect{{
+		ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.ChannelSend), name),
+		Type:        taxonomy.ChannelSend,
+		Tier:        taxonomy.TierP1,
+		Location:    loc,
+		Description: fmt.Sprintf("sends on channel '%s'", name),
+		Target:      name,
+	}}
+}
+
+// detectP1CallEffects handles *ast.CallExpr nodes, detecting
+// ChannelClose (close(ch)), WriterOutput (w.Write(...) where w
+// implements io.Writer), and HTTPResponseWrite (calls to
+// ResponseWriter.Write, .WriteHeader, .Header).
+func detectP1CallEffects(
+	fset *token.FileSet,
+	info *types.Info,
+	node *ast.CallExpr,
+	pkg string,
+	funcName string,
+	seen map[string]bool,
+) []taxonomy.SideEffect {
+	var effects []taxonomy.SideEffect
+
+	// Channel close: close(ch).
+	if isCloseCall(node, info) && len(node.Args) == 1 {
+		name := exprName(node.Args[0])
+		key := "chclose:" + name
+		if !seen[key] {
+			seen[key] = true
+			loc := fset.Position(node.Pos()).String()
+			effects = append(effects, taxonomy.SideEffect{
+				ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.ChannelClose), name),
+				Type:        taxonomy.ChannelClose,
+				Tier:        taxonomy.TierP1,
+				Location:    loc,
+				Description: fmt.Sprintf("closes channel '%s'", name),
+				Target:      name,
+			})
+		}
+	}
+
+	// Writer output and HTTP response writes via selector expressions.
+	if sel, ok := node.Fun.(*ast.SelectorExpr); ok {
+		if sel.Sel.Name == "Write" && isWriterType(info, sel.X) {
+			name := exprName(sel.X)
+			key := "writer:" + name
+			if !seen[key] {
+				seen[key] = true
+				loc := fset.Position(node.Pos()).String()
+				effects = append(effects, taxonomy.SideEffect{
+					ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.WriterOutput), name),
+					Type:        taxonomy.WriterOutput,
+					Tier:        taxonomy.TierP1,
+					Location:    loc,
+					Description: fmt.Sprintf("writes to io.Writer '%s'", name),
+					Target:      name,
+				})
+			}
+		}
+
+		// HTTP response writes: calls to
+		// ResponseWriter.Write, .WriteHeader, .Header.
+		if isHTTPResponseWriter(info, sel.X) {
+			method := sel.Sel.Name
+			if method == "Write" || method == "WriteHeader" || method == "Header" {
+				name := exprName(sel.X)
+				key := "http:" + name + ":" + method
+				if !seen[key] {
+					seen[key] = true
+					loc := fset.Position(node.Pos()).String()
+					effects = append(effects, taxonomy.SideEffect{
+						ID:          taxonomy.GenerateID(pkg, funcName, string(taxonomy.HTTPResponseWrite), name+"."+method),
+						Type:        taxonomy.HTTPResponseWrite,
+						Tier:        taxonomy.TierP1,
+						Location:    loc,
+						Description: fmt.Sprintf("calls %s.%s()", name, method),
+						Target:      name + "." + method,
+					})
 				}
 			}
 		}
-		return true
-	})
+	}
 
 	return effects
 }

--- a/internal/docscan/filter_test.go
+++ b/internal/docscan/filter_test.go
@@ -1,0 +1,189 @@
+package docscan_test
+
+import (
+	"testing"
+
+	"github.com/unbound-force/gaze/internal/config"
+	"github.com/unbound-force/gaze/internal/docscan"
+)
+
+func TestFilter(t *testing.T) {
+	tests := []struct {
+		name string
+		rel  string
+		cfg  *config.GazeConfig
+		want bool
+	}{
+		// FR-001: default inclusion (no include/exclude patterns).
+		{
+			name: "default_inclusion_no_patterns",
+			rel:  "docs/readme.md",
+			cfg: &config.GazeConfig{
+				Classification: config.ClassificationConfig{
+					DocScan: config.DocScan{},
+				},
+			},
+			want: true,
+		},
+		// FR-001: nil config fallback (uses DefaultConfig).
+		{
+			name: "nil_config_fallback_included",
+			rel:  "README.md",
+			cfg:  nil,
+			want: true,
+		},
+		// FR-001: nil config with excluded file (DefaultConfig excludes LICENSE).
+		{
+			name: "nil_config_fallback_excluded",
+			rel:  "LICENSE",
+			cfg:  nil,
+			want: false,
+		},
+		// FR-001: include-pattern match (file matches include glob).
+		{
+			name: "include_pattern_match",
+			rel:  "docs/design.md",
+			cfg: &config.GazeConfig{
+				Classification: config.ClassificationConfig{
+					DocScan: config.DocScan{
+						Include: []string{"docs/**"},
+					},
+				},
+			},
+			want: true,
+		},
+		// FR-001: include-pattern miss (file does not match any include glob).
+		{
+			name: "include_pattern_miss",
+			rel:  "src/main.go",
+			cfg: &config.GazeConfig{
+				Classification: config.ClassificationConfig{
+					DocScan: config.DocScan{
+						Include: []string{"docs/**"},
+					},
+				},
+			},
+			want: false,
+		},
+		// FR-001: exclude-pattern match (file matches exclude glob).
+		{
+			name: "exclude_pattern_match",
+			rel:  "vendor/lib/readme.md",
+			cfg: &config.GazeConfig{
+				Classification: config.ClassificationConfig{
+					DocScan: config.DocScan{
+						Exclude: []string{"vendor/**"},
+					},
+				},
+			},
+			want: false,
+		},
+		// Include match overridden by exclude.
+		{
+			name: "include_match_then_exclude_match",
+			rel:  "docs/internal/secret.md",
+			cfg: &config.GazeConfig{
+				Classification: config.ClassificationConfig{
+					DocScan: config.DocScan{
+						Include: []string{"docs/**"},
+						Exclude: []string{"docs/internal/**"},
+					},
+				},
+			},
+			want: false,
+		},
+		// FR-002: pattern with path separator (full-path matching).
+		{
+			name: "glob_full_path_match",
+			rel:  "specs/001/spec.md",
+			cfg: &config.GazeConfig{
+				Classification: config.ClassificationConfig{
+					DocScan: config.DocScan{
+						Include: []string{"specs/**"},
+					},
+				},
+			},
+			want: true,
+		},
+		// FR-002: pattern without path separator (base-name matching).
+		{
+			name: "glob_basename_match",
+			rel:  "deep/nested/dir/README.md",
+			cfg: &config.GazeConfig{
+				Classification: config.ClassificationConfig{
+					DocScan: config.DocScan{
+						Exclude: []string{"README.md"},
+					},
+				},
+			},
+			want: false,
+		},
+		// FR-002: pattern without separator matches basename only.
+		{
+			name: "glob_basename_wildcard",
+			rel:  "some/path/notes.txt",
+			cfg: &config.GazeConfig{
+				Classification: config.ClassificationConfig{
+					DocScan: config.DocScan{
+						Include: []string{"*.txt"},
+					},
+				},
+			},
+			want: true,
+		},
+		// Edge case: forward-slash path matching.
+		// On Unix, filepath.ToSlash is a no-op (backslash is a valid
+		// filename character, not a separator). On Windows, it
+		// converts backslashes to forward slashes. This test verifies
+		// that Filter handles forward-slash paths correctly on all
+		// platforms. Backslash normalization is only meaningful on
+		// Windows and cannot be tested on Unix.
+		{
+			name: "forward_slash_path_match",
+			rel:  "docs/readme.md",
+			cfg: &config.GazeConfig{
+				Classification: config.ClassificationConfig{
+					DocScan: config.DocScan{
+						Include: []string{"docs/**"},
+					},
+				},
+			},
+			want: true,
+		},
+		// Double-star prefix: exact directory name match.
+		{
+			name: "doublestar_exact_dir_match",
+			rel:  "testdata",
+			cfg: &config.GazeConfig{
+				Classification: config.ClassificationConfig{
+					DocScan: config.DocScan{
+						Exclude: []string{"testdata/**"},
+					},
+				},
+			},
+			want: false,
+		},
+		// Exclude pattern that does not match.
+		{
+			name: "exclude_pattern_no_match",
+			rel:  "docs/guide.md",
+			cfg: &config.GazeConfig{
+				Classification: config.ClassificationConfig{
+					DocScan: config.DocScan{
+						Exclude: []string{"vendor/**"},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := docscan.Filter(tt.rel, tt.cfg)
+			if got != tt.want {
+				t.Errorf("Filter(%q, cfg) = %v, want %v", tt.rel, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -1,6 +1,8 @@
 package loader_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/unbound-force/gaze/internal/loader"
@@ -28,5 +30,122 @@ func TestLoad_InvalidPattern(t *testing.T) {
 	_, err := loader.Load("github.com/nonexistent/package/that/does/not/exist")
 	if err == nil {
 		t.Error("expected error for nonexistent package")
+	}
+}
+
+// findModuleRoot walks up from the current directory to find go.mod.
+func findModuleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find module root (go.mod)")
+		}
+		dir = parent
+	}
+}
+
+func TestLoadModule_ValidModule(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow test: loads real Go module via go/packages")
+	}
+
+	root := findModuleRoot(t)
+	result, err := loader.LoadModule(root)
+	if err != nil {
+		t.Fatalf("LoadModule(%q) failed: %v", root, err)
+	}
+	if len(result.Packages) == 0 {
+		t.Fatal("expected at least one package")
+	}
+	if result.Fset == nil {
+		t.Fatal("expected non-nil Fset")
+	}
+
+	// Verify at least one package has resolved type information.
+	hasTypes := false
+	for _, pkg := range result.Packages {
+		if pkg.Types != nil {
+			hasTypes = true
+			break
+		}
+	}
+	if !hasTypes {
+		t.Error("expected at least one package with resolved type information")
+	}
+}
+
+func TestLoadModule_NonExistentDir(t *testing.T) {
+	_, err := loader.LoadModule("/nonexistent/path/that/does/not/exist")
+	if err == nil {
+		t.Error("expected error for non-existent directory")
+	}
+}
+
+func TestLoadModule_ExcludesBrokenPackages(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow test: creates temp module and invokes Go toolchain")
+	}
+
+	// Create a temporary directory with a go.mod and two packages:
+	// one valid and one broken.
+	tmpDir := t.TempDir()
+
+	// Write go.mod.
+	goMod := "module example.com/testmod\n\ngo 1.21\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
+	}
+
+	// Create valid package.
+	validDir := filepath.Join(tmpDir, "valid")
+	if err := os.MkdirAll(validDir, 0o755); err != nil {
+		t.Fatalf("creating valid dir: %v", err)
+	}
+	validSrc := "package valid\n\nfunc Hello() string { return \"hello\" }\n"
+	if err := os.WriteFile(filepath.Join(validDir, "valid.go"), []byte(validSrc), 0o644); err != nil {
+		t.Fatalf("writing valid.go: %v", err)
+	}
+
+	// Create broken package (syntax error).
+	brokenDir := filepath.Join(tmpDir, "broken")
+	if err := os.MkdirAll(brokenDir, 0o755); err != nil {
+		t.Fatalf("creating broken dir: %v", err)
+	}
+	brokenSrc := "package broken\n\nfunc Oops() { this is not valid go }\n"
+	if err := os.WriteFile(filepath.Join(brokenDir, "broken.go"), []byte(brokenSrc), 0o644); err != nil {
+		t.Fatalf("writing broken.go: %v", err)
+	}
+
+	result, err := loader.LoadModule(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadModule(%q) failed: %v", tmpDir, err)
+	}
+
+	// Should have at least the valid package.
+	if len(result.Packages) == 0 {
+		t.Fatal("expected at least one valid package")
+	}
+
+	// Verify the valid package is present.
+	foundValid := false
+	for _, pkg := range result.Packages {
+		if pkg.PkgPath == "example.com/testmod/valid" {
+			foundValid = true
+		}
+		// Verify broken package is excluded.
+		if pkg.PkgPath == "example.com/testmod/broken" {
+			t.Errorf("broken package should have been excluded, but found %q", pkg.PkgPath)
+		}
+	}
+	if !foundValid {
+		t.Error("expected valid package 'example.com/testmod/valid' in result")
 	}
 }

--- a/specs/009-crapload-reduction/checklists/requirements.md
+++ b/specs/009-crapload-reduction/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: CRAPload Reduction
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The spec deliberately avoids naming specific programming constructs, file paths, or technical patterns — these belong in the plan, not the spec.
+- Success criteria use relative targets (e.g., "drops from X to below Y") rather than absolute numbers, which are verifiable by running the quality analysis tool before and after.

--- a/specs/009-crapload-reduction/data-model.md
+++ b/specs/009-crapload-reduction/data-model.md
@@ -1,0 +1,85 @@
+# Data Model: CRAPload Reduction
+
+**Feature**: 009-crapload-reduction
+**Date**: 2026-02-27
+
+## Overview
+
+This feature does not introduce new persistent data entities. All changes are structural (code decomposition) or test additions. The key entities below describe the existing domain concepts that the feature's success criteria are measured against, and the new internal structures introduced by decomposition.
+
+## Existing Entities (unchanged)
+
+### CRAPScore
+
+Represents the computed CRAP score for a single function.
+
+| Field | Description |
+|-------|-------------|
+| Package | Go package path |
+| Function | Qualified function name (including receiver) |
+| Complexity | Cyclomatic complexity (integer) |
+| LineCoverage | Line coverage percentage (0-100) |
+| CRAP | Computed CRAP score: `CC² × (1-cov)³ + CC` |
+| ContractCoverage | Contract coverage percentage (0-100), optional |
+| GazeCRAP | GazeCRAP score using contract coverage, optional |
+| Quadrant | Q1/Q2/Q3/Q4 classification based on CRAP and GazeCRAP thresholds |
+
+### CRAPSummary
+
+Aggregate metrics across all analyzed functions.
+
+| Field | Description |
+|-------|-------------|
+| TotalFunctions | Count of functions analyzed |
+| CRAPload | Count of functions with CRAP ≥ threshold |
+| GazeCRAPload | Count of functions with GazeCRAP ≥ threshold |
+| AvgContractCoverage | Mean contract coverage across scored functions |
+| QuadrantCounts | Map of quadrant label → count |
+
+## New Internal Structures
+
+### crapParams (modified — US3)
+
+The existing params struct for `runCrap` gains optional function fields for dependency injection.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| patterns | list of strings | Package patterns to analyze |
+| format | string | Output format: "text" or "json" |
+| opts | analysis options | CRAP analysis configuration |
+| maxCrapload | integer | CI threshold for CRAPload |
+| maxGazeCrapload | integer | CI threshold for GazeCRAPload |
+| moduleDir | string | Module root directory |
+| stdout | writer | Output destination |
+| stderr | writer | Diagnostic output destination |
+| analyzeFunc | function (new) | Optional override for CRAP analysis; nil = production default |
+| coverageFunc | function (new) | Optional override for contract coverage lookup; nil = production default |
+
+### selfCheckParams (modified — US3)
+
+The existing params struct for `runSelfCheck` gains optional function fields.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| format | string | Output format |
+| maxCrapload | integer | CI threshold |
+| maxGazeCrapload | integer | CI threshold |
+| stdout | writer | Output destination |
+| stderr | writer | Diagnostic output destination |
+| moduleRootFunc | function (new) | Optional override for module root discovery; nil = production default |
+| runCrapFunc | function (new) | Optional override to delegate to runCrap; nil = production default |
+
+## Relationships
+
+```text
+CRAPScore ──belongs to──▸ CRAPSummary
+crapParams ──uses──▸ analyzeFunc ──produces──▸ CRAPScore[]
+crapParams ──uses──▸ coverageFunc ──provides──▸ ContractCoverage
+selfCheckParams ──delegates to──▸ crapParams (via runCrapFunc)
+```
+
+## Validation Rules
+
+- `analyzeFunc` and `coverageFunc` fields are optional (nil = use production default). When set, they must match the production function signatures exactly.
+- `moduleRootFunc` must return a directory path and an error. Nil means use production `findModuleRoot`.
+- Decomposed handler functions must preserve the deduplication invariant: no duplicate effects for the same target within a single function analysis.

--- a/specs/009-crapload-reduction/plan.md
+++ b/specs/009-crapload-reduction/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: CRAPload Reduction
+
+**Branch**: `009-crapload-reduction` | **Date**: 2026-02-27 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/009-crapload-reduction/spec.md`
+
+## Summary
+
+Reduce the project's CRAPload and GazeCRAPload by addressing the top 5 priority functions identified in the Gaze quality report. The work consists of three strategies: (1) adding contract-level tests for functions with zero coverage (`docscan.Filter`, `LoadModule`), (2) making CLI command functions testable via dependency injection (`runCrap`, `runSelfCheck`), and (3) decomposing high-complexity monolithic functions (`buildContractCoverageFunc`, `AnalyzeP1Effects`, `AnalyzeP2Effects`). The target is GazeCRAPload 7→4 and CRAPload 27→24.
+
+## Technical Context
+
+**Language/Version**: Go 1.24+
+**Primary Dependencies**: `golang.org/x/tools` (go/packages, go/ssa), Cobra (CLI), Bubble Tea/Lipgloss (TUI)
+**Storage**: Filesystem only (embedded assets via `embed.FS`)
+**Testing**: Standard library `testing` package only; no external assertion libraries
+**Target Platform**: darwin/linux (amd64, arm64)
+**Project Type**: Single binary CLI with layered internal packages
+**Performance Goals**: Standard test suite (`-short`) completes within 10-minute CI timeout
+**Constraints**: All tests must pass with `-race -count=1`; no new external dependencies
+**Scale/Scope**: ~208 functions across 11 packages; changes affect 5 packages
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### I. Accuracy — PASS
+
+- **Decomposition (US4, US5)**: FR-017 and FR-021 explicitly require that decomposition produces identical analysis output — no false positives or negatives introduced.
+- **Testing (US1, US2, US3)**: All new tests assert on observable contractual outputs (return values, error conditions, written output). No tests verify implementation internals.
+- **Regression guard**: SC-008 requires all existing tests pass with zero regressions, backed by FR-023.
+
+### II. Minimal Assumptions — PASS
+
+- **No annotation changes**: No production code changes require users to modify their test code or project structure.
+- **CLI behavior preserved**: FR-012 explicitly requires that dependency injection changes do not alter external CLI behavior. Users see identical output.
+- **Explicit assumptions**: 6 assumptions documented in spec, all specific and auditable.
+
+### III. Actionable Output — PASS
+
+- **Metrics remain comparable**: Decomposition and testing changes do not alter the CRAP/GazeCRAP scoring formulas or report format. Users can compare runs before and after this feature.
+- **Report output unchanged**: FR-017 (pipeline orchestrator) and FR-021 (effect detection) both require output identity pre- and post-change.
+- **JSON/text formats preserved**: No changes to output schemas or formatters.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-crapload-reduction/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0: technical decisions
+├── data-model.md        # Phase 1: entity definitions
+├── quickstart.md        # Phase 1: integration scenarios
+├── checklists/
+│   └── requirements.md  # Specification quality checklist
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+cmd/gaze/
+├── main.go              # US3: runCrap/runSelfCheck dependency injection
+│                        # US4: buildContractCoverageFunc decomposition
+└── main_test.go         # US3: fast unit tests for runCrap/runSelfCheck
+                         # US4: tests for extracted pipeline functions
+
+internal/
+├── analysis/
+│   ├── p1effects.go     # US5: decompose AnalyzeP1Effects into handlers
+│   ├── p1effects_test.go # US5: verify handler decomposition
+│   ├── p2effects.go     # US5: decompose AnalyzeP2Effects into handlers
+│   └── p2effects_test.go # US5: verify handler decomposition
+├── docscan/
+│   ├── filter.go        # US1: (no changes — test-only)
+│   └── filter_test.go   # US1: new contract-level tests for Filter
+├── loader/
+│   ├── loader.go        # US2: (no changes — test-only)
+│   └── loader_test.go   # US2: new unit tests for LoadModule
+└── crap/
+    └── analyze.go       # (no changes — reference only)
+```
+
+**Structure Decision**: This feature modifies existing files within the established `cmd/gaze/` and `internal/` package structure. No new packages or top-level directories are introduced. New test files are created alongside their source files following Go conventions. Production code changes are limited to `cmd/gaze/main.go` (US3 dependency injection + US4 decomposition) and `internal/analysis/p1effects.go`/`p2effects.go` (US5 decomposition).
+
+### Group Organization
+
+The implementation is organized into three groups based on the type of change:
+
+**Group A — Test-Only (US1, US2)**: New test files with zero production code changes. These are independent and can be developed in parallel.
+
+- `internal/docscan/filter_test.go` — contract-level tests for `docscan.Filter`
+- `internal/loader/loader_test.go` — unit tests for `LoadModule`
+
+**Group B — Production Refactoring + Tests (US3, US4)**: Changes to `cmd/gaze/main.go` that modify function signatures and internal structure, plus corresponding test updates.
+
+- `cmd/gaze/main.go` — dependency injection for `runCrap`/`runSelfCheck` params structs + `buildContractCoverageFunc` decomposition
+- `cmd/gaze/main_test.go` — fast unit tests for all modified functions
+
+**Group C — Production Decomposition + Test Verification (US5)**: Structural refactoring of analysis functions with existing test verification.
+
+- `internal/analysis/p1effects.go` — decompose into per-node-type handlers
+- `internal/analysis/p2effects.go` — decompose into per-node-type handlers
+- `internal/analysis/p1effects_test.go` — verify identical output after decomposition
+- `internal/analysis/p2effects_test.go` — verify identical output after decomposition

--- a/specs/009-crapload-reduction/quickstart.md
+++ b/specs/009-crapload-reduction/quickstart.md
@@ -1,0 +1,118 @@
+# Quickstart: CRAPload Reduction
+
+**Feature**: 009-crapload-reduction
+**Date**: 2026-02-27
+
+## Verification Workflow
+
+This feature is verified entirely through the project's own quality analysis tool. No external services, databases, or configuration changes are needed.
+
+### Step 1: Capture Baseline Metrics
+
+Before any changes, run the quality analysis to capture current scores:
+
+```bash
+gaze crap --format=json ./... > baseline.json
+```
+
+Key baseline values to record:
+- CRAPload: 27
+- GazeCRAPload: 7
+- `docscan.Filter` GazeCRAP: 72 (Q3)
+- `LoadModule` CRAP: 56
+- `runCrap` CRAP: 52
+- `runSelfCheck` CRAP: 43
+- `buildContractCoverageFunc` CRAP: 70
+- `AnalyzeP1Effects` GazeCRAP: 32 (Q4)
+- `AnalyzeP2Effects` GazeCRAP: 18 (Q4)
+
+### Step 2: Verify After Each User Story
+
+After completing each user story, run the analysis again and compare:
+
+```bash
+gaze crap --format=json ./... > after-usN.json
+```
+
+#### US1 — docscan.Filter
+
+Check that the function moved from Q3 to Q1:
+- GazeCRAP should be below 15
+- Quadrant should be Q1_Safe
+- Q3 quadrant count should be 0
+
+#### US2 — LoadModule
+
+Check that the CRAP score dropped:
+- CRAP should be below 15
+- Line coverage should be significantly above 0%
+
+#### US3 — runCrap / runSelfCheck
+
+Check that both functions improved:
+- `runCrap` CRAP should be below 20
+- `runSelfCheck` CRAP should be below 20
+- Line coverage for both should be above 70%
+
+#### US4 — buildContractCoverageFunc
+
+Check that no decomposed function exceeds the threshold:
+- No function in the pipeline should have CRAP above 30
+- The original `buildContractCoverageFunc` should have lower CC
+
+#### US5 — AnalyzeP1Effects / AnalyzeP2Effects
+
+Check that all handler functions are below threshold:
+- No individual handler should have GazeCRAP above 15
+- All handlers should be in Q1 or Q2
+
+### Step 3: Verify Overall Targets
+
+After all user stories are complete:
+
+```bash
+gaze crap --format=json ./... > final.json
+```
+
+Verify success criteria:
+- GazeCRAPload ≤ 4 (down from 7)
+- CRAPload ≤ 24 (down from 27)
+- Q3 quadrant count = 0
+
+### Step 4: Regression Check
+
+Run the full test suite to verify no regressions:
+
+```bash
+go test -race -count=1 -short ./...
+golangci-lint run
+```
+
+Both must pass cleanly.
+
+## Integration Scenarios
+
+### Scenario 1: Developer Runs Quality Report
+
+A developer runs `gaze crap ./...` and sees improved scores compared to the baseline. The "worst GazeCRAP" and "worst CRAP" lists no longer contain the 5 target functions (or they appear with scores below threshold).
+
+**Before**: `docscan.Filter` appears as #1 worst GazeCRAP (72).
+**After**: `docscan.Filter` no longer appears in the worst list.
+
+### Scenario 2: CI Pipeline Threshold Check
+
+The CI pipeline runs `gaze crap --max-crapload=24 --max-gaze-crapload=4 ./...` and the command exits with status 0 (thresholds satisfied).
+
+**Before**: This command would exit with status 1 (CRAPload 27 > 24, GazeCRAPload 7 > 4).
+**After**: Both thresholds are met.
+
+### Scenario 3: Adding a New P1 Effect Category (Post-Decomposition)
+
+After US5 is complete, a developer wants to add a new P1 effect type (e.g., `SyscallInvocation`). They:
+
+1. Create a new handler function `detectSyscallEffects(...)` following the same signature as existing handlers.
+2. Add a case to the type-switch dispatcher in `AnalyzeP1Effects`.
+3. Add tests for the new handler.
+4. No existing handlers need modification.
+
+This scenario validates FR-022 (open for extension, closed for modification).

--- a/specs/009-crapload-reduction/research.md
+++ b/specs/009-crapload-reduction/research.md
@@ -1,0 +1,71 @@
+# Research: CRAPload Reduction
+
+**Feature**: 009-crapload-reduction
+**Date**: 2026-02-27
+
+## R1: Dependency Injection Strategy for CLI Commands
+
+**Decision**: Use optional function fields on existing params structs with default-to-production-function semantics.
+
+**Rationale**: The project already uses the testable CLI pattern where commands delegate to `runXxx(params)` functions with params structs containing `io.Writer` for stdout/stderr. Adding function fields (e.g., `analyzeFunc func(...) (*crap.Report, error)`) to these structs is the minimal extension of this existing pattern. When the field is nil, the production function is called; tests set the field to a stub.
+
+**Alternatives considered**:
+
+- **Interface-based injection**: Would require defining new interfaces (`CrapAnalyzer`, `CoverageProvider`) and wrapping production functions in adapter types. More boilerplate, introduces new types into the package namespace, and conflicts with the project's "No global state" and functional style preferences.
+- **Package-level variables**: Setting `var analyzeFunc = crap.Analyze` at package level and overriding in tests. Violates the project's "No global state" convention and introduces race conditions in parallel tests.
+- **Constructor/factory functions**: `newCrapRunner(opts)` returning a struct with methods. Over-engineered for two CLI commands; adds unnecessary abstraction layers.
+
+## R2: LoadModule Test Fixture Strategy
+
+**Decision**: Use the project's own `go.mod` for the happy-path test and a temporary directory with a minimal `go.mod` + broken `.go` file for the error-filtering test. Guard with `testing.Short()`.
+
+**Rationale**: `LoadModule` wraps `go/packages.Load` which requires real Go source to parse and type-check. Using the project's own module root is the simplest valid input and tests a realistic scenario. For the error-filtering test, a temporary directory with a deliberately broken Go file verifies the exclusion logic. Both tests are inherently slow (they invoke the Go toolchain), so guarding with `testing.Short()` keeps the standard CI suite fast.
+
+**Alternatives considered**:
+
+- **Testdata fixtures only**: Would require maintaining a valid `go.mod` + Go source tree under `internal/loader/testdata/`. Feasible but adds maintenance burden for fixtures that mirror what the project root already provides.
+- **Mocking `go/packages.Load`**: Not feasible without making `LoadModule` accept a loader function, which changes the production API for a function that is purely infrastructure. The cost exceeds the benefit.
+- **Using the existing analysis testdata fixtures**: These are in `internal/analysis/testdata/src/` but lack standalone `go.mod` files — they rely on the parent module. Not suitable for `LoadModule` which expects a module root.
+
+## R3: AnalyzeP1Effects Decomposition Approach
+
+**Decision**: Extract four handler functions, one per `ast.Node` type switch arm: `detectAssignEffects`, `detectIncDecEffects`, `detectSendEffects`, `detectCallEffects`. The main `ast.Inspect` callback becomes a thin dispatcher.
+
+**Rationale**: The current CC=32 comes from a single `ast.Inspect` callback with a 4-arm type switch (`*ast.AssignStmt`, `*ast.IncDecStmt`, `*ast.SendStmt`, `*ast.CallExpr`), each arm containing nested logic. Extracting one handler per arm creates functions with CC of 5-10 each. The `seen` map and `locals` set are passed as parameters (or captured via a shared analysis context struct) to preserve deduplication semantics. The `ast.Inspect` callback becomes approximately: `switch n := node.(type) { case *ast.AssignStmt: ... case *ast.IncDecStmt: ... }` with each case delegating to a handler that appends to a shared `effects` slice.
+
+**Alternatives considered**:
+
+- **Visitor pattern with interface**: Define a `NodeHandler` interface and register handlers. Over-engineered for 4 handlers; Go's type switch is the idiomatic approach.
+- **Separate `ast.Inspect` passes per effect type**: Each handler does its own tree walk. Correct but O(n*k) instead of O(n), and changes the architecture unnecessarily.
+- **Analysis context struct with methods**: Wrap `fset`, `info`, `pkg`, `funcName`, `locals`, `seen`, and `effects` in a struct and make handlers methods. Viable and would avoid parameter passing, but introduces a new exported type into the analysis package. The project currently uses plain functions. The decision is to start with plain functions and only introduce a struct if parameter count becomes unwieldy.
+
+## R4: AnalyzeP2Effects Decomposition Approach
+
+**Decision**: Same pattern as P1 — extract per-node-type handlers. The P2 function has a 2-arm type switch (`*ast.GoStmt`, `*ast.CallExpr`), with inline detection for panic, selector-based effects (logging, OS operations, context cancellation), database operations, and callback invocation within the `*ast.CallExpr` arm.
+
+**Rationale**: The P2 function (CC=18) follows the same monolithic callback pattern as P1. The `*ast.CallExpr` arm is the most complex, containing sub-checks for logging, OS exit, panic, exec, database, and HTTP calls. Extracting `detectP2CallEffects` from the call expression arm and `detectGoroutineEffects` from the goroutine arm reduces the per-function CC to approximately 6-8 each.
+
+**Alternatives considered**: Same as R3. The symmetry between P1 and P2 decomposition means the same pattern applies.
+
+## R5: buildContractCoverageFunc Decomposition Strategy
+
+**Decision**: Extract three functions: (1) `resolvePackagePaths` for pattern expansion + test-variant filtering, (2) `analyzePackageCoverage` for the per-package pipeline (analysis → classify → test-load → quality assess), and (3) keep `buildContractCoverageFunc` as a thin coordinator that calls the extracted functions and builds the final closure.
+
+**Rationale**: The current function (CC=18, 100 lines) has three distinct responsibilities crammed together. The package resolution step (lines 516-538 of main.go) filters out `_test` packages and resolves patterns to individual paths. The per-package pipeline (lines 561-594) runs analysis, classification, test loading, and quality assessment with 5 separate `continue`-on-error branches. The aggregation step builds a map from reports. Extracting these makes each step independently testable. The coordinator retains the nil-return-on-empty-map logic.
+
+**Alternatives considered**:
+
+- **Pipeline struct with methods**: Wrap the entire pipeline in a struct. Would make testing cleaner via method injection, but introduces a type for a single call site. The project's codebase currently has no pipeline structs in `cmd/gaze/`.
+- **Functional pipeline composition**: Chain functions like `resolvePackagePaths |> map(analyzePackageCoverage) |> buildCoverageMap`. Elegant but Go lacks first-class pipeline operators; the boilerplate would be worse than explicit calls.
+- **No decomposition, just more tests**: Would improve line coverage but not CC. With CC=18, even 100% coverage yields CRAP=18, still above the threshold. Decomposition is required to bring individual functions below 15.
+
+## R6: docscan.Filter Contract Coverage Gap
+
+**Decision**: Create a dedicated `internal/docscan/filter_test.go` with table-driven tests using `package docscan_test` (external test package) that directly call `docscan.Filter` and assert on the boolean return value.
+
+**Rationale**: The existing tests in `scanner_test.go` test `Filter` indirectly through the `Scan` function, but the quality pipeline does not map these assertions back to `Filter`'s contract because the assertions target `Scan`'s output (a list of documents), not `Filter`'s output (a boolean). Direct tests that call `Filter(path, cfg)` and assert `== true` / `== false` will be recognized as contract-level assertions on the return value.
+
+**Alternatives considered**:
+
+- **Modify existing scanner_test.go tests to also assert Filter directly**: Would mix concerns (integration tests testing both Scan and Filter). Cleaner to have a dedicated file.
+- **Internal test package (`package docscan`)**: Would allow testing unexported helpers like `matchGlob` directly. However, the spec only requires contract coverage on the exported `Filter` function. Using the external test package is cleaner and tests the public API surface.

--- a/specs/009-crapload-reduction/spec.md
+++ b/specs/009-crapload-reduction/spec.md
@@ -1,0 +1,177 @@
+# Feature Specification: CRAPload Reduction
+
+**Feature Branch**: `009-crapload-reduction`
+**Created**: 2026-02-27
+**Status**: Complete
+**Input**: User description: "please make a spec to address the top 5 priority improvements"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Contract Coverage for Document Filter (Priority: P1)
+
+A developer runs the quality analysis on the project and sees the document filter function flagged as the only Q3 function in the entire codebase — the worst GazeCRAP score (72) despite having near-perfect line coverage. The function has 0% contract coverage, meaning tests execute the code but no test assertions verify the function's observable output (a boolean filtering decision). The developer wants to close this gap so the function moves to Q1 and no longer dominates the "worst GazeCRAP" list.
+
+**Why this priority**: This is the single highest GazeCRAP score in the project and the only Q3 function. Closing the contract coverage gap eliminates the entire Q3 quadrant from the health report and delivers the largest single-function GazeCRAP reduction possible.
+
+**Independent Test**: Can be fully tested by running the quality analysis on the document scanner package before and after, verifying that the filter function moves from Q3 to Q1 with GazeCRAP below the threshold.
+
+**Acceptance Scenarios**:
+
+1. **Given** the filter function currently has 0% contract coverage, **When** direct tests are added that assert on the boolean return value for each distinct code path (include match, exclude match, default inclusion, nil config), **Then** the function achieves at least 80% contract coverage.
+2. **Given** the new contract-level tests, **When** running the quality analysis, **Then** the filter function's GazeCRAP score drops below 15 and the function is classified as Q1 (Safe).
+3. **Given** the new tests, **When** running the full test suite, **Then** all existing tests continue to pass with zero regressions.
+
+---
+
+### User Story 2 — Unit Tests for Module Loader (Priority: P1)
+
+A developer reviews the quality report and sees the module loader function with a CRAP score of 56 and 0% line coverage. This function loads all packages in a module for static analysis — a critical path in the analysis pipeline — yet has no direct tests whatsoever. A regression in this function would cascade across all downstream features. The developer wants to establish a regression safety net and reduce the CRAP score.
+
+**Why this priority**: Zero coverage on a critical infrastructure function is the highest-risk scenario. Adding tests delivers the largest CRAP reduction per line of test code and protects a foundational pipeline component.
+
+**Independent Test**: Can be tested by running the quality analysis on the loader package before and after and verifying the CRAP score drops below 15.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid module directory, **When** the module loader is called, **Then** it returns a result containing at least one package with resolved type information.
+2. **Given** a non-existent or empty directory, **When** the module loader is called, **Then** it returns a descriptive error without panicking.
+3. **Given** a module containing both valid packages and packages with compilation errors, **When** the module loader is called, **Then** it returns only the valid packages and excludes the broken ones.
+4. **Given** the new tests, **When** running the quality analysis, **Then** the module loader's CRAP score drops below 15.
+
+---
+
+### User Story 3 — Testable CLI Commands (Priority: P2)
+
+A developer examines the quality report and sees two CLI command functions — the CRAP report runner (CRAP 52) and the self-check runner (CRAP 43) — flagged as high-risk. Both functions already follow the testable CLI pattern (accepting params structs with writer outputs) but their heavy pipeline dependencies are hard-wired, making fast unit testing impossible without running the full analysis pipeline. The developer wants to make these dependencies pluggable so that fast unit tests can cover all branches without spawning subprocesses or loading real packages.
+
+**Why this priority**: These two functions account for a combined CRAP of 95 and represent the CLI's two primary user-facing commands. Making them testable establishes the pattern for all future CLI commands and removes 2 functions from the CRAPload.
+
+**Independent Test**: Can be tested by running the quality analysis on the CLI package before and after and verifying both functions drop below CRAP 20.
+
+**Acceptance Scenarios**:
+
+1. **Given** the CRAP report runner with pluggable dependencies, **When** a developer provides stub implementations of the analysis and coverage functions, **Then** unit tests can exercise all branches (valid text output, valid JSON output, coverage unavailability warning, threshold pass, threshold breach) without running the real pipeline.
+2. **Given** the self-check runner with pluggable dependencies, **When** a developer provides stubs, **Then** unit tests can exercise the happy path, format validation, and threshold checking without spawning subprocesses.
+3. **Given** the pluggability changes, **When** running the existing CLI commands as an end user, **Then** behavior is identical to the current implementation — no user-visible changes.
+4. **Given** the new fast unit tests, **When** running the standard (non-long-running) test suite, **Then** both functions achieve at least 70% line coverage.
+
+---
+
+### User Story 4 — Decompose Quality Pipeline Orchestrator (Priority: P2)
+
+A developer examining the quality pipeline orchestrator function sees a 100-line function with the highest CRAP score in the entire project (70). It orchestrates four sequential steps — package resolution, side-effect analysis, classification, and quality assessment — all tightly coupled in a single function with 18 cyclomatic complexity. The developer wants to decompose it into smaller, independently testable functions that each handle one pipeline stage.
+
+**Why this priority**: This is the highest CRAP score in the project. Decomposition reduces per-function complexity and enables targeted testing of each pipeline stage, which is impossible with the current monolithic structure.
+
+**Independent Test**: Can be tested by running the quality analysis on the CLI package before and after and verifying that no function in the decomposed pipeline has a CRAP score above 30.
+
+**Acceptance Scenarios**:
+
+1. **Given** the decomposed pipeline functions, **When** a developer tests each function independently, **Then** package resolution, per-package analysis, and coverage map aggregation can each be verified with focused inputs.
+2. **Given** the decomposed pipeline, **When** running the quality analysis, **Then** no individual function in the pipeline has a CRAP score above 30.
+3. **Given** the decomposed pipeline, **When** running the CLI command end-to-end, **Then** the output is identical to the current implementation.
+4. **Given** the decomposition, **When** running the full test suite, **Then** all existing tests pass with zero regressions.
+
+---
+
+### User Story 5 — Decompose Effect Detection Engines (Priority: P3)
+
+A developer examining the P1 effect detection function sees cyclomatic complexity of 32 — the highest in the project — and GazeCRAP of 32 (Q4). Despite perfect contract and line coverage, the function is inherently risky to modify because a single monolithic callback handles seven distinct effect types (GlobalMutation, MapMutation, SliceMutation, ChannelSend, ChannelClose, WriterOutput, HTTPResponseWrite) across four AST node type arms. The P2 effect detection function has the same structural problem (CC=18, GazeCRAP 18, Q4). The developer wants to decompose both callbacks into focused handler functions, each responsible for one node type, making future additions of new effect categories safer and more modular.
+
+**Why this priority**: This is the lowest urgency because coverage is already perfect — the risk is purely structural. Decomposition reduces per-function complexity and makes the architecture more maintainable, but does not address any testing gap.
+
+**Independent Test**: Can be tested by running the quality analysis on the analysis package before and after and verifying that no function has a GazeCRAP score above 15.
+
+**Acceptance Scenarios**:
+
+1. **Given** the decomposed P1 effect detection with per-node-type handlers, **When** running the full side-effect analysis on any package, **Then** the detection results are identical to the current implementation — same effects, same types, same descriptions.
+2. **Given** the decomposed handlers, **When** running the quality analysis, **Then** no individual handler function has a GazeCRAP score above 15.
+3. **Given** the P2 effect detection function is decomposed using the same pattern, **Then** it also drops below GazeCRAP 15.
+4. **Given** the decomposition, **When** a developer adds a new effect category in the future, **Then** they can add a new handler function without modifying the existing handlers.
+5. **Given** all decomposition changes, **When** running the full test suite, **Then** all existing tests pass with zero regressions.
+
+---
+
+### Edge Cases
+
+- What happens when the document filter receives a path with backslash separators? The function normalizes paths internally; tests MUST verify this behavior.
+- What happens when the module loader is pointed at a directory containing a module file but no source files? It MUST return a descriptive error (no packages found).
+- What happens when the CRAP report runner receives an empty patterns list? It MUST either use a sensible default or return a descriptive error.
+- What happens when the pipeline orchestrator resolves patterns that match only test-variant packages? These MUST be filtered out, preserving current behavior.
+- What happens when the decomposed effect detection encounters a node type not handled by any handler? The dispatcher MUST continue the walk, matching current behavior.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### US1 — Document Filter Contract Coverage
+
+- **FR-001**: Direct tests MUST assert on the boolean return value of the document filter function for each distinct code path: include-pattern match, include-pattern miss, exclude-pattern match, default inclusion, and nil config fallback.
+- **FR-002**: Tests MUST cover the glob-matching delegation path, including patterns with and without path separators (base-name matching vs. full-path matching).
+- **FR-003**: After test additions, the document filter function MUST achieve at least 80% contract coverage as reported by the quality analysis.
+
+#### US2 — Module Loader Unit Tests
+
+- **FR-004**: Direct tests MUST exercise the module loader with a valid module directory and verify that the returned result contains at least one package with resolved types.
+- **FR-005**: Tests MUST verify the error path when pointed at a non-existent or empty directory.
+- **FR-006**: Tests MUST verify that packages with compilation errors are excluded from the returned result while valid packages are retained.
+- **FR-007**: Slow tests that load real modules MUST be guarded to keep the standard test suite fast (under the default timeout).
+
+#### US3 — CLI Command Testability
+
+- **FR-008**: The CRAP report runner function MUST accept pluggable function dependencies for the analysis pipeline so that unit tests can provide stub implementations.
+- **FR-009**: The self-check runner function MUST accept pluggable dependencies or delegate to the CRAP report runner internally to eliminate redundant pipeline wiring.
+- **FR-010**: Fast unit tests MUST cover all branches of the CRAP report runner: valid text output, valid JSON output, coverage unavailability warning, threshold pass, and threshold breach error.
+- **FR-011**: Fast unit tests MUST cover self-check runner branches: happy path, format validation error, module root not found error, and threshold checking.
+- **FR-012**: Pluggability changes MUST NOT alter the external behavior of any CLI commands.
+
+#### US4 — Pipeline Orchestrator Decomposition
+
+- **FR-013**: The package resolution logic (pattern expansion and test-variant filtering) MUST be extracted into a separate, independently testable function.
+- **FR-014**: The per-package analysis pipeline (analysis, classification, test loading, quality assessment) MUST be extracted into a separate function.
+- **FR-015**: The coverage map aggregation logic MUST be extracted into a separate function or kept as a thin coordinator.
+- **FR-016**: Each extracted function MUST have direct tests covering its primary paths.
+- **FR-017**: The decomposition MUST NOT change the behavior or return value of the pipeline orchestrator's closure.
+
+#### US5 — Effect Detection Decomposition
+
+- **FR-018**: The inspection callback in the P1 effect detection function MUST be decomposed into per-node-type handler functions, each handling one node type (assignments, send statements, call expressions, increment/decrement statements).
+- **FR-019**: Each handler function MUST be independently callable. Testability is satisfied when the handler is verified through the dispatcher's existing integration tests, which cover all node types and assert on identical output pre- and post-decomposition.
+- **FR-020**: The P2 effect detection function MUST be decomposed using the same handler pattern.
+- **FR-021**: Decomposition MUST NOT change the detected side effects for any existing test fixture — the analysis output MUST be identical pre- and post-decomposition.
+- **FR-022**: After decomposition, no individual handler function SHOULD have cyclomatic complexity above 15.
+
+#### Cross-Cutting
+
+- **FR-023**: All changes MUST pass the standard test suite with zero regressions.
+- **FR-024**: All changes MUST pass the linter with no new violations.
+- **FR-025**: All new functions and types intended for external use MUST have documentation comments.
+
+### Key Entities
+
+- **CRAPload**: The count of functions with CRAP scores at or above the threshold (default 15). The primary metric this feature aims to reduce.
+- **GazeCRAPload**: The count of functions with GazeCRAP scores (incorporating contract coverage) at or above the threshold (default 15). The secondary metric.
+- **Quadrant**: Classification of a function based on CRAP and GazeCRAP thresholds — Q1 (Safe), Q2 (Complex but Tested), Q3 (Simple but Underspecified), Q4 (Dangerous).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The project-wide GazeCRAPload drops from 7 to at most 4 (at least 3 functions removed from the "above threshold" list).
+- **SC-002**: The project-wide CRAPload drops from 27 to at most 24 (at least 3 functions removed from the "above threshold" list).
+- **SC-003**: The document filter function moves from Q3 to Q1 with GazeCRAP below 15.
+- **SC-004**: The module loader function's CRAP score drops from 56 to below 15.
+- **SC-005**: The CRAP report runner and self-check runner each drop below CRAP 20 in the standard test suite.
+- **SC-006**: No individual function in the decomposed P1 or P2 effect detection has GazeCRAP above 15.
+- **SC-007**: No individual function in the decomposed pipeline orchestrator has CRAP above 30.
+- **SC-008**: All existing tests pass with zero regressions after all changes.
+- **SC-009**: No new lint violations are introduced.
+
+### Assumptions
+
+- The document filter's existing tests (which test it indirectly through the higher-level scanner function) are not detected by the contract coverage pipeline as direct contract assertions. Dedicated direct tests that call the filter function explicitly and assert on its return value will be recognized.
+- The module loader tests will use small fixture modules or the project's own module to keep execution time reasonable. The heaviest tests will be guarded to avoid exceeding the standard CI timeout.
+- Pluggability in the CLI command functions will use function fields on the existing params structs rather than global state, consistent with the project's functional style preference.
+- Decomposition of the P1 and P2 effect detection functions preserves the existing deduplication behavior (the seen-effects tracking) by passing state to each handler or maintaining it in the dispatcher.
+- The pipeline orchestrator decomposition preserves the existing nil-return behavior when no coverage data can be collected.
+- The self-check runner may be refactored to delegate to the CRAP report runner internally, since both functions perform essentially the same pipeline with different input defaults.

--- a/specs/009-crapload-reduction/tasks.md
+++ b/specs/009-crapload-reduction/tasks.md
@@ -1,0 +1,228 @@
+# Tasks: CRAPload Reduction
+
+**Input**: Design documents from `/specs/009-crapload-reduction/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Capture baseline metrics before any changes
+
+- [x] T001 Capture baseline CRAP/GazeCRAP metrics by running `gaze crap --format=json ./...` and recording: CRAPload=27, GazeCRAPload=7, docscan.Filter GazeCRAP=72, LoadModule CRAP=56, runCrap CRAP=52, runSelfCheck CRAP=43, buildContractCoverageFunc CRAP=70, AnalyzeP1Effects GazeCRAP=32, AnalyzeP2Effects GazeCRAP=18
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Verify baseline and confirm test infrastructure is in place
+
+- [x] T002 Run full test suite `go test -race -count=1 -short ./...` to confirm clean baseline — all 11 packages must pass before any changes begin
+- [x] T003 Run `golangci-lint run` to confirm clean lint baseline
+
+**Checkpoint**: Baseline captured, all tests and lint pass — user story implementation can begin
+
+---
+
+## Phase 3: User Story 1 — Contract Coverage for Document Filter (Priority: P1) MVP
+
+**Goal**: Close the contract coverage gap on `docscan.Filter` (GazeCRAP 72 → <15, Q3 → Q1)
+
+**Independent Test**: Run `gaze crap ./internal/docscan/...` and verify `Filter` is Q1 with GazeCRAP < 15
+
+- [x] T004 [P] [US1] Create `internal/docscan/filter_test.go` with `package docscan_test` and table-driven tests for `docscan.Filter` covering: default inclusion (no config patterns), nil config fallback, exclude-pattern match, include-pattern match, include-pattern miss (FR-001)
+- [x] T005 [P] [US1] Add glob-matching tests to `internal/docscan/filter_test.go` covering: patterns with path separators (full-path matching), patterns without path separators (base-name matching), backslash path normalization edge case (FR-002)
+- [x] T006 [US1] Run `go test -race -count=1 ./internal/docscan/...` to verify all new and existing tests pass with zero regressions (FR-023)
+- [x] T007 [US1] Run `gaze crap ./internal/docscan/...` and verify `docscan.Filter` achieves contract coverage ≥ 80% and GazeCRAP < 15 (FR-003, SC-003)
+
+**Checkpoint**: docscan.Filter moves from Q3 to Q1. Q3 quadrant eliminated from project.
+
+---
+
+## Phase 4: User Story 2 — Unit Tests for Module Loader (Priority: P1)
+
+**Goal**: Add direct tests for `LoadModule` (CRAP 56 → <15, 0% coverage → >70%)
+
+**Independent Test**: Run `gaze crap ./internal/loader/...` and verify `LoadModule` CRAP < 15
+
+- [x] T008 [P] [US2] Add happy-path test `TestLoadModule_ValidModule` to existing `internal/loader/loader_test.go` that calls `LoadModule` with the project's own module root directory and verifies the returned `ModuleResult` contains at least one package with resolved type information. Guard with `testing.Short()` (FR-004, FR-007)
+- [x] T009 [P] [US2] Add error-path test `TestLoadModule_NonExistentDir` to `internal/loader/loader_test.go` that calls `LoadModule` with a non-existent directory and verifies a descriptive error is returned without panicking (FR-005)
+- [x] T010 [US2] Add error-filtering test `TestLoadModule_ExcludesBrokenPackages` to `internal/loader/loader_test.go` that creates a temporary directory with a minimal `go.mod` + deliberately broken `.go` file alongside a valid `.go` file, calls `LoadModule`, and verifies broken packages are excluded while valid packages are retained. Guard with `testing.Short()` (FR-006, FR-007)
+- [x] T011 [US2] Run `go test -race -count=1 ./internal/loader/...` to verify all new and existing tests pass with zero regressions (FR-023)
+- [x] T012 [US2] Run `gaze crap ./internal/loader/...` and verify `LoadModule` CRAP < 15 (SC-004)
+
+**Checkpoint**: LoadModule has direct tests and CRAP drops from 56 to below 15.
+
+---
+
+## Phase 5: User Story 3 — Testable CLI Commands (Priority: P2)
+
+**Goal**: Make `runCrap` and `runSelfCheck` testable via dependency injection (CRAP 52/43 → <20)
+
+**Independent Test**: Run `gaze crap ./cmd/gaze/...` and verify both functions have CRAP < 20
+
+- [x] T013 [US3] Add `analyzeFunc` and `coverageFunc` optional function fields to `crapParams` struct in `cmd/gaze/main.go`. When nil, the function delegates to the production implementation (`crap.Analyze` and `buildContractCoverageFunc` respectively). Update `runCrap` to check for non-nil fields before calling production defaults (FR-008, R1)
+- [x] T014 [US3] Add `moduleRootFunc` and `runCrapFunc` optional function fields to `selfCheckParams` struct in `cmd/gaze/main.go`. Update `runSelfCheck` to delegate to `runCrapFunc` when non-nil, or call `runCrap` directly with discovered module root. Verify external behavior is preserved by running existing tests (FR-009, FR-012, R1)
+- [x] T015 [US3] Verify `newCrapCmd` and `newSelfCheckCmd` cobra command constructors still produce correct params with nil function fields (default behavior). Run `go test -race -count=1 -short ./cmd/gaze/...` to confirm zero regressions (FR-012)
+- [x] T016 [P] [US3] Add fast unit tests for `runCrap` to `cmd/gaze/main_test.go`: `TestRunCrap_TextOutput` (stub analyzeFunc returning canned report, verify text output contains expected content), `TestRunCrap_JSONOutput` (same with JSON format), `TestRunCrap_NoCoverageWarning` (nil coverageFunc, verify stderr contains unavailability warning), `TestRunCrap_ThresholdPass` (under threshold, verify nil error), `TestRunCrap_ThresholdBreach` (over threshold, verify non-nil error), `TestRunCrap_EmptyPatterns` (empty patterns list, verify sensible default or descriptive error per edge case spec) (FR-010)
+- [x] T017 [P] [US3] Add fast unit tests for `runSelfCheck` to `cmd/gaze/main_test.go`: `TestRunSelfCheck_HappyPath` (stub runCrapFunc, verify delegation), `TestRunSelfCheck_ModuleRootError` (stub moduleRootFunc returning error, verify error propagation), `TestRunSelfCheck_FormatValidation` (invalid format, verify error) (FR-011)
+- [x] T018 [US3] Run `go test -race -count=1 -short ./cmd/gaze/...` to verify all new and existing tests pass with zero regressions (FR-023)
+- [x] T019 [US3] Run `gaze crap ./cmd/gaze/...` and verify `runCrap` and `runSelfCheck` each have CRAP < 20 (SC-005)
+
+**Checkpoint**: Both CLI command functions are testable with fast unit tests. CRAP drops from 52/43 to below 20.
+
+---
+
+## Phase 6: User Story 4 — Decompose Quality Pipeline Orchestrator (Priority: P2)
+
+**Goal**: Decompose `buildContractCoverageFunc` (CRAP 70, CC=18) into independently testable functions (no function > CRAP 30)
+
+**Independent Test**: Run `gaze crap ./cmd/gaze/...` and verify no decomposed pipeline function has CRAP > 30
+
+- [x] T020 [US4] Extract `resolvePackagePaths(patterns []string, moduleDir string) ([]string, error)` from `buildContractCoverageFunc` in `cmd/gaze/main.go`. This function resolves patterns via `go/packages.Load` (NeedName mode), filters out `_test` suffix packages, and returns individual package paths. The original function calls the new extracted function (FR-013, R5)
+- [x] T021 [US4] Extract `analyzePackageCoverage(pkgPath string, gazeConfig *config.GazeConfig, stderr io.Writer) []taxonomy.QualityReport` from the per-package loop body in `buildContractCoverageFunc` in `cmd/gaze/main.go`. This function runs the 4-step pipeline (analysis → classify → test-load → quality assess) for a single package, returning quality reports or nil on any step failure. The original function iterates and calls this for each path. Note: `moduleDir` parameter was dropped during implementation because the function uses `pkgPath` directly via `analysis.LoadAndAnalyze` and does not need the module directory (FR-014, R5)
+- [x] T022 [US4] Refactor `buildContractCoverageFunc` in `cmd/gaze/main.go` to be a thin coordinator: call `resolvePackagePaths`, iterate calling `analyzePackageCoverage`, aggregate reports into coverage map, return closure. Verify the return value and nil-on-empty-map behavior is preserved (FR-015, FR-017)
+- [x] T023 [P] [US4] Add tests for extracted pipeline functions in `cmd/gaze/main_test.go`: (a) `TestResolvePackagePaths_ValidPattern` (verify returns non-empty paths for `./internal/docscan/...`), `TestResolvePackagePaths_FilterTestSuffix` (verify `_test` packages are excluded), `TestResolvePackagePaths_AllTestVariants` (verify that patterns resolving to only `_test` packages return an empty list, preserving current filtering behavior per edge case spec), `TestResolvePackagePaths_InvalidPattern` (verify error for non-resolvable pattern); (b) `TestAnalyzePackageCoverage_ValidPackage` (verify returns non-nil quality reports for a well-tested package like `internal/docscan`), `TestAnalyzePackageCoverage_InvalidPackage` (verify returns nil for non-existent package). Guard slow tests with `testing.Short()` (FR-016)
+- [x] T024 [US4] Run `go test -race -count=1 -short ./cmd/gaze/...` to verify all new and existing tests pass with zero regressions. Pay special attention to `TestBuildContractCoverageFunc_WelltestedPackage` and `TestBuildContractCoverageFunc_InvalidPattern` (FR-017, FR-023)
+- [x] T025 [US4] Run `gaze crap ./cmd/gaze/...` and verify no decomposed pipeline function has CRAP > 30 (SC-007)
+
+**Checkpoint**: Pipeline orchestrator decomposed. No individual function exceeds CRAP 30. Existing behavior preserved.
+
+---
+
+## Phase 7: User Story 5 — Decompose Effect Detection Engines (Priority: P3)
+
+**Goal**: Decompose `AnalyzeP1Effects` (CC=32, GazeCRAP 32) and `AnalyzeP2Effects` (CC=18, GazeCRAP 18) into per-node-type handlers (all handlers GazeCRAP < 15)
+
+**Independent Test**: Run `gaze crap ./internal/analysis/...` and verify no function has GazeCRAP > 15
+
+### P1 Effects Decomposition
+
+- [x] T026 [US5] Extract `detectAssignEffects(fset *token.FileSet, info *types.Info, node *ast.AssignStmt, pkg, funcName string, seen map[string]bool, locals map[string]bool) []taxonomy.SideEffect` from the `*ast.AssignStmt` arm of `AnalyzeP1Effects` in `internal/analysis/p1effects.go`. This handler detects GlobalMutation, MapMutation, and SliceMutation effects from assignment statements. Note: parameter order refined during implementation to place `node` before context params (FR-018, R3)
+- [x] T027 [US5] Extract `detectIncDecEffects(fset *token.FileSet, info *types.Info, node *ast.IncDecStmt, pkg, funcName string, seen map[string]bool, locals map[string]bool) []taxonomy.SideEffect` from the `*ast.IncDecStmt` arm of `AnalyzeP1Effects` in `internal/analysis/p1effects.go`. This handler detects GlobalMutation effects from increment/decrement statements (FR-018, R3)
+- [x] T028 [US5] Extract `detectSendEffects(fset *token.FileSet, node *ast.SendStmt, pkg, funcName string, seen map[string]bool) []taxonomy.SideEffect` from the `*ast.SendStmt` arm of `AnalyzeP1Effects` in `internal/analysis/p1effects.go`. This handler detects ChannelSend effects. Note: `info *types.Info` omitted from signature because send detection does not require type information (FR-018, R3)
+- [x] T029 [US5] Extract `detectP1CallEffects(fset *token.FileSet, info *types.Info, node *ast.CallExpr, pkg, funcName string, seen map[string]bool) []taxonomy.SideEffect` from the `*ast.CallExpr` arm of `AnalyzeP1Effects` in `internal/analysis/p1effects.go`. This handler detects ChannelClose, WriterOutput, and HTTPResponseWrite effects. Note: `locals` omitted because call effect detection does not check for local variables (FR-018, R3)
+- [x] T030 [US5] Refactor `AnalyzeP1Effects` in `internal/analysis/p1effects.go` to be a thin dispatcher: collect locals, initialize seen map, then `ast.Inspect` with type switch delegating to the four extracted handlers. Append returned effects to the shared slice. Preserve deduplication via the shared `seen` map (FR-018, FR-021)
+- [x] T031 [US5] Run `go test -race -count=1 ./internal/analysis/...` to verify all 9 direct P1 tests and 13 integration tests produce identical results post-decomposition. Pay special attention to `TestAnalyzeP1Effects_Direct_*` and `TestP1_*` tests (FR-021, FR-023)
+
+### P2 Effects Decomposition
+
+- [x] T032 [P] [US5] Extract `detectP2CallEffects(fset *token.FileSet, info *types.Info, node *ast.CallExpr, pkg, funcName string, seen map[string]bool, funcParams map[string]bool) []taxonomy.SideEffect` from the `*ast.CallExpr` arm of `AnalyzeP2Effects` in `internal/analysis/p2effects.go`. This handler detects Panic, selector-based effects (LogWrite, FileSystemWrite, FileSystemDelete, FileSystemMeta, ContextCancellation), DatabaseWrite/DatabaseTransaction, and CallbackInvocation effects (FR-020, R4)
+- [x] T033 [P] [US5] Extract `detectGoroutineEffects(fset *token.FileSet, node *ast.GoStmt, pkg, funcName string, seen map[string]bool) []taxonomy.SideEffect` from the `*ast.GoStmt` arm of `AnalyzeP2Effects` in `internal/analysis/p2effects.go`. This handler detects GoroutineSpawn effects. Note: `seen` parameter added during implementation because deduplication is needed for the shared map invariant (FR-020, R4)
+- [x] T034 [US5] Refactor `AnalyzeP2Effects` in `internal/analysis/p2effects.go` to be a thin dispatcher: collect function params, initialize seen map, then `ast.Inspect` with type switch delegating to the two extracted handlers (`detectGoroutineEffects` for `*ast.GoStmt`, `detectP2CallEffects` for `*ast.CallExpr`). Preserve deduplication via the shared `seen` map (FR-020, FR-021)
+- [x] T035 [US5] Run `go test -race -count=1 ./internal/analysis/...` to verify all P2 direct and integration tests produce identical results post-decomposition. Pay special attention to `TestAnalyzeP2Effects_Direct_*` and `TestP2_*` tests (FR-021, FR-023)
+
+### US5 Verification
+
+- [x] T036 [US5] Run `gaze crap ./internal/analysis/...` and verify no individual handler function has GazeCRAP > 15. Verify `AnalyzeP1Effects` and `AnalyzeP2Effects` are no longer in Q4 (SC-006)
+- [x] T037 [US5] Verify cyclomatic complexity of each extracted handler is ≤ 15 by inspecting the `gaze crap` output for the `complexity` field of each new function (FR-022)
+
+**Checkpoint**: Both P1 and P2 effect detection engines decomposed. All handlers have GazeCRAP < 15. All existing tests pass with identical results.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification, documentation, and metrics validation
+
+- [x] T038 Run full test suite `go test -race -count=1 -short ./...` to verify zero regressions across all 11 packages (SC-008)
+- [x] T039 Run `golangci-lint run` to verify no new lint violations introduced (SC-009, FR-024)
+- [x] T040 Verify GoDoc comments on all new exported or helper functions across all modified files (FR-025)
+- [x] T041 Run `gaze crap --format=json ./...` and verify final metrics: GazeCRAPload ≤ 4, CRAPload ≤ 24, Q3 count = 0 (SC-001, SC-002, SC-003)
+- [x] T042 Update `specs/009-crapload-reduction/tasks.md` with final baseline/after measurements summary
+- [x] T043 Assess documentation impact: check if README.md, AGENTS.md, or other docs need updates for new patterns or conventions introduced
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — MUST run first to capture baseline
+- **Foundational (Phase 2)**: Depends on Phase 1 — verification gate only
+- **US1 (Phase 3)**: Depends on Phase 2 completion — can run in parallel with US2
+- **US2 (Phase 4)**: Depends on Phase 2 completion — can run in parallel with US1
+- **US3 (Phase 5)**: Depends on Phase 2 completion — can run in parallel with US1/US2 but MUST complete before US4 (US4 decomposes a function in the same file US3 modifies)
+- **US4 (Phase 6)**: Depends on US3 (Phase 5) completion — both modify `cmd/gaze/main.go`
+- **US5 (Phase 7)**: Depends on Phase 2 completion — can run in parallel with all other stories (different files)
+- **Polish (Phase 8)**: Depends on all previous phases
+
+### User Story Dependencies
+
+- **US1 (docscan.Filter)**: Independent — only touches `internal/docscan/filter_test.go` (new file)
+- **US2 (LoadModule)**: Independent — only touches `internal/loader/loader_test.go` (new file)
+- **US3 (CLI testability)**: Independent of US1/US2 — modifies `cmd/gaze/main.go` and `cmd/gaze/main_test.go`
+- **US4 (Pipeline decomposition)**: Depends on US3 — both modify `cmd/gaze/main.go` sequentially
+- **US5 (Effect decomposition)**: Independent — only touches `internal/analysis/p1effects.go` and `internal/analysis/p2effects.go`
+
+### Within Each User Story
+
+- Production code changes before test additions (for US3, US4, US5)
+- Test-only stories (US1, US2) have no production changes
+- Verification step at the end of each story
+
+### Parallel Opportunities
+
+- **US1 + US2**: Can run fully in parallel (different packages, no file conflicts)
+- **US1 + US5**: Can run in parallel (different packages)
+- **US2 + US5**: Can run in parallel (different packages)
+- **US3 T016 + T017**: Test tasks can run in parallel (different test functions, same file but no conflicts)
+- **US5 T032 + T033**: P2 handler extractions can run in parallel (different node types, but same file — must be done sequentially in practice)
+
+---
+
+## Parallel Example: US1 + US2
+
+```bash
+# These two stories touch completely different packages and can run simultaneously:
+# Worker A:
+Task: T004 [US1] Create filter_test.go with table-driven tests
+Task: T005 [US1] Add glob-matching tests to filter_test.go
+Task: T006 [US1] Run tests for docscan package
+Task: T007 [US1] Verify GazeCRAP metrics
+
+# Worker B (simultaneously):
+Task: T008 [US2] Create loader_test.go with happy-path test
+Task: T009 [US2] Add error-path test
+Task: T010 [US2] Add error-filtering test
+Task: T011 [US2] Run tests for loader package
+Task: T012 [US2] Verify CRAP metrics
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US2 Only)
+
+1. Complete Phase 1: Capture baseline metrics
+2. Complete Phase 2: Verify clean baseline
+3. Complete Phase 3 (US1) + Phase 4 (US2) in parallel
+4. **STOP and VALIDATE**: GazeCRAPload should drop from 7 to ~5, CRAPload from 27 to ~26
+5. This delivers the two highest-ROI improvements with zero production code changes
+
+### Incremental Delivery
+
+1. US1 + US2 → Test-only MVP (GazeCRAPload 7→5, CRAPload 27→26)
+2. US3 → CLI testability (CRAPload 26→24, adds testable CLI pattern)
+3. US4 → Pipeline decomposition (highest CRAP function addressed)
+4. US5 → Effect decomposition (structural improvement, Q4 cleanup)
+5. Polish → Final metrics validation
+
+### Sequential Single-Worker Order
+
+For a single developer working sequentially:
+
+1. Phase 1 + 2 (baseline)
+2. US1 (test-only, fast, highest GazeCRAP impact)
+3. US2 (test-only, fast, highest CRAP impact)
+4. US3 (production code change, establishes DI pattern)
+5. US4 (depends on US3, decomposes pipeline)
+6. US5 (independent, can be done any time after Phase 2)
+7. Phase 8 (polish)


### PR DESCRIPTION
## Summary

- Add contract-level tests for `docscan.Filter` (13 table-driven cases) and `loader.LoadModule` (3 tests covering valid, error, and broken-package filtering)
- Introduce dependency injection on `crapParams` (`analyzeFunc`, `coverageFunc`) and `selfCheckParams` (`moduleRootFunc`, `runCrapFunc`) enabling fast unit tests without spawning `go test -coverprofile`
- Decompose `buildContractCoverageFunc` (CC=18) into `resolvePackagePaths` and `analyzePackageCoverage`
- Decompose `AnalyzeP1Effects` (CC=32) into 4 per-node-type handlers: `detectAssignEffects`, `detectIncDecEffects`, `detectSendEffects`, `detectP1CallEffects`
- Decompose `AnalyzeP2Effects` (CC=18) into 2 per-node-type handlers: `detectGoroutineEffects`, `detectP2CallEffects`
- Refactor `runSelfCheck` to delegate to `runCrap`, eliminating duplicated CRAP pipeline logic
- Add `logger.Debug` at all `analyzePackageCoverage` nil-return paths for pipeline observability

## Review Council

Passed review council (2 iterations):
- **Iteration 1**: 13 findings (2 HIGH, 5 MEDIUM, 6 LOW) — all addressed
- **Iteration 2**: Unanimous **APPROVE** from Adversary, Architect, and Guard

## Test Verification

- `go build ./cmd/gaze` — clean
- `go vet ./...` — clean
- `go test -race -count=1 -short ./...` — all 11 packages pass
- `golangci-lint run` — only pre-existing staticcheck issue (not in changed files)

## Spec Artifacts

Full spec pipeline completed under `specs/009-crapload-reduction/` (spec.md, plan.md, tasks.md, research.md, data-model.md, quickstart.md, checklists/).