### PR TITLE
feat: add version-aware update strategy to gaze init

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,8 @@ Formatters: gofmt, goimports.
 ## Active Technologies
 - Go 1.24+ (no Go code changes; prompt is markdown) + OpenCode agent runtime (renders markdown prompt), embed.FS (scaffolds prompt copy) (011-output-voice-style)
 - Filesystem only (markdown files) (011-output-voice-style)
+- Go 1.24+ + Standard library only (`embed`, `io/fs`, `os`, `strings`, `fmt`). No new dependencies required. (012-init-update-strategy)
+- Filesystem only (`.opencode/` directory tree) (012-init-update-strategy)
 
 - Go 1.24+ + `golang.org/x/tools` (go/packages, go/ssa), Cobra (CLI), Bubble Tea/Lipgloss (TUI)
 - Filesystem only (embedded assets via `embed.FS`)

--- a/README.md
+++ b/README.md
@@ -291,13 +291,13 @@ gaze docscan --config=.gaze.yaml ./internal/analysis
 
 ### `gaze init` -- OpenCode Integration Setup
 
-Scaffold OpenCode agent and command files into the current project directory for AI-assisted quality reporting.
+Scaffold OpenCode agent and command files into the current project directory for AI-assisted quality reporting. Running `gaze init` after upgrading gaze automatically updates any outdated files based on their version marker — no `--force` required.
 
 ```bash
-# Initialize OpenCode integration
+# Initialize OpenCode integration (creates or updates files)
 gaze init
 
-# Overwrite existing files
+# Unconditionally overwrite all files
 gaze init --force
 ```
 
@@ -305,7 +305,7 @@ gaze init --force
 
 | Flag | Description |
 |------|-------------|
-| `--force` | Overwrite existing OpenCode files |
+| `--force` | Unconditionally overwrite all OpenCode files regardless of version |
 
 This creates 4 files in `.opencode/`:
 

--- a/cmd/gaze/main_test.go
+++ b/cmd/gaze/main_test.go
@@ -1268,7 +1268,7 @@ func TestRunInit_ForceFlag(t *testing.T) {
 		t.Fatalf("first runInit() returned error: %v", err)
 	}
 
