### PR TITLE
feat: replace quill signing with native codesign/notarytool on macos runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,20 @@ jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    outputs:
+      has_signing_secrets: ${{ steps.check-secrets.outputs.has_secrets }}
     steps:
+      - name: Check signing secrets
+        id: check-secrets
+        run: |
+          if [ -n "$MACOS_SIGN_P12" ]; then
+            echo "has_secrets=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_secrets=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
@@ -32,8 +45,97 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+  sign-macos:
+    runs-on: macos-latest
+    needs: release
+    if: ${{ needs.release.outputs.has_signing_secrets == 'true' }}
+    timeout-minutes: 30
+    steps:
+      - name: Import certificate into Keychain
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+
+          echo -n "$MACOS_SIGN_P12" | base64 --decode -o $RUNNER_TEMP/cert.p12
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security import $RUNNER_TEMP/cert.p12 -P "$MACOS_SIGN_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+        env:
           MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
           MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+
+      - name: Prepare notary key
+        run: |
+          echo -n "$MACOS_NOTARY_KEY" | base64 --decode -o $RUNNER_TEMP/notary_key.p8
+        env:
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+
+      - name: Download darwin archives
+        run: |
+          gh release download "${GITHUB_REF_NAME}" --pattern "gaze_*_darwin_*.tar.gz" --dir ./artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign and notarize
+        run: |
+          mkdir -p ./signed
+          for archive in ./artifacts/gaze_*_darwin_*.tar.gz; do
+            echo "==> Processing $(basename "$archive")"
+            workdir=$(mktemp -d)
+
+            # Extract binary
+            tar -xzf "$archive" -C "$workdir"
+
+            # Sign with codesign
+            codesign --force --timestamp --options runtime \
+              --sign "Developer ID Application: John Flowers (PGFWLVZX55)" \
+              "$workdir/gaze"
+
+            # Verify signature
+            codesign --verify --verbose=2 "$workdir/gaze"
+
+            # Zip for notarytool (requires .zip, not .tar.gz)
+            ditto -c -k "$workdir/gaze" "$workdir/gaze.zip"
+
+            # Submit for notarization and wait
+            xcrun notarytool submit "$workdir/gaze.zip" \
+              --key "$RUNNER_TEMP/notary_key.p8" \
+              --key-id "$MACOS_NOTARY_KEY_ID" \
+              --issuer "$MACOS_NOTARY_ISSUER_ID" \
+              --wait --timeout 20m
+
+            # Re-archive signed binary with original archive name
+            tar -czf "./signed/$(basename "$archive")" -C "$workdir" gaze
+
+            rm -rf "$workdir"
+            echo "==> Done: $(basename "$archive")"
+          done
+        env:
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+
+      - name: Replace release assets and update checksums
+        run: |
+          # Upload signed darwin archives (replaces unsigned)
+          gh release upload "${GITHUB_REF_NAME}" ./signed/*.tar.gz --clobber
+
+          # Download existing checksums
+          gh release download "${GITHUB_REF_NAME}" --pattern "checksums.txt" --dir ./
+
+          # Remove darwin lines from checksums (keep linux and other lines)
+          grep -v darwin checksums.txt > checksums_updated.txt || true
+
+          # Compute SHA256 for each signed darwin archive
+          for archive in ./signed/*.tar.gz; do
+            shasum -a 256 "$archive" | sed 's|./signed/||' >> checksums_updated.txt
+          done
+
+          # Replace checksums file
+          mv checksums_updated.txt checksums.txt
+          gh release upload "${GITHUB_REF_NAME}" checksums.txt --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,18 +27,6 @@ archives:
 checksum:
   name_template: checksums.txt
 
-notarize:
-  macos:
-    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
-      sign:
-        certificate: "{{.Env.MACOS_SIGN_P12}}"
-        password: "{{.Env.MACOS_SIGN_PASSWORD}}"
-      notarize:
-        issuer_id: "{{.Env.MACOS_NOTARY_ISSUER_ID}}"
-        key_id: "{{.Env.MACOS_NOTARY_KEY_ID}}"
-        key: "{{.Env.MACOS_NOTARY_KEY}}"
-        wait: false
-
 changelog:
   sort: asc
   use: github

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,8 @@ specs/
   009-crapload-reduction/        # spec.md, plan.md, tasks.md, research.md, data-model.md, quickstart.md
   011-output-voice-style/        # spec.md, plan.md, tasks.md, research.md, data-model.md, quickstart.md, checklists/
   012-consolidate-classify-docs/ # spec.md, plan.md, tasks.md, research.md, data-model.md, quickstart.md
+  014-macos-notarization/        # spec.md, plan.md, tasks.md, research.md, data-model.md, quickstart.md
+  015-native-macos-signing/      # spec.md, plan.md, tasks.md, research.md, data-model.md, quickstart.md, checklists/
 ```
 
 Branch names follow the same numbering pattern (e.g., `001-side-effect-detection`).
@@ -236,6 +238,7 @@ Formatters: gofmt, goimports.
 - Go 1.24+ (scaffold Go code); Markdown (agent/command prompts) + `embed.FS` (Go standard library), OpenCode agent runtime (012-consolidate-classify-docs)
 - Filesystem only (embedded assets via `embed.FS`, `.opencode/` directory) (012-consolidate-classify-docs)
 - Go 1.24+ (no Go code changes; YAML/workflow configuration only) + GoReleaser v2 (OSS), quill (embedded in GoReleaser as a Go library) (014-macos-notarization)
+- Go 1.24+ (no Go code changes; YAML/workflow configuration only) + GitHub Actions, `codesign` (macOS native), `xcrun notarytool` (macOS native), `security` (macOS Keychain), `gh` CLI (GitHub) (015-native-macos-signing)
 
 - Go 1.24+ + `golang.org/x/tools` (go/packages, go/ssa), Cobra (CLI), Bubble Tea/Lipgloss (TUI)
 - Filesystem only (embedded assets via `embed.FS`)
@@ -243,6 +246,7 @@ Formatters: gofmt, goimports.
 
 ## Recent Changes
 
+- 015-native-macos-signing: Replaced broken quill-based cross-platform signing with native `codesign`/`notarytool` on `macos-latest` runner. Removed `notarize.macos` from `.goreleaser.yaml`. Added `sign-macos` job to release workflow (Keychain import, codesign with hardened runtime, notarytool submit --wait, asset replacement with --clobber, checksum update). Conditional on `MACOS_SIGN_P12` secret via job output gate.
 - 014-macos-notarization: Added macOS code signing and notarization to GoReleaser release pipeline via built-in `notarize.macos` (quill), conditional on `MACOS_SIGN_P12` secret presence, 20m notarization timeout, 45m job timeout, no runner change (stays ubuntu-latest)
 - 012-consolidate-classify-docs: Removed /classify-docs command and doc-classifier agent, inlined document-signal scoring model into gaze-reporter, added emoji formatting override block and sandwich prompt structure, reduced scaffold from 4 to 2 files
 - 011-output-voice-style: Rewrote gaze-reporter agent prompt for fun, emoji-rich output — emoji section markers (🔍📊🧪🏷️🏥), colored circle severity indicators (🟢🟡🔴⚪), letter grades with emoji, severity-prefixed recommendations, tone anti-pattern bans, canonical example output

--- a/specs/015-native-macos-signing/checklists/requirements.md
+++ b/specs/015-native-macos-signing/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Native macOS Code Signing and Notarization
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The Context section documents why this spec exists (quill bugs from spec 014) to provide continuity. This is background, not implementation detail.
+- SC-007 references `codesign --verify` and `spctl --assess` as verification tools. These are Apple's standard verification commands, analogous to "the user can verify the download" — they describe what to check, not how to build.
+- The same 5 GitHub secrets from spec 014 are reused. No new secrets needed.

--- a/specs/015-native-macos-signing/data-model.md
+++ b/specs/015-native-macos-signing/data-model.md
@@ -1,0 +1,111 @@
+# Data Model: Native macOS Code Signing and Notarization
+
+**Feature**: 015-native-macos-signing
+**Date**: 2026-03-02
+
+## Overview
+
+This feature has no application-level data model. The "data model" consists of CI workflow jobs, their dependencies, and the secrets they consume. This document defines the workflow architecture and entity relationships.
+
+## Workflow Architecture
+
+### Job Dependency Graph
+
+```text
+[tag push v*]
+    │
+    ▼
+[release] (ubuntu-latest)
+    │  GoReleaser: build, archive, checksum, publish release, update Homebrew cask
+    │  Outputs: tag name, release URL
+    │
+    ▼
+[sign-macos] (macos-latest, needs: release, conditional on secrets)
+    │  1. Import .p12 cert into temp Keychain
+    │  2. Decode .p8 notary key to temp file
+    │  3. Download darwin archives from release
+    │  4. For each darwin archive:
+    │     ├── Extract binary from tar.gz
+    │     ├── codesign --force --timestamp --options runtime --sign "..."
+    │     ├── Verify: codesign --verify
+    │     ├── Zip binary (ditto -c -k) for notarytool
+    │     ├── notarytool submit --wait --timeout 20m
+    │     └── Re-tar.gz signed binary
+    │  5. Replace darwin archives on release (gh release upload --clobber)
+    │  6. Update checksums.txt (remove darwin lines, add new, re-upload)
+    │
+    ▼
+[Release complete with signed darwin binaries]
+```
+
+### When Secrets Are Absent
+
+```text
+[tag push v*]
+    │
+    ▼
+[release] (ubuntu-latest)
+    │  GoReleaser: build, archive, checksum, publish release, update Homebrew cask
+    │
+    ▼
+[sign-macos] — SKIPPED (condition not met)
+    │
+    ▼
+[Release complete with unsigned darwin binaries]
+```
+
+## CI/CD Secrets
+
+**Location**: GitHub repository settings > Secrets and variables > Actions
+
+| Secret Name | Used By | Content Type | Encoding |
+|-------------|---------|-------------|----------|
+| `MACOS_SIGN_P12` | sign-macos (Keychain import) | Binary (.p12 file) | Base64 |
+| `MACOS_SIGN_PASSWORD` | sign-macos (Keychain import) | Plain text | None |
+| `MACOS_NOTARY_KEY` | sign-macos (notarytool) | Binary (.p8 file) | Base64 |
+| `MACOS_NOTARY_KEY_ID` | sign-macos (notarytool) | Plain text | None |
+| `MACOS_NOTARY_ISSUER_ID` | sign-macos (notarytool) | UUID | None |
+| `GITHUB_TOKEN` | release + sign-macos | Auto-generated | N/A |
+| `HOMEBREW_TAP_GITHUB_TOKEN` | release (GoReleaser) | PAT | N/A |
+
+**Changes from spec 014**: The 5 `MACOS_*` secrets are no longer passed to the GoReleaser step. They are only used by the `sign-macos` job. `GITHUB_TOKEN` is used by both jobs (build publishes release, sign-macos downloads/uploads assets).
+
+## Temporary Artifacts
+
+Created and destroyed within the `sign-macos` job:
+
+| Artifact | Path | Lifecycle |
+|----------|------|-----------|
+| Decoded .p12 certificate | `$RUNNER_TEMP/cert.p12` | Created at step 1, destroyed with VM |
+| Temporary Keychain | `$RUNNER_TEMP/app-signing.keychain-db` | Created at step 1, destroyed with VM |
+| Decoded .p8 notary key | `$RUNNER_TEMP/notary_key.p8` | Created at step 2, destroyed with VM |
+| Downloaded archives | `./artifacts/*.tar.gz` | Created at step 3, consumed at step 4 |
+| Signed archives | `./signed/*.tar.gz` | Created at step 4, uploaded at step 5 |
+| Zip for notarytool | `$workdir/gaze.zip` | Created and consumed within step 4 loop |
+
+## Release Asset Lifecycle
+
+### Darwin Archives
+
+```text
+[Build Job creates] → gaze_X.Y.Z_darwin_amd64.tar.gz (unsigned)
+                    → gaze_X.Y.Z_darwin_arm64.tar.gz (unsigned)
+
+[Sign Job replaces] → gaze_X.Y.Z_darwin_amd64.tar.gz (signed + notarized)
+                    → gaze_X.Y.Z_darwin_arm64.tar.gz (signed + notarized)
+```
+
+### Checksums
+
+```text
+[Build Job creates] → checksums.txt (SHA256 for all archives, unsigned darwin)
+
+[Sign Job updates]  → checksums.txt (linux checksums preserved, darwin checksums updated)
+```
+
+### Linux Archives (unchanged)
+
+```text
+[Build Job creates] → gaze_X.Y.Z_linux_amd64.tar.gz
+                    → gaze_X.Y.Z_linux_arm64.tar.gz
+```

--- a/specs/015-native-macos-signing/plan.md
+++ b/specs/015-native-macos-signing/plan.md
@@ -1,0 +1,72 @@
+# Implementation Plan: Native macOS Code Signing and Notarization
+
+**Branch**: `015-native-macos-signing` | **Date**: 2026-03-02 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/015-native-macos-signing/spec.md`
+
+## Summary
+
+Replace the broken quill-based cross-platform signing (spec 014) with Apple's native `codesign` and `notarytool` running on a `macos-latest` CI runner. The build stays on `ubuntu-latest`. A new `sign-macos` job downloads unsigned darwin archives from the release, imports the .p12 certificate into a temporary Keychain, signs each binary with `codesign`, submits for notarization via `notarytool --wait`, re-archives, and replaces the release assets. Checksums are updated to reflect the signed archives. The existing quill-based `notarize.macos` section is removed from `.goreleaser.yaml`.
+
+## Technical Context
+
+**Language/Version**: Go 1.24+ (no Go code changes; YAML/workflow configuration only)
+**Primary Dependencies**: GitHub Actions, `codesign` (macOS native), `xcrun notarytool` (macOS native), `security` (macOS Keychain), `gh` CLI (GitHub)
+**Storage**: N/A
+**Testing**: Manual verification via test release + `codesign --verify` + `spctl --assess` on macOS
+**Target Platform**: GitHub Actions `ubuntu-latest` (build) + `macos-latest` (sign)
+**Project Type**: Single CLI binary — release pipeline configuration change
+**Performance Goals**: Signing + notarization complete within 30 minutes
+**Constraints**: Public repo (free macOS minutes); same 5 secrets from spec 014; brief unsigned window acceptable
+**Scale/Scope**: 2 files modified (`.goreleaser.yaml`, `.github/workflows/release.yml`); no new files outside specs/
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Research Check
+
+| Principle | Status | Assessment |
+|-----------|--------|------------|
+| **I. Accuracy** | PASS | This feature does not alter Gaze's analysis engine, side effect detection, or reporting. It only modifies the release distribution pipeline. No risk of introducing false positives or false negatives. |
+| **II. Minimal Assumptions** | PASS | No changes to how Gaze analyzes host projects. No new user-facing annotations or restructuring required. The signing is transparent to end users. The only assumption is that the maintainer has Apple Developer credentials (already documented and configured from spec 014). |
+| **III. Actionable Output** | PASS | No changes to Gaze's output, reports, or metrics. The feature exclusively affects binary distribution trust. |
+
+**Gate result**: PASS — All three principles satisfied. This feature operates entirely outside the analysis domain.
+
+### Post-Design Check
+
+| Principle | Status | Assessment |
+|-----------|--------|------------|
+| **I. Accuracy** | PASS | Design confirms: zero changes to analysis engine. Only workflow YAML modified. No new Go code. |
+| **II. Minimal Assumptions** | PASS | Design confirms: no new user-facing requirements. Same 5 secrets from spec 014 reused. Users continue using `brew install --cask gaze` unchanged. Signing job conditional on secret presence — skips cleanly when absent. |
+| **III. Actionable Output** | PASS | Design confirms: no changes to output formats, reports, or metrics. Feature is invisible to users — they simply stop seeing Gatekeeper warnings. |
+
+**Post-design gate result**: PASS — No constitution concerns.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/015-native-macos-signing/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0: Native signing research
+├── data-model.md        # Phase 1: Workflow entities and secrets model
+├── quickstart.md        # Phase 1: Verification guide
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+.goreleaser.yaml                     # Remove notarize.macos section
+.github/workflows/release.yml       # Remove MACOS_* env vars from GoReleaser step;
+                                     # add sign-macos job with codesign + notarytool
+```
+
+**Structure Decision**: No new source files or directories. This feature modifies two existing configuration files. The GoReleaser config gets simpler (removal). The workflow file gains a new job. No Go code changes.
+
+## Complexity Tracking
+
+> No Constitution Check violations. No complexity justification needed.

--- a/specs/015-native-macos-signing/quickstart.md
+++ b/specs/015-native-macos-signing/quickstart.md
@@ -1,0 +1,143 @@
+# Quickstart: Native macOS Code Signing and Notarization
+
+**Feature**: 015-native-macos-signing
+**Date**: 2026-03-02
+
+## Prerequisites
+
+The 5 GitHub secrets from spec 014 must already be configured:
+
+| Secret Name | Already configured? |
+|-------------|-------------------|
+| `MACOS_SIGN_P12` | Yes (from spec 014) |
+| `MACOS_SIGN_PASSWORD` | Yes (from spec 014) |
+| `MACOS_NOTARY_KEY` | Yes (from spec 014) |
+| `MACOS_NOTARY_KEY_ID` | Yes (from spec 014) |
+| `MACOS_NOTARY_ISSUER_ID` | Yes (from spec 014) |
+
+No new secrets are needed. If you haven't configured these yet, see `specs/014-macos-notarization/quickstart.md` for setup instructions.
+
+## Implementation Steps
+
+### Step 1: Remove quill config from `.goreleaser.yaml`
+
+Delete the entire `notarize.macos` section (lines 30-41 in the current file):
+
+```yaml
+# DELETE THIS ENTIRE BLOCK:
+notarize:
+  macos:
+    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+      sign:
+        certificate: "{{.Env.MACOS_SIGN_P12}}"
+        password: "{{.Env.MACOS_SIGN_PASSWORD}}"
+      notarize:
+        issuer_id: "{{.Env.MACOS_NOTARY_ISSUER_ID}}"
+        key_id: "{{.Env.MACOS_NOTARY_KEY_ID}}"
+        key: "{{.Env.MACOS_NOTARY_KEY}}"
+        wait: false
+```
+
+### Step 2: Update `.github/workflows/release.yml`
+
+1. Remove the 5 `MACOS_*` env vars from the GoReleaser step (GoReleaser no longer needs them)
+2. Add a `sign-macos` job after the `release` job
+
+The `sign-macos` job structure:
+
+```yaml
+sign-macos:
+  runs-on: macos-latest
+  needs: release
+  if: ${{ needs.release.outputs.has_signing_secrets == 'true' }}
+  timeout-minutes: 30
+  steps:
+    - name: Import certificate into Keychain
+      # Decode .p12, create temp keychain, import cert, set partition list
+
+    - name: Prepare notary key
+      # Decode .p8 to temp file
+
+    - name: Download darwin archives
+      # gh release download $TAG --pattern "gaze_*_darwin_*.tar.gz"
+
+    - name: Sign and notarize
+      # For each archive: extract, codesign, verify, zip, notarytool submit --wait, re-tar.gz
+
+    - name: Replace release assets and update checksums
+      # gh release upload --clobber for signed archives + updated checksums.txt
+```
+
+The `release` job needs an output to signal whether signing secrets are available:
+
+```yaml
+release:
+  outputs:
+    has_signing_secrets: ${{ steps.check-secrets.outputs.has_secrets }}
+  steps:
+    - name: Check signing secrets
+      id: check-secrets
+      run: |
+        if [ -n "${{ secrets.MACOS_SIGN_P12 }}" ]; then
+          echo "has_secrets=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_secrets=false" >> "$GITHUB_OUTPUT"
+        fi
+```
+
+## Verification
+
+### After Implementation (dry run)
+
+```bash
+# Validate GoReleaser config (quill section removed)
+goreleaser check
+
+# Verify snapshot build works without quill
+goreleaser release --snapshot --clean
+```
+
+### First Signed Release
+
+1. Push a test tag: `git tag v0.X.Y-rc.1 && git push origin v0.X.Y-rc.1`
+2. Monitor GitHub Actions:
+   - `release` job should complete on `ubuntu-latest`
+   - `sign-macos` job should start on `macos-latest`
+   - Watch for: "signing", "notarizing", "upload" steps
+3. After `sign-macos` completes, download the darwin binary:
+
+```bash
+gh release download v0.X.Y-rc.1 --pattern "gaze_*_darwin_arm64*" --dir ./test
+tar -xzf ./test/gaze_*_darwin_arm64*.tar.gz -C ./test
+```
+
+4. Verify on macOS:
+
+```bash
+# Check code signature (should show TeamIdentifier)
+codesign -dv --verbose=4 ./test/gaze
+
+# Check Gatekeeper assessment (should say "accepted")
+spctl --assess --type execute --verbose=2 ./test/gaze
+```
+
+5. Verify checksums:
+
+```bash
+gh release download v0.X.Y-rc.1 --pattern "checksums.txt" --dir ./test
+cd ./test && shasum -a 256 -c checksums.txt
+```
+
+### Homebrew Verification
+
+```bash
+brew install --cask gaze
+gaze --version  # Should run without Gatekeeper warning
+```
+
+### Verify Graceful Degradation
+
+On a fork without secrets configured, tag a release and verify:
+- `release` job succeeds
+- `sign-macos` job is skipped (not failed)
+- Release contains unsigned but functional binaries

--- a/specs/015-native-macos-signing/research.md
+++ b/specs/015-native-macos-signing/research.md
@@ -1,0 +1,129 @@
+# Research: Native macOS Code Signing and Notarization
+
+**Feature**: 015-native-macos-signing
+**Date**: 2026-03-02
+
+## Decision 1: Signing Approach
+
+**Decision**: Use Apple's native `codesign` tool on a `macos-latest` GitHub Actions runner.
+
+**Rationale**: The cross-platform approach (quill via GoReleaser) has two unfixed bugs that prevent notarization from working:
+
+1. quill issue #147: `TeamIdentifier` is never set in the code signature. `newCodeDirectory()` in quill's source has a `TeamOffset` field but never populates it. Apple's notary service cannot associate the binary with the developer account, causing submissions to stall at "In Progress" indefinitely.
+2. quill's notarization polling is aggressive enough to exhaust Apple's App Store Connect API hourly rate limit (429 Too Many Requests).
+
+`codesign` is Apple's native signing tool. It correctly sets TeamIdentifier from the certificate, supports hardened runtime (`--options runtime`, required for notarization since macOS 10.15), and embeds trusted timestamps (`--timestamp`).
+
+**Alternatives considered**:
+
+| Alternative | Status | Reason rejected |
+|-------------|--------|-----------------|
+| quill via GoReleaser (spec 014) | Broken | TeamIdentifier not set (bug #147, open 2.5 years). Notarization polling causes rate limiting. |
+| Fork quill and fix | Viable but slow | Fix is small (populate `TeamOffset`), but requires forking, building a custom GoReleaser, maintaining it. Not worth the effort when native tools are available. |
+| GoReleaser `notarize.macos_native` | Pro-only | Requires GoReleaser Pro license ($). |
+
+## Decision 2: Workflow Architecture
+
+**Decision**: Split-runner workflow — build on `ubuntu-latest`, sign on `macos-latest`.
+
+**Rationale**: `codesign` and `xcrun notarytool` are macOS-only tools. The build must happen on a separate runner. The split approach keeps the fast, cheap build on Ubuntu and only uses the macOS runner for the short signing step.
+
+The architecture:
+1. **Job 1 (`release`)**: GoReleaser builds all targets, creates archives, checksums, publishes GitHub Release, updates Homebrew cask. Runs on `ubuntu-latest`. Unchanged from today except removal of quill config.
+2. **Job 2 (`sign-macos`)**: Runs on `macos-latest` after Job 1 completes (`needs: release`). Downloads darwin archives from the release, signs, notarizes, re-archives, replaces release assets, updates checksums.
+
+**Cost**: The repository is public, so all GitHub Actions runners (including macOS) are free. No cost concern.
+
+**Alternatives considered**:
+
+| Alternative | Status | Reason rejected |
+|-------------|--------|-----------------|
+| Full macOS runner for everything | Viable but wasteful | The entire build+release would run on macOS (~10x more expensive for private repos). No benefit since Go cross-compilation works fine on Linux. |
+| Draft release + publish after signing | More complex | Homebrew cask `skip_upload: auto` skips drafts. Would need manual cask update after undrafting. More workflow complexity for marginal benefit (avoiding brief unsigned window). |
+
+## Decision 3: Certificate Import
+
+**Decision**: Create a temporary Keychain on the macOS runner and import the .p12 certificate into it.
+
+**Rationale**: `codesign` reads certificates from Keychain, not from files. The standard CI pattern (documented by GitHub and Apple) is:
+
+1. Create a temporary keychain with a random password
+2. Decode the base64 .p12 secret to a file
+3. Import the .p12 into the temporary keychain
+4. Set the keychain partition list to allow `codesign` access without UI prompts
+5. Add the keychain to the search list
+
+The temporary keychain is destroyed when the runner VM terminates (GitHub-hosted runners are ephemeral).
+
+**Key commands**:
+```bash
+KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+
+echo -n "$MACOS_SIGN_P12" | base64 --decode -o $RUNNER_TEMP/cert.p12
+security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+security import $RUNNER_TEMP/cert.p12 -P "$MACOS_SIGN_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+security list-keychain -d user -s $KEYCHAIN_PATH
+```
+
+## Decision 4: Codesign Flags
+
+**Decision**: Use `codesign --force --timestamp --options runtime --sign "Developer ID Application: John Flowers (PGFWLVZX55)"`.
+
+**Rationale**:
+- `--force`: Re-signs even if the binary has an ad-hoc signature (Go binaries may have one)
+- `--timestamp`: Embeds a trusted timestamp from Apple's TSA server (required for notarization)
+- `--options runtime`: Enables Hardened Runtime (required for notarization since macOS 10.15)
+- `--sign "IDENTITY"`: The full common name from the Developer ID Application certificate
+
+No entitlements file needed — gaze is a CLI tool with no special macOS capability requirements.
+
+## Decision 5: Notarization Submission
+
+**Decision**: Use `xcrun notarytool submit --wait --timeout 20m` with App Store Connect API key authentication.
+
+**Rationale**: `notarytool` is Apple's official notarization tool (replaced the deprecated `altool`). It supports `--wait` to block until Apple returns a result, with configurable `--timeout`. API key authentication (`.p8` file + key ID + issuer ID) is the recommended method for CI.
+
+`notarytool` requires `.zip`, `.dmg`, or `.pkg` format — not `.tar.gz`. The binary must be zipped before submission using `ditto -c -k`.
+
+**Key commands**:
+```bash
+echo -n "$MACOS_NOTARY_KEY" | base64 --decode -o $RUNNER_TEMP/notary_key.p8
+
+ditto -c -k ./gaze ./gaze.zip
+xcrun notarytool submit ./gaze.zip \
+  --key $RUNNER_TEMP/notary_key.p8 \
+  --key-id "$MACOS_NOTARY_KEY_ID" \
+  --issuer "$MACOS_NOTARY_ISSUER_ID" \
+  --wait --timeout 20m
+```
+
+## Decision 6: Release Asset Replacement
+
+**Decision**: Use `gh release upload --clobber` to replace unsigned archives with signed ones, then update checksums.
+
+**Rationale**: The `--clobber` flag replaces an existing asset with the same filename. This is simpler than delete-then-upload and is atomic from the GitHub API perspective.
+
+Checksums must be regenerated because the archive contents changed (signed binary replaces unsigned). The approach:
+1. Download existing `checksums.txt`
+2. Remove darwin lines (keep linux lines intact)
+3. Compute SHA256 for the new signed darwin archives
+4. Append the new darwin checksums
+5. Re-upload `checksums.txt` with `--clobber`
+
+## Decision 7: Graceful Degradation
+
+**Decision**: Use GitHub Actions `if` condition on the signing job to skip when secrets are absent.
+
+**Rationale**: GitHub Actions supports `if: ${{ secrets.MACOS_SIGN_P12 != '' }}` (or similar patterns) to conditionally run jobs. When secrets are not configured (forks, contributors), the signing job is skipped entirely. The build job still publishes the release with unsigned binaries.
+
+Note: GitHub Actions does not directly expose secrets in `if` conditions for security reasons. The standard pattern is to set a job output in the build job that checks for secret presence, then reference that output in the signing job's `if` condition.
+
+## Decision 8: Stapling
+
+**Decision**: Do not staple. Not needed and not possible for bare Mach-O binaries.
+
+**Rationale**: `xcrun stapler staple` only works on `.app` bundles, `.dmg`, `.pkg`, and `.kext`. Bare binaries cannot be stapled. macOS Gatekeeper verifies notarization online — it contacts Apple's servers to check the notarization ticket at runtime. This is sufficient for CLI tools distributed via Homebrew or direct download.

--- a/specs/015-native-macos-signing/spec.md
+++ b/specs/015-native-macos-signing/spec.md
@@ -1,0 +1,119 @@
+# Feature Specification: Native macOS Code Signing and Notarization
+
+**Feature Branch**: `015-native-macos-signing`  
+**Created**: 2026-03-02  
+**Status**: Draft  
+**Input**: User description: "Replace quill-based cross-platform signing with native macOS codesign and notarytool in a split-runner CI workflow to fix TeamIdentifier bug and notarization stalling"
+
+## Context
+
+Spec 014 added macOS code signing and notarization to the release pipeline using GoReleaser v2's built-in cross-platform notarization (quill). In production, two critical bugs surfaced:
+
+1. **quill does not set TeamIdentifier** in the code signature (quill issue #147, open since Sep 2023, unfixed). Apple's notary service cannot associate the binary with the developer account, causing all notarization submissions to stall at "In Progress" indefinitely.
+2. **quill's notarization polling exhausts Apple's API rate limit** (429 Too Many Requests), failing the release before even reaching the second binary.
+
+The result: binaries are signed but never notarized, and macOS Gatekeeper blocks execution with "unidentified developer" warnings.
+
+This spec replaces the broken quill approach with Apple's native signing tools (`codesign` and `notarytool`) running on a macOS CI runner in a split-runner workflow.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Trusted Homebrew Installation (Priority: P1)
+
+A macOS user installs gaze via `brew install --cask gaze` and runs it without macOS Gatekeeper blocking execution. The binary is properly code-signed with a Developer ID Application certificate (including TeamIdentifier) and notarized by Apple, so macOS trusts it on first run.
+
+**Why this priority**: This is the core user-facing outcome. Without working code signing and notarization, macOS users must manually override Gatekeeper security, which erodes trust and blocks adoption. Spec 014 attempted to deliver this but failed due to quill bugs.
+
+**Independent Test**: Tag a release, verify the release pipeline signs and notarizes darwin binaries, download the binary, verify with `codesign --verify` and `spctl --assess` on macOS, then install via Homebrew and confirm no Gatekeeper warning.
+
+**Acceptance Scenarios**:
+
+1. **Given** a tagged release triggers the release pipeline, **When** the signing job runs on both darwin/amd64 and darwin/arm64 binaries, **Then** both binaries have a valid code signature with the correct TeamIdentifier set.
+2. **Given** signed darwin binaries are submitted for notarization, **When** Apple's notary service processes them, **Then** notarization completes with status "Accepted" (not stalled at "In Progress").
+3. **Given** notarized binaries are published to the GitHub Release, **When** a user installs via `brew install --cask gaze` and runs `gaze`, **Then** macOS does not display a Gatekeeper warning or block execution.
+4. **Given** the signing job replaces unsigned darwin archives on the release, **When** a user downloads the tar.gz manually from GitHub Releases, **Then** the extracted binary passes `spctl --assess --type execute`.
+
+---
+
+### User Story 2 - Graceful Degradation Without Signing Credentials (Priority: P2)
+
+When Apple signing secrets are not configured (e.g., fork PRs, contributors without access), the release pipeline completes successfully. The build job publishes unsigned binaries. The signing job either skips entirely or fails without affecting the published release.
+
+**Why this priority**: The release pipeline must remain functional for all contributors. Signing is an enhancement, not a gate.
+
+**Independent Test**: Run the release workflow without Apple signing secrets configured and verify the build job succeeds and publishes a release with working (unsigned) binaries.
+
+**Acceptance Scenarios**:
+
+1. **Given** the release pipeline runs without Apple signing secrets, **When** the build job executes, **Then** it completes successfully and publishes a release with unsigned darwin and linux binaries.
+2. **Given** Apple signing secrets are absent, **When** the signing job evaluates its conditions, **Then** the signing job is skipped without error and does not affect the published release.
+
+---
+
+### User Story 3 - Checksum Integrity After Signing (Priority: P3)
+
+After the signing job replaces unsigned darwin archives with signed ones, the published checksums file accurately reflects the signed archives. Users and automated tools that verify downloads against checksums get correct results.
+
+**Why this priority**: The build job publishes checksums for unsigned archives. When the signing job replaces those archives, the checksums become stale. Stale checksums break `brew audit`, security-conscious users who verify downloads, and any automation that checks integrity.
+
+**Independent Test**: After a release with signing, download the checksums file and all archives, compute SHA256 for each archive, and verify every checksum matches.
+
+**Acceptance Scenarios**:
+
+1. **Given** the signing job has replaced darwin archives with signed versions, **When** it updates the checksums file, **Then** the SHA256 values for darwin archives match the actual signed archives.
+2. **Given** the signing job updates checksums, **When** it re-uploads the checksums file, **Then** the linux archive checksums remain unchanged from what the build job originally published.
+
+---
+
+### Edge Cases
+
+- What happens if notarization for one architecture (amd64) succeeds but fails for the other (arm64)?
+- What happens if the signing job fails after replacing some but not all darwin archives on the release?
+- How does the pipeline handle a corrupted or expired .p12 certificate?
+- What happens if the GitHub Release assets are being downloaded by a user at the exact moment the signing job is replacing them?
+- What happens if Apple's notary service is down or returns errors for an extended period?
+- How does the pipeline behave if the temporary Keychain creation fails on the macOS runner?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The release pipeline MUST use a separate CI job on a macOS runner to sign darwin binaries with Apple's native signing tools, producing a code signature that includes the correct TeamIdentifier.
+- **FR-002**: The signing job MUST submit signed binaries to Apple's notary service and wait for notarization to complete with status "Accepted" before publishing signed archives.
+- **FR-003**: The signing job MUST replace unsigned darwin archives on the GitHub Release with signed and notarized versions, preserving the original archive names and format.
+- **FR-004**: The signing job MUST update the checksums file to reflect the signed darwin archives while preserving checksums for non-darwin (linux) archives.
+- **FR-005**: The build job MUST continue to run on the existing CI runner environment (not macOS) for building, archiving, and publishing the initial release.
+- **FR-006**: The signing job MUST be skipped without error when Apple signing secrets are not configured in the environment.
+- **FR-007**: The release pipeline MUST use project secrets (stored as CI/CD secrets) for all Apple credentials; no credentials MUST be hardcoded or committed to the repository.
+- **FR-008**: The existing Homebrew cask distribution MUST continue to work after this change.
+- **FR-009**: The broken cross-platform signing configuration (quill-based) MUST be removed from the release pipeline to avoid confusion and unnecessary processing.
+- **FR-010**: The signing job MUST set a timeout to prevent indefinite blocking if Apple's notary service is slow or unresponsive.
+
+### Key Entities
+
+- **Build Job**: The existing CI job that compiles binaries, creates archives, generates checksums, publishes the GitHub Release, and updates the Homebrew cask. Runs on the standard CI runner.
+- **Signing Job**: A new CI job that runs on a macOS runner after the build job. Downloads unsigned darwin archives, signs binaries, submits for notarization, and replaces release assets with signed versions.
+- **Temporary Keychain**: A short-lived credential store created on the macOS runner to hold the imported signing certificate. Destroyed when the runner VM terminates.
+- **Signing Certificate**: A Developer ID Application certificate (.p12 format) imported into the temporary Keychain for use by the native signing tool.
+- **Notarization Credentials**: An App Store Connect API key (.p8 format) with associated Key ID and Issuer ID, used to authenticate with Apple's notary service.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: macOS users can install gaze via Homebrew and run it immediately without any Gatekeeper warnings or security overrides.
+- **SC-002**: The signing and notarization job completes within 30 minutes of the build job finishing.
+- **SC-003**: The release pipeline succeeds without errors when Apple signing secrets are not configured, producing functional unsigned binaries.
+- **SC-004**: 100% of darwin binaries (both architectures) in every release are signed with the correct TeamIdentifier and notarized when Apple credentials are available.
+- **SC-005**: No changes to the existing Linux binary build or distribution process.
+- **SC-006**: Published checksums match all release archives (both signed darwin and unsigned linux) after the signing job completes.
+- **SC-007**: `codesign --verify` and `spctl --assess` both report the signed binary as valid and accepted on macOS.
+
+## Assumptions
+
+- The project maintainer has an active Apple Developer Program membership and has already configured the 5 required GitHub secrets (from spec 014): `MACOS_SIGN_P12`, `MACOS_SIGN_PASSWORD`, `MACOS_NOTARY_KEY`, `MACOS_NOTARY_KEY_ID`, `MACOS_NOTARY_ISSUER_ID`.
+- macOS CI runners provide the `codesign`, `xcrun notarytool`, and `security` tools pre-installed.
+- The repository is public, so macOS CI runner minutes are free.
+- Apple's notary service accepts bare Mach-O binaries submitted as zip archives (it does not accept tar.gz directly).
+- There is a brief window (~5-15 minutes) between the build job publishing unsigned darwin archives and the signing job replacing them with signed versions. This is acceptable because Homebrew fetches the download URL at install time, not at release time, and most users install well after the signing job completes.
+- The Homebrew cask update is handled by the build job. The cask's download URLs point to the release assets, which are replaced in-place by the signing job (same filenames). No separate cask update is needed after signing.

--- a/specs/015-native-macos-signing/tasks.md
+++ b/specs/015-native-macos-signing/tasks.md
@@ -1,0 +1,174 @@
+# Tasks: Native macOS Code Signing and Notarization
+
+**Input**: Design documents from `/specs/015-native-macos-signing/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Tests**: No automated test tasks — this feature is CI workflow configuration. Verification is manual (test release + `codesign --verify` + `spctl --assess` on macOS). See quickstart.md for verification steps.
+
+**Organization**: Tasks are grouped by user story. US1 contains the core signing job implementation. US2 adds the conditional skip logic. US3 adds checksum update. All three are implemented in `.github/workflows/release.yml`.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+```text
+.goreleaser.yaml                     # GoReleaser configuration (repository root)
+.github/workflows/release.yml       # GitHub Actions release workflow
+```
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: No project initialization needed — this feature modifies existing files only.
+
+*Phase 1 is empty for this feature. Proceed directly to Phase 2.*
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Remove the broken quill-based signing before adding the native replacement.
+
+- [x] T001 [P] Remove the entire `notarize.macos` section (the `notarize:` key and all its children) from .goreleaser.yaml. The section is between the `checksum:` and `changelog:` sections. Verify with `goreleaser check` after removal.
+- [x] T002 [P] Remove the 5 `MACOS_*` environment variables (`MACOS_SIGN_P12`, `MACOS_SIGN_PASSWORD`, `MACOS_NOTARY_KEY`, `MACOS_NOTARY_KEY_ID`, `MACOS_NOTARY_ISSUER_ID`) from the `Run GoReleaser` step's `env` block in .github/workflows/release.yml. Keep `GITHUB_TOKEN` and `HOMEBREW_TAP_GITHUB_TOKEN` unchanged.
+
+**Checkpoint**: Quill-based signing fully removed. GoReleaser config validated. Release pipeline produces unsigned binaries only.
+
+---
+
+## Phase 3: User Story 1 — Trusted Homebrew Installation (Priority: P1) MVP
+
+**Goal**: Add a `sign-macos` job to the release workflow that signs darwin binaries with `codesign` and notarizes them with `notarytool` on a macOS runner.
+
+**Independent Test**: Tag a test release, verify `sign-macos` job runs on `macos-latest`, download darwin binary, run `codesign -dv --verbose=4` (should show `TeamIdentifier=PGFWLVZX55`), run `spctl --assess --type execute --verbose=2` (should say `accepted source=Notarized Developer ID`).
+
+### Implementation for User Story 1
+
+- [x] T003 [US1] Add a `sign-macos` job to .github/workflows/release.yml with `runs-on: macos-latest`, `needs: release`, and `timeout-minutes: 30`. Add a step named "Import certificate into Keychain" that: (a) decodes `MACOS_SIGN_P12` from base64 to `$RUNNER_TEMP/cert.p12`, (b) creates a temporary keychain at `$RUNNER_TEMP/app-signing.keychain-db` with a random password, (c) unlocks the keychain, (d) imports the .p12 with `security import`, (e) sets the key partition list with `security set-key-partition-list -S apple-tool:,apple:`, (f) adds the keychain to the search list. Reference the exact commands from research.md Decision 3.
+- [x] T004 [US1] Add a "Prepare notary key" step to the `sign-macos` job in .github/workflows/release.yml that decodes `MACOS_NOTARY_KEY` from base64 to `$RUNNER_TEMP/notary_key.p8`.
+- [x] T005 [US1] Add a "Download darwin archives" step to the `sign-macos` job in .github/workflows/release.yml that uses `gh release download "${GITHUB_REF_NAME}" --pattern "gaze_*_darwin_*.tar.gz" --dir ./artifacts`. Set `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` in the step env.
+- [x] T006 [US1] Add a "Sign and notarize" step to the `sign-macos` job in .github/workflows/release.yml that loops over each archive in `./artifacts/gaze_*_darwin_*.tar.gz` and for each: (a) extracts the binary with `tar -xzf`, (b) signs with `codesign --force --timestamp --options runtime --sign "Developer ID Application: John Flowers (PGFWLVZX55)"`, (c) verifies with `codesign --verify --verbose=2`, (d) zips with `ditto -c -k` for notarytool, (e) submits with `xcrun notarytool submit --key $RUNNER_TEMP/notary_key.p8 --key-id --issuer --wait --timeout 20m`, (f) re-archives the signed binary with `tar -czf` into `./signed/` preserving the original archive name. Set `MACOS_NOTARY_KEY_ID` and `MACOS_NOTARY_ISSUER_ID` in the step env from secrets.
+- [x] T007 [US1] Add a "Replace release assets" step to the `sign-macos` job in .github/workflows/release.yml that uploads each signed archive from `./signed/` using `gh release upload "${GITHUB_REF_NAME}" ./signed/*.tar.gz --clobber`. Set `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` in the step env.
+
+**Checkpoint**: The `sign-macos` job signs and notarizes both darwin binaries and replaces the unsigned archives on the release. TeamIdentifier is correctly set by native `codesign`.
+
+---
+
+## Phase 4: User Story 2 — Graceful Degradation (Priority: P2)
+
+**Goal**: Ensure the signing job is skipped cleanly when Apple secrets are not configured.
+
+**Independent Test**: Run the release workflow in a fork or environment without `MACOS_SIGN_P12` configured. Verify the `release` job succeeds and the `sign-macos` job shows as "skipped" (not "failed").
+
+### Implementation for User Story 2
+
+- [x] T008 [US2] Add a "Check signing secrets" step to the `release` job in .github/workflows/release.yml with `id: check-secrets`. The step should output `has_secrets=true` to `$GITHUB_OUTPUT` if `MACOS_SIGN_P12` is non-empty, otherwise `has_secrets=false`. Add `outputs: has_signing_secrets: ${{ steps.check-secrets.outputs.has_secrets }}` to the `release` job definition.
+- [x] T009 [US2] Add an `if: ${{ needs.release.outputs.has_signing_secrets == 'true' }}` condition to the `sign-macos` job in .github/workflows/release.yml so it is skipped when secrets are absent.
+
+**Checkpoint**: The signing job is conditionally skipped based on secret presence. The release job always succeeds regardless.
+
+---
+
+## Phase 5: User Story 3 — Checksum Integrity (Priority: P3)
+
+**Goal**: Update the checksums file after signing so published checksums match signed darwin archives.
+
+**Independent Test**: After a release with signing, download `checksums.txt` and all archives, run `shasum -a 256 -c checksums.txt` and verify all lines pass.
+
+### Implementation for User Story 3
+
+- [x] T010 [US3] Extend the "Replace release assets" step (T007) in .github/workflows/release.yml to also: (a) download the existing `checksums.txt` from the release with `gh release download`, (b) remove darwin lines from the checksums with `grep -v darwin`, (c) compute SHA256 for each signed darwin archive in `./signed/` with `shasum -a 256`, (d) append the new darwin checksums, (e) re-upload `checksums.txt` with `gh release upload --clobber`.
+
+**Checkpoint**: Checksums file is accurate for both signed darwin and unchanged linux archives.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation updates and validation
+
+- [x] T011 [P] Update AGENTS.md "Recent Changes" section to add an entry for 015-native-macos-signing documenting the switch from quill to native codesign/notarytool
+- [x] T012 [P] Update AGENTS.md "Active Technologies" section to verify the 015-native-macos-signing entry was added by `update-agent-context.sh` (check for existing entry; add if missing)
+- [x] T013 Run `goreleaser check` to validate .goreleaser.yaml after quill removal (dry-run verification)
+- [x] T014 Run `goreleaser release --snapshot --clean` to verify the build works without the quill notarize section
+
+**Checkpoint**: Documentation updated, YAML validated. Feature is ready for a test release.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Empty — no setup tasks
+- **Foundational (Phase 2)**: T001 and T002 modify different files and can run in parallel. MUST complete before US1 work begins.
+- **User Story 1 (Phase 3)**: Depends on Phase 2 (quill removal). T003-T007 are sequential — each step builds on the previous within the same file.
+- **User Story 2 (Phase 4)**: Depends on US1 (T003 creates the `sign-macos` job that T009 adds the `if` condition to). T008 modifies the `release` job; T009 modifies the `sign-macos` job — sequential.
+- **User Story 3 (Phase 5)**: Depends on US1 (T007 creates the "Replace release assets" step that T010 extends).
+- **Polish (Phase 6)**: T011/T012 can run in parallel and at any time. T013/T014 depend on T001 being complete.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Depends on Phase 2 (quill removal) — core implementation
+- **User Story 2 (P2)**: Depends on US1 (adds condition to the job US1 creates)
+- **User Story 3 (P3)**: Depends on US1 (extends the asset replacement step US1 creates)
+
+### Parallel Opportunities
+
+- T001 and T002 modify different files (`.goreleaser.yaml` vs `.github/workflows/release.yml`) and can run in parallel
+- T011 and T012 modify the same file (`AGENTS.md`) but different sections — can run in parallel
+- T013 and T014 are both validation commands and can run sequentially after Phase 2
+
+---
+
+## Parallel Example: Foundational Phase
+
+```bash
+# Launch both foundational tasks together (different files):
+Task: "Remove notarize.macos section from .goreleaser.yaml"
+Task: "Remove MACOS_* env vars from GoReleaser step in release.yml"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 2: Remove quill config (T001 + T002)
+2. Complete Phase 3: Add sign-macos job (T003-T007)
+3. **STOP and VALIDATE**: Push a test tag and verify signing works
+4. US2 and US3 can be added after validation
+
+### Incremental Delivery
+
+1. T001 + T002 → Remove broken quill config
+2. T003-T007 → Core signing job (US1)
+3. T008 + T009 → Graceful degradation (US2)
+4. T010 → Checksum update (US3)
+5. T011-T014 → Documentation and validation
+
+### Full Verification (requires Apple credentials)
+
+1. Push a test tag (e.g., `v0.X.Y-rc.1`)
+2. Monitor GitHub Actions: `release` job on ubuntu, `sign-macos` job on macos
+3. Download darwin binary and verify:
+   - `codesign -dv --verbose=4` → TeamIdentifier set
+   - `spctl --assess --type execute --verbose=2` → accepted, Notarized Developer ID
+4. Download `checksums.txt` and verify with `shasum -a 256 -c`
+5. Install via `brew install --cask gaze` and confirm no Gatekeeper warning
+
+---
+
+## Notes
+
+- This feature modifies 2 files: `.goreleaser.yaml` (removal only) and `.github/workflows/release.yml` (removal + addition)
+- T003-T007 build up the `sign-macos` job incrementally within the same file — they are sequential, not parallel
+- US2 and US3 add small modifications to the job structure created by US1
+- The same 5 GitHub secrets from spec 014 are reused — no new secret configuration needed
+- Full end-to-end verification requires the Apple credentials already configured from spec 014


### PR DESCRIPTION
## Summary

- **Removed** broken quill-based `notarize.macos` section from `.goreleaser.yaml` and 5 `MACOS_*` env vars from the GoReleaser step (quill bug #147: `TeamIdentifier` never set, notarization stalls indefinitely)
- **Added** `sign-macos` job to release workflow running on `macos-latest` -- imports .p12 cert into temp Keychain, signs darwin binaries with `codesign --force --timestamp --options runtime`, notarizes via `xcrun notarytool submit --wait --timeout 20m`, replaces unsigned release assets with `gh release upload --clobber`, and updates `checksums.txt`
- **Added** graceful degradation -- `sign-macos` job is conditionally skipped via job output gate when `MACOS_SIGN_P12` secret is absent (forks/contributors get unsigned but functional binaries)

## Files Changed

| File | Change |
|------|--------|
| `.goreleaser.yaml` | Removed `notarize.macos` section (12 lines) |
| `.github/workflows/release.yml` | Removed MACOS env vars from GoReleaser step; added `check-secrets` output + `sign-macos` job (+97 lines) |
| `AGENTS.md` | Added 015 to Recent Changes, Active Technologies, and spec listing |
| `specs/015-native-macos-signing/` | Spec artifacts (spec, plan, research, data-model, quickstart, tasks, checklists) |

## Validation

- `goreleaser check` -- PASS
- `goreleaser release --snapshot --clean` -- PASS (all 4 targets build)
- All 14 tasks in tasks.md marked complete

## Verification (requires Apple credentials)

1. Push test tag: `git tag v0.X.Y-rc.1 && git push origin v0.X.Y-rc.1`
2. Monitor: `release` job on ubuntu-latest, `sign-macos` job on macos-latest
3. Download darwin binary and run `codesign -dv --verbose=4` (TeamIdentifier=PGFWLVZX55)
4. Run `spctl --assess --type execute --verbose=2` (accepted, Notarized Developer ID)
5. Verify `shasum -a 256 -c checksums.txt`