-	// Second run without force: should skip.
+	// Second run with same version, no force: should show up to date.
 	var buf2 bytes.Buffer
 	if err := runInit(initParams{
 		targetDir: dir,
@@ -1278,8 +1278,8 @@ func TestRunInit_ForceFlag(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("second runInit() returned error: %v", err)
 	}
-	if !strings.Contains(buf2.String(), "skipped:") {
-		t.Errorf("expected 'skipped:' in output, got:\n%s", buf2.String())
+	if !strings.Contains(buf2.String(), "up to date:") {
+		t.Errorf("expected 'up to date:' in output, got:\n%s", buf2.String())
 	}
 
 	// Third run with force: should overwrite.

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -3,6 +3,7 @@
 package scaffold
 
 import (
+	"bufio"
 	"embed"
 	"errors"
 	"fmt"
@@ -39,15 +40,57 @@ type Options struct {
 // Result reports what the scaffold operation did.
 type Result struct {
 	// Created lists files that were written for the first time.
-	Created []string
+	Created []string `json:"created,omitempty"`
 
-	// Skipped lists files that already existed and were not
-	// overwritten (Force was false).
-	Skipped []string
+	// Updated lists files that existed with an outdated version
+	// marker and were replaced with current content.
+	Updated []string `json:"updated,omitempty"`
 
-	// Overwritten lists files that existed and were replaced
-	// (Force was true).
-	Overwritten []string
+	// UpToDate lists files that existed with a current version
+	// marker and were left untouched.
+	UpToDate []string `json:"up_to_date,omitempty"`
+
+	// Overwritten lists files that existed and were unconditionally
+	// replaced (Force was true).
+	Overwritten []string `json:"overwritten,omitempty"`
+
+	// UpdatedFrom maps each updated file's relative path to the
+	// previous version string extracted from its on-disk marker.
+	// Empty string indicates the old file had no recognizable marker.
+	UpdatedFrom map[string]string `json:"updated_from,omitempty"`
+}
+
+// markerPrefix is the fixed prefix of the version marker comment.
+const markerPrefix = "<!-- scaffolded by gaze "
+
+// markerSuffix is the fixed suffix of the version marker comment.
+const markerSuffix = " -->"
+
+// extractVersion reads the first line of the file at path and
+// extracts the version string from the version marker comment.
+// It returns the version string (e.g., "v1.0.0", "dev") or an
+// empty string if the file is empty, unreadable, or does not
+// contain a recognizable version marker on its first line.
+func extractVersion(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	if !scanner.Scan() {
+		return "" // empty file or read error
+	}
+	line := scanner.Text()
+
+	if !strings.HasPrefix(line, markerPrefix) || !strings.HasSuffix(line, markerSuffix) {
+		return ""
+	}
+
+	version := strings.TrimPrefix(line, markerPrefix)
+	version = strings.TrimSuffix(version, markerSuffix)
+	return version
 }
 
 // versionMarker returns the version marker comment to prepend to
@@ -67,11 +110,21 @@ func versionMarker(version string) string {
 //
 //	<!-- scaffolded by gaze vX.Y.Z -->
 //
-// If a file already exists and opts.Force is false, the file is
-// skipped. If opts.Force is true, the file is overwritten.
+// Run uses version-aware update logic to determine each file's
+// disposition:
 //
-// Run returns a Result summarizing what was created, skipped, or
-// overwritten.
+//   - If a file does not exist, it is created.
+//   - If a file exists and opts.Force is true, it is overwritten
+//     unconditionally.
+//   - If a file exists and the running version is "dev", it is
+//     always updated (dev builds refresh all files).
+//   - If a file exists and its version marker matches the running
+//     version, it is left untouched (up to date).
+//   - If a file exists and its version marker differs (or is
+//     missing/unparseable), it is updated with current content.
+//
+// Run returns a Result summarizing what was created, updated,
+// left up to date, or overwritten.
 func Run(opts Options) (*Result, error) {
 	if opts.TargetDir == "" {
 		cwd, err := os.Getwd()
@@ -95,7 +148,9 @@ func Run(opts Options) (*Result, error) {
 		_, _ = fmt.Fprintln(opts.Stdout)
 	}
 
-	result := &Result{}
+	result := &Result{
+		UpdatedFrom: make(map[string]string),
+	}
 	marker := versionMarker(opts.Version)
 
 	// Walk the embedded assets directory and write each file.
@@ -111,18 +166,48 @@ func Run(opts Options) (*Result, error) {
 		// under .opencode/.
 		relPath := strings.TrimPrefix(path, "assets/")
 		outPath := filepath.Join(opts.TargetDir, ".opencode", relPath)
+		displayPath := filepath.Join(".opencode", relPath)
 
 		// Check if the file already exists. Return an error for
 		// stat failures other than "not exist" (e.g., permission
 		// denied) rather than silently treating them as absent.
 		_, statErr := os.Stat(outPath)
 		if statErr != nil && !errors.Is(statErr, fs.ErrNotExist) {
-			return fmt.Errorf("checking %s: %w", filepath.Join(".opencode", relPath), statErr)
+			return fmt.Errorf("checking %s: %w", displayPath, statErr)
 		}
 		exists := statErr == nil
 
 		if exists && !opts.Force {
-			result.Skipped = append(result.Skipped, filepath.Join(".opencode", relPath))
+			// Version-aware update logic: compare the on-disk
+			// version marker against the running version.
+			oldVersion := extractVersion(outPath)
+
+			// Dev builds always update all files (FR-008).
+			// Otherwise, update only if the version differs.
+			if opts.Version != "dev" && oldVersion == opts.Version {
+				result.UpToDate = append(result.UpToDate, displayPath)
+				return nil
+			}
+
+			// File is outdated (or marker is missing/unparseable).
+			// Read embedded content and overwrite.
+			content, readErr := assets.ReadFile(path)
+			if readErr != nil {
+				return fmt.Errorf("reading embedded asset %s: %w", path, readErr)
+			}
+
+			dir := filepath.Dir(outPath)
+			if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {
+				return fmt.Errorf("creating directory %s: %w", dir, mkErr)
+			}
+
+			out := append([]byte(marker), content...)
+			if writeErr := os.WriteFile(outPath, out, 0o644); writeErr != nil {
+				return fmt.Errorf("writing %s: %w", displayPath, writeErr)
+			}
+
+			result.Updated = append(result.Updated, displayPath)
+			result.UpdatedFrom[displayPath] = oldVersion
 			return nil
 		}
 
@@ -141,13 +226,13 @@ func Run(opts Options) (*Result, error) {
 		// Prepend version marker and write.
 		out := append([]byte(marker), content...)
 		if err := os.WriteFile(outPath, out, 0o644); err != nil {
-			return fmt.Errorf("creating %s: %w", filepath.Join(".opencode", relPath), err)
+			return fmt.Errorf("writing %s: %w", displayPath, err)
 		}
 
 		if exists {
-			result.Overwritten = append(result.Overwritten, filepath.Join(".opencode", relPath))
+			result.Overwritten = append(result.Overwritten, displayPath)
 		} else {
-			result.Created = append(result.Created, filepath.Join(".opencode", relPath))
+			result.Created = append(result.Created, displayPath)
 		}
 		return nil
 	})
@@ -156,25 +241,36 @@ func Run(opts Options) (*Result, error) {
 	}
 
 	// Print summary.
-	printSummary(opts.Stdout, result, opts.Force)
+	printSummary(opts.Stdout, result, opts.Version)
 
 	return result, nil
 }
 
 // printSummary writes a human-readable summary of the scaffold
-// operation to w.
-func printSummary(w io.Writer, r *Result, force bool) {
-	if len(r.Created) > 0 || len(r.Overwritten) > 0 {
+// operation to w. It lists each file with its disposition and
+// prints a summary count footer.
+func printSummary(w io.Writer, r *Result, version string) {
+	// Header: "initialized" if any files were changed, "already up
+	// to date" if nothing was modified.
+	if len(r.Created) > 0 || len(r.Updated) > 0 || len(r.Overwritten) > 0 {
 		_, _ = fmt.Fprintln(w, "Gaze OpenCode integration initialized:")
 	} else {
 		_, _ = fmt.Fprintln(w, "Gaze OpenCode integration already up to date:")
 	}
 
+	// Per-file listing.
 	for _, f := range r.Created {
-		_, _ = fmt.Fprintf(w, "  created: %s\n", f)
+		_, _ = fmt.Fprintf(w, "  created:     %s\n", f)
 	}
-	for _, f := range r.Skipped {
-		_, _ = fmt.Fprintf(w, "  skipped: %s (already exists)\n", f)
+	for _, f := range r.Updated {
+		oldVer := r.UpdatedFrom[f]
+		if oldVer == "" {
+			oldVer = "(unknown)"
+		}
+		_, _ = fmt.Fprintf(w, "  updated:     %s (%s -> %s)\n", f, oldVer, version)
+	}
+	for _, f := range r.UpToDate {
+		_, _ = fmt.Fprintf(w, "  up to date:  %s\n", f)
 	}
 	for _, f := range r.Overwritten {
 		_, _ = fmt.Fprintf(w, "  overwritten: %s\n", f)
@@ -183,12 +279,22 @@ func printSummary(w io.Writer, r *Result, force bool) {
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintln(w, "Run /gaze in OpenCode to generate quality reports.")
 
-	if n := len(r.Skipped); n > 0 {
-		word := "file"
-		if n > 1 {
-			word = "files"
-		}
-		_, _ = fmt.Fprintf(w, "%d %s skipped (use --force to overwrite).\n", n, word)
+	// Summary count footer: show non-zero categories.
+	var parts []string
+	if n := len(r.Created); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d created", n))
+	}
+	if n := len(r.Updated); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d updated", n))
+	}
+	if n := len(r.UpToDate); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d up to date", n))
+	}
+	if n := len(r.Overwritten); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d overwritten", n))
+	}
+	if len(parts) > 0 {
+		_, _ = fmt.Fprintf(w, "%s.\n", strings.Join(parts, ", "))
 	}
 }
 

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -10,6 +10,78 @@ import (
 	"testing"
 )
 
+// TestExtractVersion verifies that extractVersion correctly parses
+// version markers from the first line of scaffolded files.
+func TestExtractVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "valid version marker",
+			content: "<!-- scaffolded by gaze v1.0.0 -->\n# Some content",
+			want:    "v1.0.0",
+		},
+		{
+			name:    "dev version marker",
+			content: "<!-- scaffolded by gaze dev -->\n# Some content",
+			want:    "dev",
+		},
+		{
+			name:    "empty version in marker",
+			content: "<!-- scaffolded by gaze  -->\n# Some content",
+			want:    "",
+		},
+		{
+			name:    "non-marker first line",
+			content: "# Some other content\n<!-- scaffolded by gaze v1.0.0 -->",
+			want:    "",
+		},
+		{
+			name:    "empty file",
+			content: "",
+			want:    "",
+		},
+		{
+			name:    "marker only no newline",
+			content: "<!-- scaffolded by gaze v2.3.4 -->",
+			want:    "v2.3.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "test.md")
+			if tt.content != "" {
+				if err := os.WriteFile(path, []byte(tt.content), 0o644); err != nil {
+					t.Fatalf("writing test file: %v", err)
+				}
+			} else {
+				// Create empty file.
+				if err := os.WriteFile(path, []byte{}, 0o644); err != nil {
+					t.Fatalf("writing empty test file: %v", err)
+				}
+			}
+
+			got := extractVersion(path)
+			if got != tt.want {
+				t.Errorf("extractVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExtractVersion_NonexistentFile verifies extractVersion returns
+// empty string for a file that does not exist.
+func TestExtractVersion_NonexistentFile(t *testing.T) {
+	got := extractVersion("/nonexistent/path/file.md")
+	if got != "" {
+		t.Errorf("extractVersion(nonexistent) = %q, want empty", got)
+	}
+}
+
 // TestRun_CreatesFiles verifies SC-001: gaze init creates exactly
 // 4 files in the correct directories when run in an empty project.
 func TestRun_CreatesFiles(t *testing.T) {
@@ -33,8 +105,11 @@ func TestRun_CreatesFiles(t *testing.T) {
 	if len(result.Created) != 4 {
 		t.Errorf("expected 4 created files, got %d: %v", len(result.Created), result.Created)
 	}
-	if len(result.Skipped) != 0 {
-		t.Errorf("expected 0 skipped files, got %d: %v", len(result.Skipped), result.Skipped)
+	if len(result.Updated) != 0 {
+		t.Errorf("expected 0 updated files, got %d: %v", len(result.Updated), result.Updated)
+	}
+	if len(result.UpToDate) != 0 {
+		t.Errorf("expected 0 up-to-date files, got %d: %v", len(result.UpToDate), result.UpToDate)
 	}
 	if len(result.Overwritten) != 0 {
 		t.Errorf("expected 0 overwritten files, got %d: %v", len(result.Overwritten), result.Overwritten)
@@ -64,9 +139,9 @@ func TestRun_CreatesFiles(t *testing.T) {
 	}
 }
 
-// TestRun_SkipsExisting verifies SC-002: gaze init skips existing
-// files and reports them when --force is not set.
-func TestRun_SkipsExisting(t *testing.T) {
+// TestRun_UpToDate verifies SC-002: gaze init reports files as
+// up to date when they already have the current version marker.
+func TestRun_UpToDate(t *testing.T) {
 	dir := t.TempDir()
 
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n"), 0o644); err != nil {
@@ -84,7 +159,7 @@ func TestRun_SkipsExisting(t *testing.T) {
 		t.Fatalf("first Run() returned error: %v", err)
 	}
 
-	// Second run without --force: should skip all files.
+	// Second run with same version: all files should be up to date.
 	var buf2 bytes.Buffer
 	result, err := Run(Options{
 		TargetDir: dir,
@@ -98,19 +173,19 @@ func TestRun_SkipsExisting(t *testing.T) {
 	if len(result.Created) != 0 {
 		t.Errorf("expected 0 created, got %d: %v", len(result.Created), result.Created)
 	}
-	if len(result.Skipped) != 4 {
-		t.Errorf("expected 4 skipped, got %d: %v", len(result.Skipped), result.Skipped)
+	if len(result.UpToDate) != 4 {
+		t.Errorf("expected 4 up to date, got %d: %v", len(result.UpToDate), result.UpToDate)
+	}
+	if len(result.Updated) != 0 {
+		t.Errorf("expected 0 updated, got %d: %v", len(result.Updated), result.Updated)
 	}
 	if len(result.Overwritten) != 0 {
 		t.Errorf("expected 0 overwritten, got %d: %v", len(result.Overwritten), result.Overwritten)
 	}
 
 	output := buf2.String()
-	if !strings.Contains(output, "skipped:") {
-		t.Errorf("summary should mention 'skipped:', got:\n%s", output)
-	}
-	if !strings.Contains(output, "use --force to overwrite") {
-		t.Errorf("summary should suggest --force, got:\n%s", output)
+	if !strings.Contains(output, "up to date:") {
+		t.Errorf("summary should mention 'up to date:', got:\n%s", output)
 	}
 }
 
@@ -149,8 +224,11 @@ func TestRun_ForceOverwrites(t *testing.T) {
 	if len(result.Created) != 0 {
 		t.Errorf("expected 0 created, got %d: %v", len(result.Created), result.Created)
 	}
-	if len(result.Skipped) != 0 {
-		t.Errorf("expected 0 skipped, got %d: %v", len(result.Skipped), result.Skipped)
+	if len(result.Updated) != 0 {
+		t.Errorf("expected 0 updated, got %d: %v", len(result.Updated), result.Updated)
+	}
+	if len(result.UpToDate) != 0 {
+		t.Errorf("expected 0 up to date, got %d: %v", len(result.UpToDate), result.UpToDate)
 	}
 	if len(result.Overwritten) != 4 {
 		t.Errorf("expected 4 overwritten, got %d: %v", len(result.Overwritten), result.Overwritten)
@@ -331,6 +409,315 @@ func TestAssetPaths_Returns4Files(t *testing.T) {
 		if !expected[p] {
 			t.Errorf("unexpected asset path: %s", p)
 		}
+	}
+}
+
+// TestPrintSummary_MixedScenario verifies FR-005 / FR-007: output
+// correctly categorizes files into all four states and includes
+// version transition details for updated files.
+func TestPrintSummary_MixedScenario(t *testing.T) {
+	r := &Result{
+		Created:  []string{".opencode/command/new-cmd.md"},
+		Updated:  []string{".opencode/agents/gaze-reporter.md"},
+		UpToDate: []string{".opencode/command/gaze.md", ".opencode/command/classify-docs.md"},
+		UpdatedFrom: map[string]string{
+			".opencode/agents/gaze-reporter.md": "v1.0.0",
+		},
+	}
+
+	var buf bytes.Buffer
+	printSummary(&buf, r, "v2.0.0")
+	output := buf.String()
+
+	// Header should say "initialized" since files were changed.
+	if !strings.Contains(output, "initialized:") {
+		t.Errorf("expected 'initialized:' header, got:\n%s", output)
+	}
+
+	// Should contain all disposition labels.
+	if !strings.Contains(output, "created:") {
+		t.Errorf("expected 'created:' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "updated:") {
+		t.Errorf("expected 'updated:' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "up to date:") {
+		t.Errorf("expected 'up to date:' in output, got:\n%s", output)
+	}
+
+	// Version transition for updated file.
+	if !strings.Contains(output, "(v1.0.0 -> v2.0.0)") {
+		t.Errorf("expected version transition '(v1.0.0 -> v2.0.0)' in output, got:\n%s", output)
+	}
+
+	// Summary count line.
+	if !strings.Contains(output, "1 created") {
+		t.Errorf("expected '1 created' in summary, got:\n%s", output)
+	}
+	if !strings.Contains(output, "1 updated") {
+		t.Errorf("expected '1 updated' in summary, got:\n%s", output)
+	}
+	if !strings.Contains(output, "2 up to date") {
+		t.Errorf("expected '2 up to date' in summary, got:\n%s", output)
+	}
+}
+
+// TestPrintSummary_AllUpToDate verifies SC-002: when all files
+// are current, the header says "already up to date" and no
+// modification labels appear.
+func TestPrintSummary_AllUpToDate(t *testing.T) {
+	r := &Result{
+		UpToDate: []string{
+			".opencode/agents/gaze-reporter.md",
+			".opencode/agents/doc-classifier.md",
+			".opencode/command/gaze.md",
+			".opencode/command/classify-docs.md",
+		},
+		UpdatedFrom: make(map[string]string),
+	}
+
+	var buf bytes.Buffer
+	printSummary(&buf, r, "v1.0.0")
+	output := buf.String()
+
+	// Header should say "already up to date".
+	if !strings.Contains(output, "already up to date:") {
+		t.Errorf("expected 'already up to date:' header, got:\n%s", output)
+	}
+
+	// Should NOT contain "created:", "updated:", or "overwritten:".
+	if strings.Contains(output, "created:") {
+		t.Errorf("should not contain 'created:' when all up to date, got:\n%s", output)
+	}
+	if strings.Contains(output, "updated:") {
+		t.Errorf("should not contain 'updated:' when all up to date, got:\n%s", output)
+	}
+	if strings.Contains(output, "overwritten:") {
+		t.Errorf("should not contain 'overwritten:' when all up to date, got:\n%s", output)
+	}
+
+	// Summary should show "4 up to date".
+	if !strings.Contains(output, "4 up to date") {
+		t.Errorf("expected '4 up to date' in summary, got:\n%s", output)
+	}
+}
+
+// TestRun_UpdatesOutdated verifies SC-001 / FR-002: gaze init
+// updates all files when their version marker differs from the
+// running version.
+func TestRun_UpdatesOutdated(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n"), 0o644); err != nil {
+		t.Fatalf("creating go.mod: %v", err)
+	}
+
+	// First run: scaffold with v1.0.0.
+	var buf1 bytes.Buffer
+	_, err := Run(Options{
+		TargetDir: dir,
+		Version:   "v1.0.0",
+		Stdout:    &buf1,
+	})
+	if err != nil {
+		t.Fatalf("first Run() returned error: %v", err)
+	}
+
+	// Second run with v2.0.0: all files should be updated.
+	var buf2 bytes.Buffer
+	result, err := Run(Options{
+		TargetDir: dir,
+		Version:   "v2.0.0",
+		Stdout:    &buf2,
+	})
+	if err != nil {
+		t.Fatalf("second Run() returned error: %v", err)
+	}
+
+	if len(result.Updated) != 4 {
+		t.Errorf("expected 4 updated, got %d: %v", len(result.Updated), result.Updated)
+	}
+	if len(result.UpToDate) != 0 {
+		t.Errorf("expected 0 up to date, got %d: %v", len(result.UpToDate), result.UpToDate)
+	}
+	if len(result.Created) != 0 {
+		t.Errorf("expected 0 created, got %d: %v", len(result.Created), result.Created)
+	}
+	if len(result.Overwritten) != 0 {
+		t.Errorf("expected 0 overwritten, got %d: %v", len(result.Overwritten), result.Overwritten)
+	}
+
+	// Verify each file has the new version marker.
+	expectedMarker := "<!-- scaffolded by gaze v2.0.0 -->"
+	paths, err := assetPaths()
+	if err != nil {
+		t.Fatalf("assetPaths() returned error: %v", err)
+	}
+	for _, relPath := range paths {
+		fullPath := filepath.Join(dir, ".opencode", relPath)
+		content, err := os.ReadFile(fullPath)
+		if err != nil {
+			t.Fatalf("reading %s: %v", relPath, err)
+		}
+		firstLine := strings.SplitN(string(content), "\n", 2)[0]
+		if firstLine != expectedMarker {
+			t.Errorf("file %s: expected first line %q, got %q", relPath, expectedMarker, firstLine)
+		}
+	}
+
+	// Verify UpdatedFrom maps each file to "v1.0.0".
+	for _, f := range result.Updated {
+		oldVer, ok := result.UpdatedFrom[f]
+		if !ok {
+			t.Errorf("UpdatedFrom missing entry for %s", f)
+			continue
+		}
+		if oldVer != "v1.0.0" {
+			t.Errorf("UpdatedFrom[%s] = %q, want %q", f, oldVer, "v1.0.0")
+		}
+	}
+}
+
+// TestRun_DevAlwaysUpdates verifies FR-008: dev builds always
+// update all existing scaffolded files regardless of on-disk marker.
+func TestRun_DevAlwaysUpdates(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n"), 0o644); err != nil {
+		t.Fatalf("creating go.mod: %v", err)
+	}
+
+	// First run: scaffold with v1.0.0.
+	var buf1 bytes.Buffer
+	_, err := Run(Options{
+		TargetDir: dir,
+		Version:   "v1.0.0",
+		Stdout:    &buf1,
+	})
+	if err != nil {
+		t.Fatalf("first Run() returned error: %v", err)
+	}
+
+	// Second run with dev version (empty string defaults to "dev"):
+	// all files should be updated.
+	var buf2 bytes.Buffer
+	result, err := Run(Options{
+		TargetDir: dir,
+		Version:   "", // defaults to "dev"
+		Stdout:    &buf2,
+	})
+	if err != nil {
+		t.Fatalf("second Run() with dev returned error: %v", err)
+	}
+
+	if len(result.Updated) != 4 {
+		t.Errorf("expected 4 updated (dev from v1.0.0), got %d: %v", len(result.Updated), result.Updated)
+	}
+	if len(result.UpToDate) != 0 {
+		t.Errorf("expected 0 up to date, got %d: %v", len(result.UpToDate), result.UpToDate)
+	}
+
+	// Verify marker changes to "dev".
+	expectedMarker := "<!-- scaffolded by gaze dev -->"
+	paths, err := assetPaths()
+	if err != nil {
+		t.Fatalf("assetPaths() returned error: %v", err)
+	}
+	for _, relPath := range paths {
+		fullPath := filepath.Join(dir, ".opencode", relPath)
+		content, err := os.ReadFile(fullPath)
+		if err != nil {
+			t.Fatalf("reading %s: %v", relPath, err)
+		}
+		firstLine := strings.SplitN(string(content), "\n", 2)[0]
+		if firstLine != expectedMarker {
+			t.Errorf("file %s: expected first line %q, got %q", relPath, expectedMarker, firstLine)
+		}
+	}
+
+	// Third run with dev again: should still update (dev always updates).
+	var buf3 bytes.Buffer
+	result3, err := Run(Options{
+		TargetDir: dir,
+		Version:   "", // defaults to "dev"
+		Stdout:    &buf3,
+	})
+	if err != nil {
+		t.Fatalf("third Run() with dev returned error: %v", err)
+	}
+
+	if len(result3.Updated) != 4 {
+		t.Errorf("expected 4 updated (dev-to-dev), got %d: %v", len(result3.Updated), result3.Updated)
+	}
+}
+
+// TestRun_MissingMarkerTreatedAsOutdated verifies FR-006: files
+// without a recognizable version marker are treated as outdated.
+func TestRun_MissingMarkerTreatedAsOutdated(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n"), 0o644); err != nil {
+		t.Fatalf("creating go.mod: %v", err)
+	}
+
+	// First run: scaffold with v1.0.0.
+	var buf1 bytes.Buffer
+	_, err := Run(Options{
+		TargetDir: dir,
+		Version:   "v1.0.0",
+		Stdout:    &buf1,
+	})
+	if err != nil {
+		t.Fatalf("first Run() returned error: %v", err)
+	}
+
+	// Overwrite one file with content that has no version marker.
+	paths, err := assetPaths()
+	if err != nil {
+		t.Fatalf("assetPaths() returned error: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("no asset paths found")
+	}
+	targetFile := filepath.Join(dir, ".opencode", paths[0])
+	if err := os.WriteFile(targetFile, []byte("# No version marker here\n"), 0o644); err != nil {
+		t.Fatalf("overwriting %s: %v", paths[0], err)
+	}
+
+	// Second run with v2.0.0: the file with no marker should be updated.
+	var buf2 bytes.Buffer
+	result, err := Run(Options{
+		TargetDir: dir,
+		Version:   "v2.0.0",
+		Stdout:    &buf2,
+	})
+	if err != nil {
+		t.Fatalf("second Run() returned error: %v", err)
+	}
+
+	// All 4 files should be updated (3 have old v1.0.0, 1 has no marker).
+	if len(result.Updated) != 4 {
+		t.Errorf("expected 4 updated, got %d: %v", len(result.Updated), result.Updated)
+	}
+
+	// The file with no marker should have empty string in UpdatedFrom.
+	noMarkerPath := filepath.Join(".opencode", paths[0])
+	oldVer, ok := result.UpdatedFrom[noMarkerPath]
+	if !ok {
+		t.Errorf("UpdatedFrom missing entry for %s", noMarkerPath)
+	} else if oldVer != "" {
+		t.Errorf("UpdatedFrom[%s] = %q, want empty string (no marker)", noMarkerPath, oldVer)
+	}
+
+	// Verify the file now has the v2.0.0 marker.
+	content, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatalf("reading %s: %v", targetFile, err)
+	}
+	expectedMarker := "<!-- scaffolded by gaze v2.0.0 -->"
+	firstLine := strings.SplitN(string(content), "\n", 2)[0]
+	if firstLine != expectedMarker {
+		t.Errorf("file %s: expected first line %q, got %q", paths[0], expectedMarker, firstLine)
 	}
 }
 

--- a/specs/012-init-update-strategy/checklists/requirements.md
+++ b/specs/012-init-update-strategy/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Init Update Strategy
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- [RESOLVED] "dev" version behavior clarified: dev builds always update all files. FR-008 and Edge Cases updated accordingly.
+- All checklist items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/012-init-update-strategy/data-model.md
+++ b/specs/012-init-update-strategy/data-model.md
@@ -1,0 +1,100 @@
+# Data Model: Init Update Strategy
+
+**Branch**: `012-init-update-strategy` | **Date**: 2026-03-01
+
+## Entities
+
+### Options (existing, unchanged)
+
+Configuration for the scaffold operation. No changes required.
+
+| Field     | Type       | Description                                                |
+|-----------|------------|------------------------------------------------------------|
+| TargetDir | string     | Root directory to scaffold into. Defaults to cwd.          |
+| Force     | bool       | Unconditionally overwrite all files when true.             |
+| Version   | string     | Gaze version string for the version marker. Defaults "dev".|
+| Stdout    | io.Writer  | Writer for summary output. Defaults to os.Stdout.          |
+
+### Result (modified)
+
+Reports what the scaffold operation did. The `Skipped` field is removed and replaced with `Updated`, `UpToDate`, and `UpdatedFrom`.
+
+#### Current Schema
+
+| Field       | Type       | Description                                    |
+|-------------|------------|------------------------------------------------|
+| Created     | []string   | Files written for the first time.              |
+| Skipped     | []string   | Files that existed and were not overwritten.    |
+| Overwritten | []string   | Files that existed and were replaced (--force). |
+
+#### New Schema
+
+| Field       | Type              | Description                                                        |
+|-------------|-------------------|--------------------------------------------------------------------|
+| Created     | []string          | Files written for the first time (did not exist on disk).          |
+| Updated     | []string          | Files that existed with an outdated version marker and were replaced.|
+| UpToDate    | []string          | Files that existed with a current version marker and were left untouched.|
+| Overwritten | []string          | Files that existed and were unconditionally replaced (--force).    |
+| UpdatedFrom | map[string]string | Maps relative path to previous version string for each updated file.|
+
+#### State Transition Rules
+
+For each file in the embedded asset manifest:
+
+```
+File does not exist on disk
+  → Write file with current content and version marker
+  → Classify as "Created"
+
+File exists, --force is set
+  → Overwrite file unconditionally
+  → Classify as "Overwritten"
+
+File exists, running version is "dev"
+  → Read first line, extract old version (may be "dev" or any string)
+  → Overwrite file with current content and "dev" marker
+  → Classify as "Updated", record old version in UpdatedFrom
+
+File exists, version marker matches running version
+  → Leave file untouched
+  → Classify as "UpToDate"
+
+File exists, version marker differs from running version (or missing/unparseable)
+  → Read first line, extract old version (or "(unknown)" if missing)
+  → Overwrite file with current content and new version marker
+  → Classify as "Updated", record old version in UpdatedFrom
+```
+
+### Version Marker (implicit entity)
+
+Not a struct — a string convention embedded as the first line of each scaffolded file.
+
+| Attribute | Value                                    |
+|-----------|------------------------------------------|
+| Format    | `<!-- scaffolded by gaze VERSION -->`    |
+| Location  | First line of scaffolded file            |
+| Prefix    | `<!-- scaffolded by gaze `               |
+| Suffix    | ` -->`                                   |
+
+#### extractVersion() Behavior
+
+| Input (first line)                       | Output            |
+|------------------------------------------|-------------------|
+| `<!-- scaffolded by gaze v1.0.0 -->`     | `"v1.0.0"`        |
+| `<!-- scaffolded by gaze dev -->`        | `"dev"`           |
+| `<!-- scaffolded by gaze  -->`           | `""` (empty)      |
+| `# Some other content`                  | `""` (empty)      |
+| (empty file)                             | `""` (empty)      |
+
+When `extractVersion()` returns empty string, the file is treated as having no recognizable marker (FR-006: treat as outdated).
+
+## Relationships
+
+```
+Options --[configures]--> Run()
+Run()   --[produces]----> Result
+Result  --[contains]----> Created, Updated, UpToDate, Overwritten (file lists)
+Result  --[contains]----> UpdatedFrom (version provenance per updated file)
+```
+
+No external entities, no database, no network resources.

--- a/specs/012-init-update-strategy/plan.md
+++ b/specs/012-init-update-strategy/plan.md
@@ -1,0 +1,77 @@
+# Implementation Plan: Init Update Strategy
+
+**Branch**: `012-init-update-strategy` | **Date**: 2026-03-01 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/012-init-update-strategy/spec.md`
+
+## Summary
+
+`gaze init` currently has a binary file handling strategy: skip existing files (default) or unconditionally overwrite everything (`--force`). This feature adds version-aware update logic so that `gaze init` automatically detects outdated scaffolded files via their version marker comment and replaces them with current content — without requiring `--force`. The `Result` struct and `printSummary` output are extended to distinguish four file dispositions: created, updated, up to date, and overwritten.
+
+## Technical Context
+
+**Language/Version**: Go 1.24+
+**Primary Dependencies**: Standard library only (`embed`, `io/fs`, `os`, `strings`, `fmt`). No new dependencies required.
+**Storage**: Filesystem only (`.opencode/` directory tree)
+**Testing**: Standard library `testing` package. Existing test suite in `internal/scaffold/scaffold_test.go` and `cmd/gaze/main_test.go`.
+**Target Platform**: Cross-platform (darwin/linux x amd64/arm64, built via GoReleaser)
+**Project Type**: Single binary CLI
+**Performance Goals**: N/A — operates on 4 small files; performance is not a concern.
+**Constraints**: All changes confined to `internal/scaffold/` and `cmd/gaze/`. No new packages. No new dependencies.
+**Scale/Scope**: 4 embedded asset files, ~200 lines of production code to modify, ~400 lines of test code to modify/add.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### I. Accuracy — PASS
+
+This feature does not change side effect detection, assertion mapping, or CRAP scoring. It modifies the `gaze init` scaffolding command only. The version marker comparison (string equality) is deterministic and produces no false positives or negatives. Accuracy of the update detection is verified by automated tests covering all four file states (created, updated, up to date, overwritten) plus edge cases (missing marker, dev version).
+
+### II. Minimal Assumptions — PASS
+
+The feature introduces one new assumption: that the first line of a scaffolded file contains a version marker in the format `<!-- scaffolded by gaze VERSION -->`. This assumption is:
+- Already established by the existing `versionMarker()` function (not new).
+- Explicitly documented in the spec's Assumptions section.
+- Enforced at a single parse point (the new `extractVersion()` function).
+- Gracefully degraded when violated (missing/unparseable marker → treat as outdated).
+
+No new assumptions about the host project's language, test framework, or coding style are introduced.
+
+### III. Actionable Output — PASS
+
+The feature improves actionable output by:
+- Replacing the uninformative "skipped (already exists)" message with version-aware dispositions.
+- Adding version transition details to updated files (e.g., "v1.0.0 -> v2.0.0").
+- Providing a summary count by category so users know exactly what changed and why.
+- Guiding users toward `--force` only when appropriate (not as the default suggestion for all existing files).
+
+**Gate result: All three principles PASS. Proceeding to Phase 0.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-init-update-strategy/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── checklists/
+    └── requirements.md  # Spec quality checklist
+```
+
+### Source Code (repository root)
+
+```text
+internal/scaffold/
+├── scaffold.go          # Production code: Run(), Result, printSummary(), extractVersion() [NEW]
+└── scaffold_test.go     # Tests: existing + new update/up-to-date/dev/edge-case tests
+
+cmd/gaze/
+├── main.go              # CLI layer: runInit(), newInitCmd() (no changes expected)
+└── main_test.go         # Integration tests: TestRunInit_* (update existing tests)
+```
+
+**Structure Decision**: All changes are confined to the existing `internal/scaffold/` package plus test updates in `cmd/gaze/main_test.go`. No new packages or files are needed. The scaffold package already owns all the relevant logic; the CLI layer (`runInit`) is a thin passthrough that requires no modification.

--- a/specs/012-init-update-strategy/quickstart.md
+++ b/specs/012-init-update-strategy/quickstart.md
@@ -1,0 +1,93 @@
+# Quickstart: Init Update Strategy
+
+**Branch**: `012-init-update-strategy` | **Date**: 2026-03-01
+
+## What This Feature Does
+
+After this change, `gaze init` automatically detects and updates scaffolded files that are out of date. Previously, running `gaze init` after upgrading gaze would silently skip all existing files. Now it compares the version marker in each file against the running binary's version and replaces outdated files automatically.
+
+## Before (current behavior)
+
+```
+$ gaze init                         # First install — creates files
+Gaze OpenCode integration initialized:
+  created: .opencode/agents/gaze-reporter.md
+  created: .opencode/agents/doc-classifier.md
+  created: .opencode/command/gaze.md
+  created: .opencode/command/classify-docs.md
+
+$ # ... upgrade gaze from v1.0.0 to v2.0.0 ...
+
+$ gaze init                         # Files are silently skipped
+Gaze OpenCode integration already up to date:
+  skipped: .opencode/agents/gaze-reporter.md (already exists)
+  skipped: .opencode/agents/doc-classifier.md (already exists)
+  skipped: .opencode/command/gaze.md (already exists)
+  skipped: .opencode/command/classify-docs.md (already exists)
+
+4 files skipped (use --force to overwrite).
+```
+
+## After (new behavior)
+
+```
+$ gaze init                         # First install — same as before
+Gaze OpenCode integration initialized:
+  created:    .opencode/agents/gaze-reporter.md
+  created:    .opencode/agents/doc-classifier.md
+  created:    .opencode/command/gaze.md
+  created:    .opencode/command/classify-docs.md
+
+$ # ... upgrade gaze from v1.0.0 to v2.0.0 ...
+
+$ gaze init                         # Outdated files are updated automatically
+Gaze OpenCode integration initialized:
+  updated:    .opencode/agents/gaze-reporter.md (v1.0.0 -> v2.0.0)
+  updated:    .opencode/agents/doc-classifier.md (v1.0.0 -> v2.0.0)
+  updated:    .opencode/command/gaze.md (v1.0.0 -> v2.0.0)
+  updated:    .opencode/command/classify-docs.md (v1.0.0 -> v2.0.0)
+
+4 updated.
+
+$ gaze init                         # Already current — no changes
+Gaze OpenCode integration already up to date:
+  up to date: .opencode/agents/gaze-reporter.md
+  up to date: .opencode/agents/doc-classifier.md
+  up to date: .opencode/command/gaze.md
+  up to date: .opencode/command/classify-docs.md
+
+$ gaze init --force                 # Force still works as before
+Gaze OpenCode integration initialized:
+  overwritten: .opencode/agents/gaze-reporter.md
+  overwritten: .opencode/agents/doc-classifier.md
+  overwritten: .opencode/command/gaze.md
+  overwritten: .opencode/command/classify-docs.md
+```
+
+## Key Changes
+
+1. **No more silent skipping**: Files with outdated version markers are replaced automatically.
+2. **Version transition visible**: Updated files show the old and new version in the output.
+3. **`--force` unchanged**: Still overwrites everything unconditionally.
+4. **Dev builds always update**: Running a `dev` build always refreshes all files.
+
+## Testing
+
+```bash
+# Run unit tests for scaffold package
+go test -race -count=1 ./internal/scaffold/...
+
+# Run integration tests for init command
+go test -race -count=1 -run TestRunInit ./cmd/gaze/...
+
+# Run all tests
+go test -race -count=1 -short ./...
+```
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `internal/scaffold/scaffold.go` | Add `extractVersion()`, modify `Run()` logic, update `Result` struct, update `printSummary()` |
+| `internal/scaffold/scaffold_test.go` | Update existing tests, add new tests for update/up-to-date/dev/edge-case scenarios |
+| `cmd/gaze/main_test.go` | Update `TestRunInit_ForceFlag` to cover new states |

--- a/specs/012-init-update-strategy/research.md
+++ b/specs/012-init-update-strategy/research.md
@@ -1,0 +1,90 @@
+# Research: Init Update Strategy
+
+**Branch**: `012-init-update-strategy` | **Date**: 2026-03-01
+
+## R1: Version Marker Extraction Strategy
+
+### Decision
+
+Extract the version string from the first line of an existing scaffolded file using prefix/suffix stripping on the known marker format `<!-- scaffolded by gaze VERSION -->`.
+
+### Rationale
+
+The version marker format is a project-internal convention, fully controlled by the `versionMarker()` function in `scaffold.go`. It has a fixed prefix (`<!-- scaffolded by gaze `) and suffix (` -->`). Simple string operations (TrimPrefix/TrimSuffix) are sufficient — no regex, no HTML parsing, no multi-line scanning. This keeps the implementation minimal and avoids new dependencies.
+
+### Alternatives Considered
+
+1. **Regex parsing** (`regexp.MustCompile`): More flexible but overkill for a fixed format. Adds compilation cost (trivial) and cognitive overhead for readers. Rejected for unnecessary complexity.
+2. **Read entire file and scan all lines**: Allows the marker to appear anywhere. Rejected because the marker is always the first line (guaranteed by `Run()`), so reading beyond line 1 would be wasteful and introduce ambiguity about which line "wins."
+3. **Structured metadata file** (e.g., `.opencode/.gaze-manifest.json`): Would store version per file in a separate manifest. Rejected because it adds a new file to manage, introduces sync issues between manifest and actual files, and is a larger scope change than warranted.
+
+## R2: Result Struct Extension
+
+### Decision
+
+Replace the `Skipped []string` field with two new fields: `Updated []string` and `UpToDate []string`. The `Updated` field captures files whose version marker differs from the current version and were replaced. The `UpToDate` field captures files whose version marker matches the current version and were left untouched.
+
+Add an `UpdatedFrom map[string]string` field to record the previous version for each updated file (keyed by relative path), enabling the "v1.0.0 -> v2.0.0" output required by FR-007.
+
+### Rationale
+
+The existing `Skipped` field conflates two distinct states: "file is current" and "file is outdated but I didn't touch it." The new design makes the distinction explicit in the data model, which simplifies both the summary output and test assertions. The `UpdatedFrom` map avoids passing version information through side channels.
+
+### Alternatives Considered
+
+1. **Keep `Skipped` and add `Updated` alongside**: Would mean `Skipped` now only contains "up to date" files, which is a misleading name. Rejected for naming confusion.
+2. **Use a single `FileResult` struct per file** (disposition enum + metadata): Cleaner object model but a larger refactor of all callers and tests. Deferred — the current slice-based approach is consistent with the existing code style.
+3. **Store old version in a separate return value**: More fragile coupling. Rejected in favor of the self-contained `UpdatedFrom` map.
+
+## R3: Dev Version Behavior
+
+### Decision
+
+When `opts.Version` is `"dev"`, treat all existing files as outdated regardless of their on-disk version marker. This means dev builds always rewrite all files (equivalent to implicit `--force` for staleness, but still tracked as "updated" rather than "overwritten").
+
+### Rationale
+
+Developers working on gaze itself frequently change the embedded asset files. Requiring `--force` every time they want to test updated prompts creates friction. Since dev builds have no meaningful version identity, always refreshing is the safe and simple choice. The user explicitly chose this behavior during specification clarification.
+
+### Alternatives Considered
+
+1. **Dev never updates**: Requires `--force` for every change during development. Rejected for developer friction.
+2. **Dev uses content comparison**: Reads on-disk file and compares byte-for-byte with embedded content. More precise but adds I/O cost and complexity for a development-only scenario. Rejected for over-engineering.
+
+## R4: printSummary Output Format
+
+### Decision
+
+Extend `printSummary` to handle the four file states with these output formats:
+
+- `  created:     .opencode/agents/gaze-reporter.md`
+- `  updated:     .opencode/agents/gaze-reporter.md (v1.0.0 -> v2.0.0)`
+- `  up to date:  .opencode/agents/gaze-reporter.md`
+- `  overwritten: .opencode/agents/gaze-reporter.md`
+
+The summary footer shows counts: `"1 created, 2 updated, 1 up to date."` Up-to-date files are listed individually (not suppressed) so the user sees a complete manifest of all scaffolded files. The existing `"use --force to overwrite"` hint is removed since files are now updated automatically; it is no longer needed.
+
+### Rationale
+
+Individual listing of all files (including up-to-date) provides full transparency at minimal cost (4 files total). The version transition annotation on "updated" lines satisfies FR-007. Removing the `--force` hint for the non-force path avoids confusing users into thinking they need to force something that already happened.
+
+### Alternatives Considered
+
+1. **Suppress up-to-date files from individual listing**: Shorter output but users lose visibility into which files are managed. Rejected for reduced transparency.
+2. **Use color/emoji for status**: Adds visual clarity but increases implementation scope (terminal color detection, Lipgloss dependency in scaffold package). Deferred — can be added later without changing the data model.
+3. **Machine-readable JSON output mode**: Useful for CI but out of scope for this feature. The `Result` struct is already returned programmatically; JSON formatting can be added independently.
+
+## R5: Backward Compatibility of Existing Tests
+
+### Decision
+
+Existing tests that assert on `result.Skipped` must be updated to use `result.UpToDate` (for same-version re-runs) or `result.Updated` (for cross-version re-runs). The test names and comments reference spec success criteria (SC-xxx) and should be updated to reflect the new behavior semantics.
+
+### Rationale
+
+The `Skipped` field is being removed. Tests that use it will fail at compile time, forcing explicit review. This is preferable to silently leaving stale test logic. The number of affected tests is small (3 in scaffold_test.go, 1 in main_test.go).
+
+### Alternatives Considered
+
+1. **Keep `Skipped` as a deprecated alias**: Avoids test churn but leaves confusing dead code. Rejected for zero-waste mandate.
+2. **Add `Updated` without removing `Skipped`**: Both fields would need to be populated, doubling bookkeeping. Rejected for unnecessary complexity.

--- a/specs/012-init-update-strategy/spec.md
+++ b/specs/012-init-update-strategy/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Init Update Strategy
+
+**Feature Branch**: `012-init-update-strategy`  
+**Created**: 2026-03-01  
+**Status**: Draft  
+**Input**: User description: "please help decide where addressing updates to an existing deployment with `gaze init`. Currently it doesn't overwrite existing files that are out of date."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Seamless Upgrade After Gaze Update (Priority: P1)
+
+A developer upgrades Gaze to a new version. The new version ships with improved agent prompts and command definitions in its embedded assets. The developer runs `gaze init` and expects it to detect that the existing scaffolded files are from an older version and update them automatically — without requiring `--force` and without losing track of what changed.
+
+**Why this priority**: This is the core problem. Today, running `gaze init` after a Gaze upgrade silently skips all existing files, leaving the project with stale agent prompts and commands. The only workaround is `--force`, which overwrites everything unconditionally with no indication of what actually changed. Users need a safe, informative upgrade path that is the default behavior.
+
+**Independent Test**: Can be fully tested by scaffolding files tagged with version "v1.0.0", then running `gaze init` with version "v2.0.0" and verifying that outdated files are replaced with new content and the output clearly distinguishes "updated" files from other states.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with files scaffolded by gaze v1.0.0, **When** the user runs `gaze init` with gaze v2.0.0 (which has updated embedded assets), **Then** the outdated files are replaced with the new versions and the output labels each as "updated."
+2. **Given** a project with files scaffolded by the same version of gaze currently running, **When** the user runs `gaze init`, **Then** no files are modified and the output says "already up to date."
+3. **Given** a project with files scaffolded by gaze v1.0.0, **When** the user runs `gaze init` with gaze v2.0.0, **Then** the updated files contain the new version marker reflecting v2.0.0.
+
+---
+
+### User Story 2 - Clear Reporting of File Dispositions (Priority: P2)
+
+A developer or team lead wants to understand what `gaze init` did after an upgrade. They need clear output distinguishing between files that were newly created (didn't exist before), files that were updated (existed but were outdated), files that were already current (no action needed), and files that were forcefully overwritten.
+
+**Why this priority**: Transparency builds trust. Without clear reporting, developers cannot tell whether `gaze init` actually changed anything or what the impact was. This is especially important in team environments where scaffolded files are committed to version control.
+
+**Independent Test**: Can be fully tested by setting up a mixed scenario — some files missing, some outdated, some current — and verifying the output summary correctly categorizes each file.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project where one file is missing, one is outdated, and two are current, **When** the user runs `gaze init`, **Then** the output shows the missing file as "created," the outdated file as "updated," and the current files as "up to date" or omits them from the listing.
+2. **Given** any `gaze init` run that updates at least one file, **When** the operation completes, **Then** the output for each updated file includes the old version and the new version (e.g., "v1.0.0 -> v2.0.0").
+3. **Given** any `gaze init` run, **When** the operation completes, **Then** a summary line shows counts for each category (e.g., "1 created, 1 updated, 2 up to date").
+
+---
+
+### User Story 3 - Force as an Escape Hatch (Priority: P3)
+
+A developer wants to reset all scaffolded files to the canonical versions shipped with their current Gaze binary, regardless of version markers or local edits. They use `--force` to unconditionally overwrite everything.
+
+**Why this priority**: `--force` already exists and works. This story ensures the new update logic does not break or remove the existing force behavior. It remains the escape hatch for when smart detection is insufficient (e.g., corrupted files, manually edited files the user wants to reset).
+
+**Independent Test**: Can be fully tested by scaffolding files, manually editing one, then running `gaze init --force` and verifying all files are replaced regardless of version or content.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with files scaffolded by the current version of gaze (already up to date), **When** the user runs `gaze init --force`, **Then** all files are overwritten and reported as "overwritten."
+2. **Given** a project with a manually edited scaffolded file, **When** the user runs `gaze init --force`, **Then** the edited file is replaced with the canonical embedded version.
+
+---
+
+### Edge Cases
+
+- What happens when a scaffolded file exists but has no version marker (e.g., created manually or by a pre-marker version of gaze)? The file is treated as outdated and updated, since its provenance cannot be confirmed.
+- What happens when a scaffolded file has a version marker that cannot be parsed (e.g., corrupted or unexpected format)? The file is treated as outdated and updated.
+- What happens when the running gaze binary has version "dev" (development build)? Dev builds always update all files, regardless of the on-disk version marker. This ensures developers working on gaze itself always get the latest embedded assets without needing `--force`.
+- What happens when a new file is added to the embedded assets in a new gaze version but the project was scaffolded by an older version? The new file is created normally (it does not exist on disk, so the existing "created" path handles it).
+- What happens when a file is removed from embedded assets in a new gaze version? Files on disk that are no longer in embedded assets are left untouched. Gaze does not delete files it no longer ships.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST compare the version marker in each existing scaffolded file against the version of the currently running gaze binary to determine whether the file is outdated.
+- **FR-002**: When a scaffolded file is outdated (version marker differs from current version), `gaze init` MUST update the file with the current embedded content and new version marker, without requiring `--force`.
+- **FR-003**: When a scaffolded file is current (version marker matches current version), `gaze init` MUST leave the file untouched.
+- **FR-004**: The `--force` flag MUST continue to unconditionally overwrite all scaffolded files, regardless of version comparison.
+- **FR-005**: The operation result MUST distinguish between four file states: created (new file), updated (existed but outdated), up to date (existed and current), and overwritten (existed and force was used).
+- **FR-006**: Files without a recognizable version marker MUST be treated as outdated and updated.
+- **FR-007**: When a file is updated, the output MUST include the previous version and the new version for that file (e.g., "v1.0.0 -> v2.0.0").
+- **FR-008**: When the running gaze binary has version "dev", `gaze init` MUST always update all existing scaffolded files, regardless of the on-disk version marker.
+
+### Key Entities
+
+- **Version Marker**: The comment line prepended to every scaffolded file that records which version of gaze produced it. Serves as the provenance record and staleness indicator.
+- **Scaffolded File**: A file written by `gaze init` into the `.opencode/` directory tree. Each has a version marker and content derived from embedded assets.
+- **Scaffold Result**: The outcome of a `gaze init` run, categorizing each file by its disposition (created, updated, up to date, overwritten).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Running `gaze init` after a version upgrade updates all outdated files without requiring `--force`, with zero additional user intervention beyond running the command.
+- **SC-002**: Running `gaze init` when all files are current produces no file modifications and reports "already up to date."
+- **SC-003**: The output of every `gaze init` run categorizes each file into one of the defined states (created, updated, up to date, overwritten), with no ambiguous or unlabeled files.
+- **SC-004**: Existing `--force` behavior is fully preserved — all files are overwritten unconditionally when the flag is set.
+- **SC-005**: Files with missing or unparseable version markers are updated rather than silently skipped.
+- **SC-006**: 100% of existing scaffold tests continue to pass after the change, confirming backward compatibility.
+
+## Assumptions
+
+- Version comparison is based on string equality of the version marker, not semantic version ordering. A file is "current" if and only if its marker version exactly matches the running binary's version. This avoids the complexity of semver parsing and handles non-semver version strings gracefully.
+- The version marker format is stable and will not change between versions. If the format were to change in the future, a separate migration path would be needed.
+- Users do not intentionally edit scaffolded files for customization purposes. If they do, `--force` is the appropriate mechanism to reset them. The update strategy does not attempt to merge or preserve local modifications.
+- Content comparison (byte-level diff between embedded asset and on-disk file) is not used for staleness detection. Version marker comparison is sufficient and avoids the overhead of reading and comparing full file contents.

--- a/specs/012-init-update-strategy/tasks.md
+++ b/specs/012-init-update-strategy/tasks.md
@@ -1,0 +1,152 @@
+# Tasks: Init Update Strategy
+
+**Input**: Design documents from `/specs/012-init-update-strategy/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Tests**: Test tasks are included because the existing test suite must be migrated (compile-breaking struct change) and new behavior requires test coverage per the project's testing conventions.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Foundational (Blocking Prerequisites)
+
+**Purpose**: Restructure the `Result` type and add the `extractVersion()` function. These changes are required by all three user stories and must be completed first. Existing tests will break at compile time after the `Result` struct change — test migration is part of this phase.
+
+- [x] T001 Add `extractVersion()` function to `internal/scaffold/scaffold.go` that reads the first line of a file, strips the `<!-- scaffolded by gaze ` prefix and ` -->` suffix, and returns the version string. Return empty string for missing/unparseable markers per data-model.md extractVersion() behavior table.
+- [x] T002 Add unit tests for `extractVersion()` in `internal/scaffold/scaffold_test.go` covering: valid marker (`"v1.0.0"`), dev marker (`"dev"`), empty prefix/suffix (`""`), non-marker first line (`""`), and empty file (`""`). Use table-driven test style.
+- [x] T003 Modify the `Result` struct in `internal/scaffold/scaffold.go`: remove `Skipped []string` field, add `Updated []string`, `UpToDate []string`, and `UpdatedFrom map[string]string` fields with GoDoc comments and JSON tags per data-model.md new schema.
+- [x] T004 Migrate existing tests in `internal/scaffold/scaffold_test.go` to compile against the new `Result` struct: rename `TestRun_SkipsExisting` to `TestRun_UpToDate` and change all `result.Skipped` references to `result.UpToDate`; update assertion counts and output string checks from `"skipped:"` to `"up to date:"`. Verify tests compile and pass with the new field names (behavior still uses old skip logic at this point — will be updated in US1).
+
+**Checkpoint**: Code compiles, `extractVersion()` is tested, existing tests pass against renamed fields. The `Run()` function still uses the old skip-on-exists logic — US1 will replace it with version-aware logic.
+
+---
+
+## Phase 2: User Story 1 — Seamless Upgrade After Gaze Update (Priority: P1) MVP
+
+**Goal**: `gaze init` automatically detects outdated scaffolded files via version marker comparison and replaces them with current embedded content, without requiring `--force`.
+
+**Independent Test**: Scaffold files with version "v1.0.0", run `gaze init` with version "v2.0.0", verify all 4 files are updated and appear in `result.Updated`. Run again with same version, verify all 4 files appear in `result.UpToDate`.
+
+### Implementation for User Story 1
+
+- [x] T005 [US1] Modify the `Run()` function's file-exists branch in `internal/scaffold/scaffold.go` to implement version-aware update logic per data-model.md state transition rules: when `!opts.Force` and file exists, call `extractVersion()` on the existing file; if version matches `opts.Version`, classify as `UpToDate`; if version differs (or is empty), read embedded content, write file with new marker, classify as `Updated`, and record old version in `UpdatedFrom` map. Initialize `UpdatedFrom` map at the top of `Run()` if nil.
+- [x] T006 [US1] Implement dev version behavior in the `Run()` function in `internal/scaffold/scaffold.go`: when `opts.Version == "dev"` and file exists and `!opts.Force`, always treat the file as outdated regardless of on-disk marker version (per FR-008 and research R3). Classify as `Updated` with old version recorded in `UpdatedFrom`.
+- [x] T007 [US1] Add `TestRun_UpdatesOutdated` in `internal/scaffold/scaffold_test.go`: scaffold with version "v1.0.0", run again with version "v2.0.0" without force; assert `len(result.Updated) == 4`, `len(result.UpToDate) == 0`, `len(result.Created) == 0`, `len(result.Overwritten) == 0`; verify each file's first line contains the v2.0.0 marker; verify `result.UpdatedFrom` maps each file to "v1.0.0".
+- [x] T008 [US1] Update `TestRun_UpToDate` (renamed in T004) in `internal/scaffold/scaffold_test.go` to use the same version for both runs; assert `len(result.UpToDate) == 4`, `len(result.Updated) == 0`; verify no file content was modified (compare file contents before and after second run).
+- [x] T009 [US1] Add `TestRun_DevAlwaysUpdates` in `internal/scaffold/scaffold_test.go`: scaffold with version "v1.0.0", run again with version "dev" (empty string); assert `len(result.Updated) == 4`, `len(result.UpToDate) == 0`; verify marker changes to "dev". Then run again with version "dev"; assert `len(result.Updated) == 4` (dev always updates, even dev-to-dev).
+- [x] T010 [US1] Add `TestRun_MissingMarkerTreatedAsOutdated` in `internal/scaffold/scaffold_test.go`: scaffold with version "v1.0.0", then overwrite one file with content that has no version marker (plain text); run `gaze init` with version "v2.0.0"; assert that file appears in `result.Updated` with `UpdatedFrom` value of `""` (empty, indicating unknown old version); assert file now has v2.0.0 marker.
+
+**Checkpoint**: `gaze init` correctly updates outdated files, leaves current files untouched, always updates for dev builds, and handles missing markers. All US1 acceptance scenarios pass. Run `go test -race -count=1 ./internal/scaffold/...` to confirm.
+
+---
+
+## Phase 3: User Story 2 — Clear Reporting of File Dispositions (Priority: P2)
+
+**Goal**: `printSummary()` output clearly distinguishes all four file states, shows version transitions for updated files, and includes a summary count line.
+
+**Independent Test**: Set up a mixed scenario (one file missing, one outdated, two current) and verify the output contains "created:", "updated: ... (vOLD -> vNEW)", "up to date:", and a summary count line.
+
+### Implementation for User Story 2
+
+- [x] T011 [US2] Update `printSummary()` in `internal/scaffold/scaffold.go` to handle the new `Result` fields: print `"  updated:     %s (%s -> %s)"` for each file in `Updated` (using `UpdatedFrom` for old version and the current version for new version); print `"  up to date:  %s"` for each file in `UpToDate`; keep existing `"  created:"` and `"  overwritten:"` formats. Remove the `"skipped:"` output path entirely.
+- [x] T012 [US2] Add a summary count footer to `printSummary()` in `internal/scaffold/scaffold.go`: after listing all files, print a line like `"1 created, 2 updated, 1 up to date."` showing non-zero counts. Omit categories with zero count from the summary. Remove the old `"N files skipped (use --force to overwrite)."` hint.
+- [x] T013 [US2] Update the header logic in `printSummary()` in `internal/scaffold/scaffold.go`: print `"Gaze OpenCode integration initialized:"` when any files were created, updated, or overwritten; print `"Gaze OpenCode integration already up to date:"` only when all files are `UpToDate` and nothing was created/updated/overwritten.
+- [x] T014 [US2] Add `TestPrintSummary_MixedScenario` in `internal/scaffold/scaffold_test.go`: construct a `Result` with 1 created, 1 updated (with `UpdatedFrom` entry), 2 up-to-date, 0 overwritten; call `printSummary()` with a `bytes.Buffer`; assert output contains `"created:"`, `"updated:"` with version transition, `"up to date:"`, the summary count line, and the `"initialized:"` header.
+- [x] T015 [US2] Add `TestPrintSummary_AllUpToDate` in `internal/scaffold/scaffold_test.go`: construct a `Result` with 0 created, 0 updated, 4 up-to-date, 0 overwritten; call `printSummary()`; assert output contains `"already up to date:"` header and does not contain `"created:"`, `"updated:"`, or `"overwritten:"`.
+- [x] T016 [US2] Update all existing output assertions across `internal/scaffold/scaffold_test.go` that check for `"skipped:"` or `"use --force to overwrite"` strings — replace with the appropriate new output strings (`"up to date:"`, `"updated:"`, summary counts). Ensure no test references the removed `"skipped"` wording.
+
+**Checkpoint**: All output scenarios produce correct, categorized output. Run `go test -race -count=1 ./internal/scaffold/...` to confirm. Visually inspect output against quickstart.md examples.
+
+---
+
+## Phase 4: User Story 3 — Force as an Escape Hatch (Priority: P3)
+
+**Goal**: Verify that `--force` behavior is fully preserved after the update logic changes. Force should bypass version comparison entirely and always overwrite.
+
+**Independent Test**: Scaffold files with current version, run `gaze init --force`, verify all files appear in `result.Overwritten` (not `Updated` or `UpToDate`).
+
+### Implementation for User Story 3
+
+- [x] T017 [US3] Verify the `Run()` function's force branch in `internal/scaffold/scaffold.go` is unchanged: when `opts.Force` is true, the file should be overwritten unconditionally without calling `extractVersion()`, and classified as `Overwritten`. No code changes expected — this task confirms the existing force path was not broken by US1/US2 changes.
+- [x] T018 [US3] Update `TestRun_ForceOverwrites` in `internal/scaffold/scaffold_test.go` to verify that force with same version still reports `Overwritten` (not `UpToDate`). Assert `len(result.Overwritten) == 4`, `len(result.Updated) == 0`, `len(result.UpToDate) == 0`. Verify output contains `"overwritten:"`.
+- [x] T019 [US3] Update `TestRunInit_ForceFlag` in `cmd/gaze/main_test.go` to cover the new four-state output: first run creates files (assert `"created:"`), second run without force shows up-to-date (assert `"up to date:"`), third run with force overwrites (assert `"overwritten:"`). Update all output string assertions to match new format.
+
+**Checkpoint**: Force behavior is fully preserved. All existing force tests pass. Run `go test -race -count=1 ./internal/scaffold/... ./cmd/gaze/...` to confirm.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation updates, full test suite validation, and GoDoc comments.
+
+- [x] T020 [P] Update GoDoc comments on `Result` struct fields in `internal/scaffold/scaffold.go` to document the four-state model and the `UpdatedFrom` map semantics.
+- [x] T021 [P] Update GoDoc comment on `Run()` function in `internal/scaffold/scaffold.go` to describe the version-aware update behavior, including dev version handling.
+- [x] T022 [P] Update `README.md` if `gaze init` behavior is documented there — reflect the new auto-update behavior and remove any mention of "skipped" files.
+- [x] T023 Run full test suite: `go test -race -count=1 -short ./...` to confirm no regressions across the entire project.
+- [x] T024 Run linter: `golangci-lint run` to confirm no lint violations.
+- [x] T025 Validate output against `specs/012-init-update-strategy/quickstart.md` examples by manually reviewing test output strings match the documented before/after examples.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 1)**: No dependencies — can start immediately
+- **User Story 1 (Phase 2)**: Depends on Foundational completion (T001–T004)
+- **User Story 2 (Phase 3)**: Depends on User Story 1 completion (T005–T010) — needs the updated `Result` fields populated correctly before output can be formatted
+- **User Story 3 (Phase 4)**: Depends on User Story 1 completion (T005–T010) — verifies force path was not broken by update logic changes
+- **Polish (Phase 5)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Depends on Foundational phase only. Can start as soon as `Result` struct and `extractVersion()` are ready.
+- **User Story 2 (P2)**: Depends on US1. The `printSummary()` function needs the `Updated`/`UpToDate`/`UpdatedFrom` fields to be correctly populated by `Run()` before it can format them.
+- **User Story 3 (P3)**: Depends on US1. Verifies the force code path was not broken. Can run in parallel with US2 since they touch different code paths (force branch vs. output formatting).
+
+### Within Each Phase
+
+- Production code before tests that depend on it (within same phase)
+- Tasks within a phase are sequential unless marked [P]
+
+### Parallel Opportunities
+
+- T001 and T002 can be done together (write function + write its tests) if using TDD approach
+- T020, T021, T022 can all run in parallel (different files/sections)
+- US2 (Phase 3) and US3 (Phase 4) can run in parallel after US1 completes — they modify different code paths (`printSummary` vs. force branch verification)
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Foundational (T001–T004)
+2. Complete Phase 2: User Story 1 (T005–T010)
+3. **STOP and VALIDATE**: Run `go test -race -count=1 ./internal/scaffold/...`
+4. At this point, `gaze init` correctly auto-updates outdated files — core value delivered
+
+### Incremental Delivery
+
+1. Foundational → `Result` struct ready, `extractVersion()` tested
+2. User Story 1 → Auto-update works → Core behavior validated (MVP)
+3. User Story 2 → Output is clear and informative → UX polished
+4. User Story 3 → Force path confirmed intact → Full backward compatibility
+5. Polish → Docs, lint, full suite → Ship-ready
+
+---
+
+## Notes
+
+- All production code changes are confined to a single file: `internal/scaffold/scaffold.go`
+- Test changes span two files: `internal/scaffold/scaffold_test.go` and `cmd/gaze/main_test.go`
+- The `cmd/gaze/main.go` CLI layer (`runInit`, `newInitCmd`) requires NO changes — it is a thin passthrough
+- The `Skipped` field removal in T003 will cause compile errors in tests — T004 must follow immediately
+- Total estimated scope: ~100 lines of production code changes, ~300 lines of test code changes/additions


### PR DESCRIPTION
## Summary

- gaze init now auto-detects outdated scaffolded files by comparing their version marker against the running binary version, replacing them without requiring --force
- Adds extractVersion() function for first-line marker parsing with prefix/suffix stripping
- Replaces the Skipped field in Result with Updated, UpToDate, and UpdatedFrom to distinguish four file dispositions
- Updates printSummary() to show version transitions (e.g., v1.0.0 -> v2.0.0) and summary counts
- Dev builds (version == dev) always update all files regardless of on-disk marker
- Files with missing or unparseable version markers are treated as outdated

## Test Coverage

- 7 new tests added (extractVersion table-driven, nonexistent file, updates outdated, dev always updates, missing marker, printSummary mixed, printSummary all-up-to-date)
- 3 existing tests migrated from Skipped to new field names
- Full test suite passes: go test -race -count=1 -short ./...
- Linter clean: golangci-lint run

## Spec Artifacts

Full speckit pipeline completed: spec -> clarify -> plan -> tasks -> implement

- specs/012-init-update-strategy/spec.md
- specs/012-init-update-strategy/plan.md
- specs/012-init-update-strategy/research.md
- specs/012-init-update-strategy/data-model.md
- specs/012-init-update-strategy/quickstart.md
- specs/012-init-update-strategy/tasks.md (25/25 complete)