### PR TITLE
feat: reduce gaze-reporter prompt size 26.6% via on-demand reference files

### DIFF
--- a/.opencode/agents/gaze-reporter.md
+++ b/.opencode/agents/gaze-reporter.md
@@ -120,11 +120,9 @@ Produce a summary containing:
 3. One concise sentence after the table stating the key pattern.
 4. **GazeCRAP Quadrant Distribution** (if `gaze_crap` data is
    present) — table with columns Quadrant, Count, Meaning.
-   Use emoji-prefixed labels:
-   - 🟢 Q1 — Safe
-   - 🟡 Q2 — Complex But Tested
-   - 🔴 Q4 — Dangerous
-   - ⚪ Q3 — Needs Tests
+   Use the quadrant labels shown in the Quick Reference Example
+   above (🟢 Q1 — Safe, 🟡 Q2 — Complex But Tested, 🔴 Q4 —
+   Dangerous, ⚪ Q3 — Needs Tests).
 5. Include all quadrant rows (even zero-count) for completeness.
 6. If GazeCRAP data is NOT present, omit the quadrant section
    entirely — do not render any header or placeholder.
@@ -200,49 +198,12 @@ GazeCRAPload interpretation line)
 
 ### Document-Enhanced Classification
 
-If `gaze docscan` returns documentation files, enhance the mechanical
-classification by applying document-signal scoring. Start from the
-mechanical confidence score for each side effect, add document and AI
-inference signal weights, detect contradictions, clamp to 0–100, and
-re-apply thresholds.
-
-**Document Signal Sources**
-
-Extract signals from the documentation content and assign weights:
-
-| Source | Weight Range | Evidence |
-|--------|-------------|---------|
-| `readme` | ±5 to ±15 | Module README explicitly names the function or its behavior (positive) or describes it as internal (negative) |
-| `architecture_doc` | ±5 to ±20 | Architecture/design doc declares this function's contract (positive) or marks it as implementation detail (negative) |
-| `specify_file` | ±5 to ±25 | `specs/` files document this as required behavior (positive) or mark it as optional (negative) |
-| `api_doc` | ±5 to ±20 | API reference doc lists this function's return values or mutations (positive) or marks as non-public (negative) |
-| `other_md` | ±2 to ±10 | Other markdown files reference this function (positive) or describe it as debug/internal (negative) |
-
-**AI Inference Signals**
-
-In addition to extracting explicit mentions, infer signals from patterns:
-
-| Source | Weight Range | Evidence |
-|--------|-------------|---------|
-| `ai_pattern` | +5 to +15 | Recognizable design pattern (Repository, Factory, etc.) whose contract implies this side effect |
-| `ai_layer` | +5 to +15 | Architectural layer analysis (e.g., service layer functions that mutate state are usually contractual) |
-| `ai_corroboration` | +3 to +10 | Multiple independent document signals agree |
-
-**Contradiction Penalty**
-
-If document signals and mechanical signals point in opposite directions
-(e.g., mechanical says contractual, docs say incidental), apply a
-contradiction penalty of up to -20 to the confidence score.
-
-**Classification Thresholds**
-
-After recalculation, re-derive labels from updated confidence scores:
-
-| Confidence | Label |
-|-----------|-------|
-| ≥ 80 | contractual |
-| 50–79 | ambiguous |
-| < 50 | incidental |
+If `gaze docscan` returns documentation files, read the
+document-enhanced classification scoring model from
+`.opencode/references/doc-scoring-model.md` using the Read tool.
+Apply the signal weights, thresholds, and contradiction penalties
+defined there. If the file cannot be read, skip document-enhanced
+scoring and use mechanical-only classification.
 
 If docscan returns no documents or fails, skip document-enhanced
 scoring entirely and use the mechanical-only results. Include a
@@ -379,78 +340,14 @@ data sections).
 Always include count and context:
 "24 (functions ≥ threshold 15)"
 
-## Example Output
+## Reference Files
 
-Below is a concrete example of the expected report format. Use
-this as the definitive formatting reference. Adapt the data to the
-actual project — do not copy these specific numbers or function
-names. The recommendations and function names below are fictional.
-
-```markdown
-🔍 Gaze Full Quality Report
-Project: github.com/example/project · Branch: main
-Gaze Version: v1.0.0 · Go: 1.24.6 · Date: 2026-02-28
----
-📊 CRAP Summary
-| Metric | Value |
-|--------|-------|
-| Total functions analyzed | 216 |
-| Average complexity | 6.2 |
-| Average line coverage | 79.0% |
-| Average CRAP score | 7.7 |
-| CRAPload | 24 (functions ≥ threshold 15) |
-
-Top 5 Worst CRAP Scores
-| Function | CRAP | Complexity | Coverage | File |
-|----------|------|-----------|----------|------|
-| (*Handler).ServeHTTP | 42.0 | 6 | 0.0% | internal/api/handler.go:163 |
-| processQueue | 38.5 | 8 | 12.0% | internal/worker/queue.go:89 |
-| parseConfig | 31.2 | 5 | 0.0% | cmd/app/config.go:42 |
-| (*Store).Migrate | 28.0 | 7 | 15.0% | internal/db/store.go:201 |
-| validateInput | 22.4 | 4 | 0.0% | internal/api/validate.go:55 |
-
-Three of the five have 0% test coverage; the other two have minimal coverage with high complexity.
-
-GazeCRAP Quadrant Distribution
-| Quadrant | Count | Meaning |
-|----------|-------|---------|
-| 🟢 Q1 — Safe | 29 | Low complexity, high contract coverage |
-| 🟡 Q2 — Complex But Tested | 1 | High complexity, contracts verified |
-| 🔴 Q4 — Dangerous | 4 | Complex AND contracts not adequately verified |
-| ⚪ Q3 — Needs Tests | 0 | Simple but underspecified |
-
-GazeCRAPload: 4 — All 4 Q4 functions have adequate line coverage but high cyclomatic complexity (15–18), meaning they need decomposition, not more tests.
----
-🧪 Quality Summary
-> ⚠️ Module-level quality analysis returned 0 tests — run per-package analysis for detailed results.
----
-🏷️ Classification Summary
-| Classification | Count | % |
-|---------------|-------|---|
-| Contractual | 73 | 31.3% |
-| Ambiguous | 155 | 66.5% |
-| Incidental | 8 | 3.4% |
-
-The 66.5% ambiguous rate is typical for projects without extensive documentation; document-enhanced scoring in full mode can reduce this.
----
-🏥 Overall Health Assessment
-
-Summary Scorecard
-| Dimension | Grade | Details |
-|-----------|-------|---------|
-| CRAPload | 🟡 C+ | 24/216 functions (11%) above threshold |
-| GazeCRAPload | 🟢 A | Only 4 functions above threshold |
-| Avg Line Coverage | 🟢 B+ | 79.0% — solid foundation |
-| Contract Coverage | 🟡 C | 31.3% contractual, 66.5% ambiguous |
-| Complexity | 🟡 B- | Average 6.2, but 24 functions exceed threshold |
-
-Top 5 Prioritized Recommendations
-1. 🔴 Add tests for zero-coverage functions — ServeHTTP, parseConfig, and validateInput have 0% coverage with moderate-to-high complexity.
-2. 🔴 Increase coverage for processQueue — 12% coverage on complexity-8 function handling critical work queue logic.
-3. 🟡 Decompose high-complexity functions — 4 Q4 functions have complexity 15–18 and need to be broken into smaller units.
-4. 🟡 Resolve ambiguous classifications — 66.5% ambiguous rate can be reduced with project documentation providing stronger signal evidence.
-5. 🟢 Run per-package quality analysis — module-level returned 0 tests; per-package analysis provides granular contract coverage data.
-```
+Before producing your first report, read the formatting reference
+from `.opencode/references/example-report.md` using the Read tool.
+This file contains the definitive example of the expected output
+format. If the file cannot be read, use the Quick Reference Example
+above as your formatting guide and include:
+`> ⚠️ Could not load full formatting reference.`
 
 ## Graceful Degradation
 

--- a/.opencode/references/doc-scoring-model.md
+++ b/.opencode/references/doc-scoring-model.md
@@ -1,0 +1,45 @@
+### Document-Enhanced Classification
+
+If `gaze docscan` returns documentation files, enhance the mechanical
+classification by applying document-signal scoring. Start from the
+mechanical confidence score for each side effect, add document and AI
+inference signal weights, detect contradictions, clamp to 0–100, and
+re-apply thresholds.
+
+**Document Signal Sources**
+
+Extract signals from the documentation content and assign weights:
+
+| Source | Weight Range | Evidence |
+|--------|-------------|---------|
+| `readme` | ±5 to ±15 | Module README explicitly names the function or its behavior (positive) or describes it as internal (negative) |
+| `architecture_doc` | ±5 to ±20 | Architecture/design doc declares this function's contract (positive) or marks it as implementation detail (negative) |
+| `specify_file` | ±5 to ±25 | `specs/` files document this as required behavior (positive) or mark it as optional (negative) |
+| `api_doc` | ±5 to ±20 | API reference doc lists this function's return values or mutations (positive) or marks as non-public (negative) |
+| `other_md` | ±2 to ±10 | Other markdown files reference this function (positive) or describe it as debug/internal (negative) |
+
+**AI Inference Signals**
+
+In addition to extracting explicit mentions, infer signals from patterns:
+
+| Source | Weight Range | Evidence |
+|--------|-------------|---------|
+| `ai_pattern` | +5 to +15 | Recognizable design pattern (Repository, Factory, etc.) whose contract implies this side effect |
+| `ai_layer` | +5 to +15 | Architectural layer analysis (e.g., service layer functions that mutate state are usually contractual) |
+| `ai_corroboration` | +3 to +10 | Multiple independent document signals agree |
+
+**Contradiction Penalty**
+
+If document signals and mechanical signals point in opposite directions
+(e.g., mechanical says contractual, docs say incidental), apply a
+contradiction penalty of up to -20 to the confidence score.
+
+**Classification Thresholds**
+
+After recalculation, re-derive labels from updated confidence scores:
+
+| Confidence | Label |
+|-----------|-------|
+| ≥ 80 | contractual |
+| 50–79 | ambiguous |
+| < 50 | incidental |

--- a/.opencode/references/example-report.md
+++ b/.opencode/references/example-report.md
@@ -1,0 +1,72 @@
+## Example Output
+
+Below is a concrete example of the expected report format. Use
+this as the definitive formatting reference. Adapt the data to the
+actual project — do not copy these specific numbers or function
+names. The recommendations and function names below are fictional.
+
+```markdown
+🔍 Gaze Full Quality Report
+Project: github.com/example/project · Branch: main
+Gaze Version: v1.0.0 · Go: 1.24.6 · Date: 2026-02-28
+---
+📊 CRAP Summary
+| Metric | Value |
+|--------|-------|
+| Total functions analyzed | 216 |
+| Average complexity | 6.2 |
+| Average line coverage | 79.0% |
+| Average CRAP score | 7.7 |
+| CRAPload | 24 (functions ≥ threshold 15) |
+
+Top 5 Worst CRAP Scores
+| Function | CRAP | Complexity | Coverage | File |
+|----------|------|-----------|----------|------|
+| (*Handler).ServeHTTP | 42.0 | 6 | 0.0% | internal/api/handler.go:163 |
+| processQueue | 38.5 | 8 | 12.0% | internal/worker/queue.go:89 |
+| parseConfig | 31.2 | 5 | 0.0% | cmd/app/config.go:42 |
+| (*Store).Migrate | 28.0 | 7 | 15.0% | internal/db/store.go:201 |
+| validateInput | 22.4 | 4 | 0.0% | internal/api/validate.go:55 |
+
+Three of the five have 0% test coverage; the other two have minimal coverage with high complexity.
+
+GazeCRAP Quadrant Distribution
+| Quadrant | Count | Meaning |
+|----------|-------|---------|
+| 🟢 Q1 — Safe | 29 | Low complexity, high contract coverage |
+| 🟡 Q2 — Complex But Tested | 1 | High complexity, contracts verified |
+| 🔴 Q4 — Dangerous | 4 | Complex AND contracts not adequately verified |
+| ⚪ Q3 — Needs Tests | 0 | Simple but underspecified |
+
+GazeCRAPload: 4 — All 4 Q4 functions have adequate line coverage but high cyclomatic complexity (15–18), meaning they need decomposition, not more tests.
+---
+🧪 Quality Summary
+> ⚠️ Module-level quality analysis returned 0 tests — run per-package analysis for detailed results.
+---
+🏷️ Classification Summary
+| Classification | Count | % |
+|---------------|-------|---|
+| Contractual | 73 | 31.3% |
+| Ambiguous | 155 | 66.5% |
+| Incidental | 8 | 3.4% |
+
+The 66.5% ambiguous rate is typical for projects without extensive documentation; document-enhanced scoring in full mode can reduce this.
+---
+🏥 Overall Health Assessment
+
+Summary Scorecard
+| Dimension | Grade | Details |
+|-----------|-------|---------|
+| CRAPload | 🟡 C+ | 24/216 functions (11%) above threshold |
+| GazeCRAPload | 🟢 A | Only 4 functions above threshold |
+| Avg Line Coverage | 🟢 B+ | 79.0% — solid foundation |
+| Contract Coverage | 🟡 C | 31.3% contractual, 66.5% ambiguous |
+| Complexity | 🟡 B- | Average 6.2, but 24 functions exceed threshold |
+
+Top 5 Prioritized Recommendations
+1. 🔴 Add tests for zero-coverage functions — ServeHTTP, parseConfig, and validateInput have 0% coverage with moderate-to-high complexity.
+2. 🔴 Increase coverage for processQueue — 12% coverage on complexity-8 function handling critical work queue logic.
+3. 🟡 Decompose high-complexity functions — 4 Q4 functions have complexity 15–18 and need to be broken into smaller units.
+4. 🟡 Resolve ambiguous classifications — 66.5% ambiguous rate can be reduced with project documentation providing stronger signal evidence.
+5. 🟢 Run per-package quality analysis — module-level returned 0 tests; per-package analysis provides granular contract coverage data.
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ specs/
   012-consolidate-classify-docs/ # spec.md, plan.md, tasks.md, research.md, data-model.md, quickstart.md
   014-macos-notarization/        # spec.md, plan.md, tasks.md, research.md, data-model.md, quickstart.md
   015-native-macos-signing/      # spec.md, plan.md, tasks.md, research.md, data-model.md, quickstart.md, checklists/
+  016-agent-context-reduction/   # spec.md, plan.md, tasks.md, research.md, data-model.md, quickstart.md, checklists/
 ```
 
 Branch names follow the same numbering pattern (e.g., `001-side-effect-detection`).
@@ -239,6 +240,7 @@ Formatters: gofmt, goimports.
 - Filesystem only (embedded assets via `embed.FS`, `.opencode/` directory) (012-consolidate-classify-docs)
 - Go 1.24+ (no Go code changes; YAML/workflow configuration only) + GoReleaser v2 (OSS), quill (embedded in GoReleaser as a Go library) (014-macos-notarization)
 - Go 1.24+ (no Go code changes; YAML/workflow configuration only) + GitHub Actions, `codesign` (macOS native), `xcrun notarytool` (macOS native), `security` (macOS Keychain), `gh` CLI (GitHub) (015-native-macos-signing)
+- Go 1.24+ (scaffold Go code changes); Markdown (agent prompt and reference files) + `embed.FS` (Go standard library), OpenCode agent runtime (016-agent-context-reduction)
 
 - Go 1.24+ + `golang.org/x/tools` (go/packages, go/ssa), Cobra (CLI), Bubble Tea/Lipgloss (TUI)
 - Filesystem only (embedded assets via `embed.FS`)
@@ -246,6 +248,7 @@ Formatters: gofmt, goimports.
 
 ## Recent Changes
 
+- 016-agent-context-reduction: Reduced gaze-reporter agent prompt from 17,775 to 13,050 bytes (26.6% reduction) by externalizing canonical example output and document-enhanced classification scoring model into `.opencode/references/` files loaded on demand via Read tool. Added scaffold overwrite-on-diff behavior for tool-owned reference files (`references/` directory) while preserving skip-if-present for user-owned files (`agents/`, `command/`). Scaffold now manages 4 files (up from 2). Added `Updated` field to scaffold `Result` struct and `isToolOwned` helper. Quadrant labels deduplicated to 2 locations (Quick Reference Example + Emoji Vocabulary table).
 - 015-native-macos-signing: Replaced broken quill-based cross-platform signing with native `codesign`/`notarytool` on `macos-latest` runner. Removed `notarize.macos` from `.goreleaser.yaml`. Added `sign-macos` job to release workflow (Keychain import, codesign with hardened runtime, notarytool submit --wait, asset replacement with --clobber, checksum update). Conditional on `MACOS_SIGN_P12` secret via job output gate.
 - 014-macos-notarization: Added macOS code signing and notarization to GoReleaser release pipeline via built-in `notarize.macos` (quill), conditional on `MACOS_SIGN_P12` secret presence, 20m notarization timeout, 45m job timeout, no runner change (stays ubuntu-latest)
 - 012-consolidate-classify-docs: Removed /classify-docs command and doc-classifier agent, inlined document-signal scoring model into gaze-reporter, added emoji formatting override block and sandwich prompt structure, reduced scaffold from 4 to 2 files

--- a/cmd/gaze/main_test.go
+++ b/cmd/gaze/main_test.go
@@ -1241,6 +1241,8 @@ func TestRunInit_CreatesFiles(t *testing.T) {
 	expected := []string{
 		".opencode/agents/gaze-reporter.md",
 		".opencode/command/gaze.md",
+		".opencode/references/doc-scoring-model.md",
+		".opencode/references/example-report.md",
 	}
 	for _, rel := range expected {
 		path := filepath.Join(dir, rel)

--- a/internal/scaffold/assets/agents/gaze-reporter.md
+++ b/internal/scaffold/assets/agents/gaze-reporter.md
@@ -120,11 +120,9 @@ Produce a summary containing:
 3. One concise sentence after the table stating the key pattern.
 4. **GazeCRAP Quadrant Distribution** (if `gaze_crap` data is
    present) — table with columns Quadrant, Count, Meaning.
-   Use emoji-prefixed labels:
-   - 🟢 Q1 — Safe
-   - 🟡 Q2 — Complex But Tested
-   - 🔴 Q4 — Dangerous
-   - ⚪ Q3 — Needs Tests
+   Use the quadrant labels shown in the Quick Reference Example
+   above (🟢 Q1 — Safe, 🟡 Q2 — Complex But Tested, 🔴 Q4 —
+   Dangerous, ⚪ Q3 — Needs Tests).
 5. Include all quadrant rows (even zero-count) for completeness.
 6. If GazeCRAP data is NOT present, omit the quadrant section
    entirely — do not render any header or placeholder.
@@ -200,49 +198,12 @@ GazeCRAPload interpretation line)
 
 ### Document-Enhanced Classification
 
-If `gaze docscan` returns documentation files, enhance the mechanical
-classification by applying document-signal scoring. Start from the
-mechanical confidence score for each side effect, add document and AI
-inference signal weights, detect contradictions, clamp to 0–100, and
-re-apply thresholds.
-
-**Document Signal Sources**
-
-Extract signals from the documentation content and assign weights:
-
-| Source | Weight Range | Evidence |
-|--------|-------------|---------|
-| `readme` | ±5 to ±15 | Module README explicitly names the function or its behavior (positive) or describes it as internal (negative) |
-| `architecture_doc` | ±5 to ±20 | Architecture/design doc declares this function's contract (positive) or marks it as implementation detail (negative) |
-| `specify_file` | ±5 to ±25 | `specs/` files document this as required behavior (positive) or mark it as optional (negative) |
-| `api_doc` | ±5 to ±20 | API reference doc lists this function's return values or mutations (positive) or marks as non-public (negative) |
-| `other_md` | ±2 to ±10 | Other markdown files reference this function (positive) or describe it as debug/internal (negative) |
-
-**AI Inference Signals**
-
-In addition to extracting explicit mentions, infer signals from patterns:
-
-| Source | Weight Range | Evidence |
-|--------|-------------|---------|
-| `ai_pattern` | +5 to +15 | Recognizable design pattern (Repository, Factory, etc.) whose contract implies this side effect |
-| `ai_layer` | +5 to +15 | Architectural layer analysis (e.g., service layer functions that mutate state are usually contractual) |
-| `ai_corroboration` | +3 to +10 | Multiple independent document signals agree |
-
-**Contradiction Penalty**
-
-If document signals and mechanical signals point in opposite directions
-(e.g., mechanical says contractual, docs say incidental), apply a
-contradiction penalty of up to -20 to the confidence score.
-
-**Classification Thresholds**
-
-After recalculation, re-derive labels from updated confidence scores:
-
-| Confidence | Label |
-|-----------|-------|
-| ≥ 80 | contractual |
-| 50–79 | ambiguous |
-| < 50 | incidental |
+If `gaze docscan` returns documentation files, read the
+document-enhanced classification scoring model from
+`.opencode/references/doc-scoring-model.md` using the Read tool.
+Apply the signal weights, thresholds, and contradiction penalties
+defined there. If the file cannot be read, skip document-enhanced
+scoring and use mechanical-only classification.
 
 If docscan returns no documents or fails, skip document-enhanced
 scoring entirely and use the mechanical-only results. Include a
@@ -379,78 +340,14 @@ data sections).
 Always include count and context:
 "24 (functions ≥ threshold 15)"
 
-## Example Output
+## Reference Files
 
-Below is a concrete example of the expected report format. Use
-this as the definitive formatting reference. Adapt the data to the
-actual project — do not copy these specific numbers or function
-names. The recommendations and function names below are fictional.
-
-```markdown
-🔍 Gaze Full Quality Report
-Project: github.com/example/project · Branch: main
-Gaze Version: v1.0.0 · Go: 1.24.6 · Date: 2026-02-28
----
-📊 CRAP Summary
-| Metric | Value |
-|--------|-------|
-| Total functions analyzed | 216 |
-| Average complexity | 6.2 |
-| Average line coverage | 79.0% |
-| Average CRAP score | 7.7 |
-| CRAPload | 24 (functions ≥ threshold 15) |
-
-Top 5 Worst CRAP Scores
-| Function | CRAP | Complexity | Coverage | File |
-|----------|------|-----------|----------|------|
-| (*Handler).ServeHTTP | 42.0 | 6 | 0.0% | internal/api/handler.go:163 |
-| processQueue | 38.5 | 8 | 12.0% | internal/worker/queue.go:89 |
-| parseConfig | 31.2 | 5 | 0.0% | cmd/app/config.go:42 |
-| (*Store).Migrate | 28.0 | 7 | 15.0% | internal/db/store.go:201 |
-| validateInput | 22.4 | 4 | 0.0% | internal/api/validate.go:55 |
-
-Three of the five have 0% test coverage; the other two have minimal coverage with high complexity.
-
-GazeCRAP Quadrant Distribution
-| Quadrant | Count | Meaning |
-|----------|-------|---------|
-| 🟢 Q1 — Safe | 29 | Low complexity, high contract coverage |
-| 🟡 Q2 — Complex But Tested | 1 | High complexity, contracts verified |
-| 🔴 Q4 — Dangerous | 4 | Complex AND contracts not adequately verified |
-| ⚪ Q3 — Needs Tests | 0 | Simple but underspecified |
-
-GazeCRAPload: 4 — All 4 Q4 functions have adequate line coverage but high cyclomatic complexity (15–18), meaning they need decomposition, not more tests.
----
-🧪 Quality Summary
-> ⚠️ Module-level quality analysis returned 0 tests — run per-package analysis for detailed results.
----
-🏷️ Classification Summary
-| Classification | Count | % |
-|---------------|-------|---|
-| Contractual | 73 | 31.3% |
-| Ambiguous | 155 | 66.5% |
-| Incidental | 8 | 3.4% |
-
-The 66.5% ambiguous rate is typical for projects without extensive documentation; document-enhanced scoring in full mode can reduce this.
----
-🏥 Overall Health Assessment
-
-Summary Scorecard
-| Dimension | Grade | Details |
-|-----------|-------|---------|
-| CRAPload | 🟡 C+ | 24/216 functions (11%) above threshold |
-| GazeCRAPload | 🟢 A | Only 4 functions above threshold |
-| Avg Line Coverage | 🟢 B+ | 79.0% — solid foundation |
-| Contract Coverage | 🟡 C | 31.3% contractual, 66.5% ambiguous |
-| Complexity | 🟡 B- | Average 6.2, but 24 functions exceed threshold |
-
-Top 5 Prioritized Recommendations
-1. 🔴 Add tests for zero-coverage functions — ServeHTTP, parseConfig, and validateInput have 0% coverage with moderate-to-high complexity.
-2. 🔴 Increase coverage for processQueue — 12% coverage on complexity-8 function handling critical work queue logic.
-3. 🟡 Decompose high-complexity functions — 4 Q4 functions have complexity 15–18 and need to be broken into smaller units.
-4. 🟡 Resolve ambiguous classifications — 66.5% ambiguous rate can be reduced with project documentation providing stronger signal evidence.
-5. 🟢 Run per-package quality analysis — module-level returned 0 tests; per-package analysis provides granular contract coverage data.
-```
+Before producing your first report, read the formatting reference
+from `.opencode/references/example-report.md` using the Read tool.
+This file contains the definitive example of the expected output
+format. If the file cannot be read, use the Quick Reference Example
+above as your formatting guide and include:
+`> ⚠️ Could not load full formatting reference.`
 
 ## Graceful Degradation
 

--- a/internal/scaffold/assets/references/doc-scoring-model.md
+++ b/internal/scaffold/assets/references/doc-scoring-model.md
@@ -1,0 +1,45 @@
+### Document-Enhanced Classification
+
+If `gaze docscan` returns documentation files, enhance the mechanical
+classification by applying document-signal scoring. Start from the
+mechanical confidence score for each side effect, add document and AI
+inference signal weights, detect contradictions, clamp to 0–100, and
+re-apply thresholds.
+
+**Document Signal Sources**
+
+Extract signals from the documentation content and assign weights:
+
+| Source | Weight Range | Evidence |
+|--------|-------------|---------|
+| `readme` | ±5 to ±15 | Module README explicitly names the function or its behavior (positive) or describes it as internal (negative) |
+| `architecture_doc` | ±5 to ±20 | Architecture/design doc declares this function's contract (positive) or marks it as implementation detail (negative) |
+| `specify_file` | ±5 to ±25 | `specs/` files document this as required behavior (positive) or mark it as optional (negative) |
+| `api_doc` | ±5 to ±20 | API reference doc lists this function's return values or mutations (positive) or marks as non-public (negative) |
+| `other_md` | ±2 to ±10 | Other markdown files reference this function (positive) or describe it as debug/internal (negative) |
+
+**AI Inference Signals**
+
+In addition to extracting explicit mentions, infer signals from patterns:
+
+| Source | Weight Range | Evidence |
+|--------|-------------|---------|
+| `ai_pattern` | +5 to +15 | Recognizable design pattern (Repository, Factory, etc.) whose contract implies this side effect |
+| `ai_layer` | +5 to +15 | Architectural layer analysis (e.g., service layer functions that mutate state are usually contractual) |
+| `ai_corroboration` | +3 to +10 | Multiple independent document signals agree |
+
+**Contradiction Penalty**
+
+If document signals and mechanical signals point in opposite directions
+(e.g., mechanical says contractual, docs say incidental), apply a
+contradiction penalty of up to -20 to the confidence score.
+
+**Classification Thresholds**
+
+After recalculation, re-derive labels from updated confidence scores:
+
+| Confidence | Label |
+|-----------|-------|
+| ≥ 80 | contractual |
+| 50–79 | ambiguous |
+| < 50 | incidental |

--- a/internal/scaffold/assets/references/example-report.md
+++ b/internal/scaffold/assets/references/example-report.md
@@ -1,0 +1,72 @@
+## Example Output
+
+Below is a concrete example of the expected report format. Use
+this as the definitive formatting reference. Adapt the data to the
+actual project — do not copy these specific numbers or function
+names. The recommendations and function names below are fictional.
+
+```markdown
+🔍 Gaze Full Quality Report
+Project: github.com/example/project · Branch: main
+Gaze Version: v1.0.0 · Go: 1.24.6 · Date: 2026-02-28
+---
+📊 CRAP Summary
+| Metric | Value |
+|--------|-------|
+| Total functions analyzed | 216 |
+| Average complexity | 6.2 |
+| Average line coverage | 79.0% |
+| Average CRAP score | 7.7 |
+| CRAPload | 24 (functions ≥ threshold 15) |
+
+Top 5 Worst CRAP Scores
+| Function | CRAP | Complexity | Coverage | File |
+|----------|------|-----------|----------|------|
+| (*Handler).ServeHTTP | 42.0 | 6 | 0.0% | internal/api/handler.go:163 |
+| processQueue | 38.5 | 8 | 12.0% | internal/worker/queue.go:89 |
+| parseConfig | 31.2 | 5 | 0.0% | cmd/app/config.go:42 |
+| (*Store).Migrate | 28.0 | 7 | 15.0% | internal/db/store.go:201 |
+| validateInput | 22.4 | 4 | 0.0% | internal/api/validate.go:55 |
+
+Three of the five have 0% test coverage; the other two have minimal coverage with high complexity.
+
+GazeCRAP Quadrant Distribution
+| Quadrant | Count | Meaning |
+|----------|-------|---------|
+| 🟢 Q1 — Safe | 29 | Low complexity, high contract coverage |
+| 🟡 Q2 — Complex But Tested | 1 | High complexity, contracts verified |
+| 🔴 Q4 — Dangerous | 4 | Complex AND contracts not adequately verified |
+| ⚪ Q3 — Needs Tests | 0 | Simple but underspecified |
+
+GazeCRAPload: 4 — All 4 Q4 functions have adequate line coverage but high cyclomatic complexity (15–18), meaning they need decomposition, not more tests.
+---
+🧪 Quality Summary
+> ⚠️ Module-level quality analysis returned 0 tests — run per-package analysis for detailed results.
+---
+🏷️ Classification Summary
+| Classification | Count | % |
+|---------------|-------|---|
+| Contractual | 73 | 31.3% |
+| Ambiguous | 155 | 66.5% |
+| Incidental | 8 | 3.4% |
+
+The 66.5% ambiguous rate is typical for projects without extensive documentation; document-enhanced scoring in full mode can reduce this.
+---
+🏥 Overall Health Assessment
+
+Summary Scorecard
+| Dimension | Grade | Details |
+|-----------|-------|---------|
+| CRAPload | 🟡 C+ | 24/216 functions (11%) above threshold |
+| GazeCRAPload | 🟢 A | Only 4 functions above threshold |
+| Avg Line Coverage | 🟢 B+ | 79.0% — solid foundation |
+| Contract Coverage | 🟡 C | 31.3% contractual, 66.5% ambiguous |
+| Complexity | 🟡 B- | Average 6.2, but 24 functions exceed threshold |
+
+Top 5 Prioritized Recommendations
+1. 🔴 Add tests for zero-coverage functions — ServeHTTP, parseConfig, and validateInput have 0% coverage with moderate-to-high complexity.
+2. 🔴 Increase coverage for processQueue — 12% coverage on complexity-8 function handling critical work queue logic.
+3. 🟡 Decompose high-complexity functions — 4 Q4 functions have complexity 15–18 and need to be broken into smaller units.
+4. 🟡 Resolve ambiguous classifications — 66.5% ambiguous rate can be reduced with project documentation providing stronger signal evidence.
+5. 🟢 Run per-package quality analysis — module-level returned 0 tests; per-package analysis provides granular contract coverage data.
+```

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -3,6 +3,7 @@
 package scaffold
 
 import (
+	"bytes"
 	"embed"
 	"errors"
 	"fmt"
@@ -48,6 +49,21 @@ type Result struct {
 	// Overwritten lists files that existed and were replaced
 	// (Force was true).
 	Overwritten []string
+
+	// Updated lists tool-owned files that existed with different
+	// content and were overwritten via overwrite-on-diff (Force
+	// was false, but content differed from the embedded version).
+	Updated []string
+}
+
+// isToolOwned reports whether the given relative path (under
+// .opencode/) belongs to a tool-owned directory. Tool-owned files
+// use overwrite-on-diff behavior: they are replaced when their
+// content differs from the embedded version, even without --force.
+// User-owned files (agents/, command/) retain skip-if-present
+// behavior.
+func isToolOwned(relPath string) bool {
+	return strings.HasPrefix(relPath, "references/")
 }
 
 // versionMarker returns the version marker comment to embed in
@@ -101,19 +117,25 @@ func insertMarkerAfterFrontmatter(content []byte, marker string) []byte {
 	return out
 }
 
-// Run scaffolds OpenCode agent and command files into the target
-// directory. It creates .opencode/agents/ and .opencode/command/
-// subdirectories and writes the embedded quality-reporting files.
+// Run scaffolds OpenCode agent, command, and reference files into
+// the target directory. It creates .opencode/agents/,
+// .opencode/command/, and .opencode/references/ subdirectories
+// and writes the embedded quality-reporting files.
 //
 // Each file is prepended with a version marker comment:
 //
 //	<!-- scaffolded by gaze vX.Y.Z -->
 //
-// If a file already exists and opts.Force is false, the file is
-// skipped. If opts.Force is true, the file is overwritten.
+// Files are classified as user-owned (agents/, command/) or
+// tool-owned (references/). If a user-owned file already exists
+// and opts.Force is false, the file is skipped. Tool-owned files
+// use overwrite-on-diff: they are replaced when their content
+// differs from the embedded version, even without --force. If
+// opts.Force is true, all files are overwritten regardless of
+// ownership.
 //
-// Run returns a Result summarizing what was created, skipped, or
-// overwritten.
+// Run returns a Result summarizing what was created, skipped,
+// overwritten, or updated.
 func Run(opts Options) (*Result, error) {
 	if opts.TargetDir == "" {
 		cwd, err := os.Getwd()
@@ -163,15 +185,43 @@ func Run(opts Options) (*Result, error) {
 		}
 		exists := statErr == nil
 
-		if exists && !opts.Force {
-			result.Skipped = append(result.Skipped, filepath.Join(".opencode", relPath))
-			return nil
-		}
-
 		// Read the embedded file content.
 		content, err := assets.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("reading embedded asset %s: %w", path, err)
+		}
+
+		// Insert version marker after YAML frontmatter.
+		out := insertMarkerAfterFrontmatter(content, marker)
+
+		if exists && !opts.Force {
+			// Tool-owned files (references/) use overwrite-on-diff:
+			// compare content and overwrite if different, skip if
+			// identical. User-owned files (agents/, command/) retain
+			// the existing skip-if-present behavior.
+			if isToolOwned(relPath) {
+				existing, readErr := os.ReadFile(outPath)
+				if readErr != nil {
+					return fmt.Errorf("reading existing %s: %w", filepath.Join(".opencode", relPath), readErr)
+				}
+				if bytes.Equal(existing, out) {
+					result.Skipped = append(result.Skipped, filepath.Join(".opencode", relPath))
+					return nil
+				}
+				// Content differs — overwrite the tool-owned file.
+				// Ensure parent directory exists (guards against edge
+				// cases like broken symlinks or deleted directories).
+				if mkErr := os.MkdirAll(filepath.Dir(outPath), 0o755); mkErr != nil {
+					return fmt.Errorf("creating directory for %s: %w", filepath.Join(".opencode", relPath), mkErr)
+				}
+				if writeErr := os.WriteFile(outPath, out, 0o644); writeErr != nil {
+					return fmt.Errorf("updating %s: %w", filepath.Join(".opencode", relPath), writeErr)
+				}
+				result.Updated = append(result.Updated, filepath.Join(".opencode", relPath))
+				return nil
+			}
+			result.Skipped = append(result.Skipped, filepath.Join(".opencode", relPath))
+			return nil
 		}
 
 		// Create parent directories.
@@ -180,8 +230,6 @@ func Run(opts Options) (*Result, error) {
 			return fmt.Errorf("creating directory %s: %w", dir, err)
 		}
 
-		// Insert version marker after YAML frontmatter.
-		out := insertMarkerAfterFrontmatter(content, marker)
 		if err := os.WriteFile(outPath, out, 0o644); err != nil {
 			return fmt.Errorf("creating %s: %w", filepath.Join(".opencode", relPath), err)
 		}
@@ -206,7 +254,7 @@ func Run(opts Options) (*Result, error) {
 // printSummary writes a human-readable summary of the scaffold
 // operation to w.
 func printSummary(w io.Writer, r *Result) {
-	if len(r.Created) > 0 || len(r.Overwritten) > 0 {
+	if len(r.Created) > 0 || len(r.Overwritten) > 0 || len(r.Updated) > 0 {
 		_, _ = fmt.Fprintln(w, "Gaze OpenCode integration initialized:")
 	} else {
 		_, _ = fmt.Fprintln(w, "Gaze OpenCode integration already up to date:")
@@ -221,16 +269,29 @@ func printSummary(w io.Writer, r *Result) {
 	for _, f := range r.Overwritten {
 		_, _ = fmt.Fprintf(w, "  overwritten: %s\n", f)
 	}
+	for _, f := range r.Updated {
+		_, _ = fmt.Fprintf(w, "  updated: %s (content changed)\n", f)
+	}
 
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintln(w, "Run /gaze in OpenCode to generate quality reports.")
 
-	if n := len(r.Skipped); n > 0 {
+	// Count only user-owned skipped files for the --force hint.
+	// Tool-owned reference files that are skipped (identical content)
+	// do not need --force — they auto-update when content changes.
+	var userSkipped int
+	for _, f := range r.Skipped {
+		rel := strings.TrimPrefix(f, filepath.Join(".opencode")+string(filepath.Separator))
+		if !isToolOwned(rel) {
+			userSkipped++
+		}
+	}
+	if userSkipped > 0 {
 		word := "file"
-		if n > 1 {
+		if userSkipped > 1 {
 			word = "files"
 		}
-		_, _ = fmt.Fprintf(w, "%d %s skipped (use --force to overwrite).\n", n, word)
+		_, _ = fmt.Fprintf(w, "%d %s skipped (use --force to overwrite).\n", userSkipped, word)
 	}
 }
 

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -10,8 +10,9 @@ import (
 	"testing"
 )
 
-// TestRun_CreatesFiles verifies SC-001: gaze init creates exactly
-// 2 files in the correct directories when run in an empty project.
+// TestRun_CreatesFiles verifies that gaze init creates exactly 4
+// files (agents, command, and 2 reference files) in the correct
+// directories when run in an empty project.
 func TestRun_CreatesFiles(t *testing.T) {
 	dir := t.TempDir()
 
@@ -30,8 +31,8 @@ func TestRun_CreatesFiles(t *testing.T) {
 		t.Fatalf("Run() returned error: %v", err)
 	}
 
-	if len(result.Created) != 2 {
-		t.Errorf("expected 2 created files, got %d: %v", len(result.Created), result.Created)
+	if len(result.Created) != 4 {
+		t.Errorf("expected 4 created files, got %d: %v", len(result.Created), result.Created)
 	}
 	if len(result.Skipped) != 0 {
 		t.Errorf("expected 0 skipped files, got %d: %v", len(result.Skipped), result.Skipped)
@@ -39,11 +40,16 @@ func TestRun_CreatesFiles(t *testing.T) {
 	if len(result.Overwritten) != 0 {
 		t.Errorf("expected 0 overwritten files, got %d: %v", len(result.Overwritten), result.Overwritten)
 	}
+	if len(result.Updated) != 0 {
+		t.Errorf("expected 0 updated files, got %d: %v", len(result.Updated), result.Updated)
+	}
 
-	// Verify all 2 expected files exist on disk.
+	// Verify all 4 expected files exist on disk.
 	expected := []string{
 		".opencode/agents/gaze-reporter.md",
 		".opencode/command/gaze.md",
+		".opencode/references/doc-scoring-model.md",
+		".opencode/references/example-report.md",
 	}
 	for _, rel := range expected {
 		path := filepath.Join(dir, rel)
@@ -62,8 +68,9 @@ func TestRun_CreatesFiles(t *testing.T) {
 	}
 }
 
-// TestRun_SkipsExisting verifies SC-002: gaze init skips existing
-// files and reports them when --force is not set.
+// TestRun_SkipsExisting verifies that gaze init skips user-owned
+// files and skips tool-owned reference files when their content is
+// identical to the embedded version (no --force needed).
 func TestRun_SkipsExisting(t *testing.T) {
 	dir := t.TempDir()
 
@@ -82,7 +89,9 @@ func TestRun_SkipsExisting(t *testing.T) {
 		t.Fatalf("first Run() returned error: %v", err)
 	}
 
-	// Second run without --force: should skip all files.
+	// Second run without --force: reference files have identical
+	// content, so all 4 files land in Skipped (2 user-owned +
+	// 2 tool-owned identical).
 	var buf2 bytes.Buffer
 	result, err := Run(Options{
 		TargetDir: dir,
@@ -96,11 +105,14 @@ func TestRun_SkipsExisting(t *testing.T) {
 	if len(result.Created) != 0 {
 		t.Errorf("expected 0 created, got %d: %v", len(result.Created), result.Created)
 	}
-	if len(result.Skipped) != 2 {
-		t.Errorf("expected 2 skipped, got %d: %v", len(result.Skipped), result.Skipped)
+	if len(result.Skipped) != 4 {
+		t.Errorf("expected 4 skipped, got %d: %v", len(result.Skipped), result.Skipped)
 	}
 	if len(result.Overwritten) != 0 {
 		t.Errorf("expected 0 overwritten, got %d: %v", len(result.Overwritten), result.Overwritten)
+	}
+	if len(result.Updated) != 0 {
+		t.Errorf("expected 0 updated, got %d: %v", len(result.Updated), result.Updated)
 	}
 
 	output := buf2.String()
@@ -112,8 +124,9 @@ func TestRun_SkipsExisting(t *testing.T) {
 	}
 }
 
-// TestRun_ForceOverwrites verifies SC-003: gaze init --force
-// overwrites all files and reports the overwrites.
+// TestRun_ForceOverwrites verifies that gaze init --force
+// overwrites all files (user-owned and tool-owned) and reports
+// the overwrites.
 func TestRun_ForceOverwrites(t *testing.T) {
 	dir := t.TempDir()
 
@@ -150,8 +163,11 @@ func TestRun_ForceOverwrites(t *testing.T) {
 	if len(result.Skipped) != 0 {
 		t.Errorf("expected 0 skipped, got %d: %v", len(result.Skipped), result.Skipped)
 	}
-	if len(result.Overwritten) != 2 {
-		t.Errorf("expected 2 overwritten, got %d: %v", len(result.Overwritten), result.Overwritten)
+	if len(result.Overwritten) != 4 {
+		t.Errorf("expected 4 overwritten, got %d: %v", len(result.Overwritten), result.Overwritten)
+	}
+	if len(result.Updated) != 0 {
+		t.Errorf("expected 0 updated, got %d: %v", len(result.Updated), result.Updated)
 	}
 
 	output := buf2.String()
@@ -160,10 +176,10 @@ func TestRun_ForceOverwrites(t *testing.T) {
 	}
 }
 
-// TestRun_VersionMarker verifies SC-004: every scaffolded file
-// contains the version marker after the YAML frontmatter, not
-// before it (prepending before frontmatter breaks OpenCode's
-// YAML parsing).
+// TestRun_VersionMarker verifies that every scaffolded file
+// contains the version marker. Files with YAML frontmatter have
+// the marker inserted after the closing delimiter. Files without
+// frontmatter (e.g., reference files) have the marker appended.
 func TestRun_VersionMarker(t *testing.T) {
 	dir := t.TempDir()
 
@@ -201,23 +217,24 @@ func TestRun_VersionMarker(t *testing.T) {
 			t.Errorf("file %s: marker %q not found in content", relPath, expected)
 		}
 
-		// Frontmatter must start on the first line (not the marker).
+		// Files with YAML frontmatter: marker must appear after
+		// the closing delimiter. Files without frontmatter (e.g.,
+		// reference files): marker is appended at the end.
 		firstLine := strings.SplitN(s, "\n", 2)[0]
-		if firstLine != "---" {
-			t.Errorf("file %s: expected first line %q (frontmatter), got %q", relPath, "---", firstLine)
+		if firstLine == "---" {
+			// Frontmatter file: verify marker is after closing delimiter.
+			closingIdx := strings.Index(s[4:], "\n---\n")
+			if closingIdx < 0 {
+				t.Fatalf("file %s: no closing frontmatter delimiter found", relPath)
+			}
+			markerIdx := strings.Index(s, expected)
+			frontmatterEnd := closingIdx + 4 + len("\n---\n")
+			if markerIdx < frontmatterEnd {
+				t.Errorf("file %s: marker appears before frontmatter end (marker at %d, frontmatter ends at %d)",
+					relPath, markerIdx, frontmatterEnd)
+			}
 		}
-
-		// Marker must appear after the closing frontmatter delimiter.
-		closingIdx := strings.Index(s[4:], "\n---\n")
-		if closingIdx < 0 {
-			t.Fatalf("file %s: no closing frontmatter delimiter found", relPath)
-		}
-		markerIdx := strings.Index(s, expected)
-		frontmatterEnd := closingIdx + 4 + len("\n---\n")
-		if markerIdx < frontmatterEnd {
-			t.Errorf("file %s: marker appears before frontmatter end (marker at %d, frontmatter ends at %d)",
-				relPath, markerIdx, frontmatterEnd)
-		}
+		// Non-frontmatter files: marker presence already verified above.
 	}
 }
 
@@ -258,10 +275,13 @@ func TestRun_VersionMarker_Dev(t *testing.T) {
 			t.Errorf("file %s: marker %q not found in content", relPath, expected)
 		}
 
-		// Frontmatter must start on the first line.
+		// Files with frontmatter must start with "---".
+		// Reference files without frontmatter skip this check.
 		firstLine := strings.SplitN(s, "\n", 2)[0]
-		if firstLine != "---" {
-			t.Errorf("file %s: expected first line %q (frontmatter), got %q", relPath, "---", firstLine)
+		if strings.HasPrefix(relPath, "agents/") || strings.HasPrefix(relPath, "command/") {
+			if firstLine != "---" {
+				t.Errorf("file %s: expected first line %q (frontmatter), got %q", relPath, "---", firstLine)
+			}
 		}
 	}
 }
@@ -283,8 +303,8 @@ func TestRun_NoGoMod_PrintsWarning(t *testing.T) {
 	}
 
 	// Files should still be created.
-	if len(result.Created) != 2 {
-		t.Errorf("expected 2 created files, got %d", len(result.Created))
+	if len(result.Created) != 4 {
+		t.Errorf("expected 4 created files, got %d", len(result.Created))
 	}
 
 	// Warning should be printed.
@@ -294,9 +314,10 @@ func TestRun_NoGoMod_PrintsWarning(t *testing.T) {
 	}
 }
 
-// TestEmbeddedAssetsMatchSource verifies SC-005 / FR-017: the
-// embedded assets in internal/scaffold/assets/ are identical to
-// the corresponding files in .opencode/.
+// TestEmbeddedAssetsMatchSource verifies that the embedded assets
+// in internal/scaffold/assets/ are identical to the corresponding
+// files in .opencode/. This prevents drift between the scaffold
+// copies and the live copies used by OpenCode.
 func TestEmbeddedAssetsMatchSource(t *testing.T) {
 	// Find the project root by walking up from this test file's
 	// directory until we find go.mod.
@@ -310,8 +331,8 @@ func TestEmbeddedAssetsMatchSource(t *testing.T) {
 		t.Fatalf("assetPaths() returned error: %v", err)
 	}
 
-	if len(paths) != 2 {
-		t.Fatalf("expected 2 embedded assets, got %d: %v", len(paths), paths)
+	if len(paths) != 4 {
+		t.Fatalf("expected 4 embedded assets, got %d: %v", len(paths), paths)
 	}
 
 	for _, relPath := range paths {
@@ -334,17 +355,19 @@ func TestEmbeddedAssetsMatchSource(t *testing.T) {
 	}
 }
 
-// TestAssetPaths_Returns2Files verifies the embedded asset manifest
-// contains exactly 2 files.
-func TestAssetPaths_Returns2Files(t *testing.T) {
+// TestAssetPaths_Returns4Files verifies the embedded asset manifest
+// contains exactly 4 files.
+func TestAssetPaths_Returns4Files(t *testing.T) {
 	paths, err := assetPaths()
 	if err != nil {
 		t.Fatalf("assetPaths() returned error: %v", err)
 	}
 
 	expected := map[string]bool{
-		"agents/gaze-reporter.md": true,
-		"command/gaze.md":         true,
+		"agents/gaze-reporter.md":         true,
+		"command/gaze.md":                 true,
+		"references/doc-scoring-model.md": true,
+		"references/example-report.md":    true,
 	}
 
 	if len(paths) != len(expected) {
@@ -354,6 +377,166 @@ func TestAssetPaths_Returns2Files(t *testing.T) {
 	for _, p := range paths {
 		if !expected[p] {
 			t.Errorf("unexpected asset path: %s", p)
+		}
+	}
+}
+
+// TestRun_OverwriteOnDiff_ReferencesOnly verifies that tool-owned
+// reference files are overwritten when their content differs from
+// the embedded version, while user-owned files are skipped.
+func TestRun_OverwriteOnDiff_ReferencesOnly(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n"), 0o644); err != nil {
+		t.Fatalf("creating go.mod: %v", err)
+	}
+
+	// First run: create all 4 files.
+	var buf1 bytes.Buffer
+	result1, err := Run(Options{
+		TargetDir: dir,
+		Version:   "1.0.0",
+		Stdout:    &buf1,
+	})
+	if err != nil {
+		t.Fatalf("first Run() returned error: %v", err)
+	}
+	if len(result1.Created) != 4 {
+		t.Fatalf("expected 4 created files, got %d: %v", len(result1.Created), result1.Created)
+	}
+
+	// Second run without --force: all files should be skipped
+	// (reference files have identical content).
+	var buf2 bytes.Buffer
+	result2, err := Run(Options{
+		TargetDir: dir,
+		Version:   "1.0.0",
+		Stdout:    &buf2,
+	})
+	if err != nil {
+		t.Fatalf("second Run() returned error: %v", err)
+	}
+	if len(result2.Skipped) != 4 {
+		t.Errorf("expected 4 skipped, got %d: %v", len(result2.Skipped), result2.Skipped)
+	}
+	if len(result2.Updated) != 0 {
+		t.Errorf("expected 0 updated, got %d: %v", len(result2.Updated), result2.Updated)
+	}
+
+	// Modify a reference file on disk.
+	refPath := filepath.Join(dir, ".opencode", "references", "example-report.md")
+	if err := os.WriteFile(refPath, []byte("modified content\n"), 0o644); err != nil {
+		t.Fatalf("modifying reference file: %v", err)
+	}
+
+	// Third run without --force: the modified reference file should
+	// be overwritten (Updated), the other reference file skipped
+	// (identical), and user-owned files skipped.
+	var buf3 bytes.Buffer
+	result3, err := Run(Options{
+		TargetDir: dir,
+		Version:   "1.0.0",
+		Stdout:    &buf3,
+	})
+	if err != nil {
+		t.Fatalf("third Run() returned error: %v", err)
+	}
+
+	if len(result3.Updated) != 1 {
+		t.Errorf("expected 1 updated, got %d: %v", len(result3.Updated), result3.Updated)
+	}
+	if len(result3.Updated) == 1 && result3.Updated[0] != filepath.Join(".opencode", "references", "example-report.md") {
+		t.Errorf("expected updated file to be references/example-report.md, got %s", result3.Updated[0])
+	}
+	// 2 user-owned + 1 identical reference = 3 skipped.
+	if len(result3.Skipped) != 3 {
+		t.Errorf("expected 3 skipped, got %d: %v", len(result3.Skipped), result3.Skipped)
+	}
+	if len(result3.Created) != 0 {
+		t.Errorf("expected 0 created, got %d: %v", len(result3.Created), result3.Created)
+	}
+	if len(result3.Overwritten) != 0 {
+		t.Errorf("expected 0 overwritten, got %d: %v", len(result3.Overwritten), result3.Overwritten)
+	}
+
+	// Verify the file on disk was restored to the embedded content.
+	restored, readErr := os.ReadFile(refPath)
+	if readErr != nil {
+		t.Fatalf("reading restored reference file: %v", readErr)
+	}
+	embedded, embErr := assetContent("references/example-report.md")
+	if embErr != nil {
+		t.Fatalf("reading embedded asset: %v", embErr)
+	}
+	expectedContent := insertMarkerAfterFrontmatter(embedded, versionMarker("1.0.0"))
+	if !bytes.Equal(restored, expectedContent) {
+		t.Errorf("restored file content does not match embedded asset (got %d bytes, want %d bytes)",
+			len(restored), len(expectedContent))
+	}
+
+	// Verify the summary mentions "updated".
+	output := buf3.String()
+	if !strings.Contains(output, "updated:") {
+		t.Errorf("summary should mention 'updated:', got:\n%s", output)
+	}
+	if !strings.Contains(output, "content changed") {
+		t.Errorf("summary should mention 'content changed', got:\n%s", output)
+	}
+}
+
+// TestRun_OverwriteOnDiff_SkipsIdentical verifies that tool-owned
+// reference files with identical content to the embedded version
+// appear in result.Skipped, not result.Updated.
+func TestRun_OverwriteOnDiff_SkipsIdentical(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n"), 0o644); err != nil {
+		t.Fatalf("creating go.mod: %v", err)
+	}
+
+	// First run: create all files.
+	var buf1 bytes.Buffer
+	_, err := Run(Options{
+		TargetDir: dir,
+		Version:   "1.0.0",
+		Stdout:    &buf1,
+	})
+	if err != nil {
+		t.Fatalf("first Run() returned error: %v", err)
+	}
+
+	// Second run with same version: reference files should be
+	// skipped (content identical), not updated.
+	var buf2 bytes.Buffer
+	result, err := Run(Options{
+		TargetDir: dir,
+		Version:   "1.0.0",
+		Stdout:    &buf2,
+	})
+	if err != nil {
+		t.Fatalf("second Run() returned error: %v", err)
+	}
+
+	if len(result.Updated) != 0 {
+		t.Errorf("expected 0 updated (identical content), got %d: %v", len(result.Updated), result.Updated)
+	}
+
+	// All 4 files should be skipped.
+	if len(result.Skipped) != 4 {
+		t.Errorf("expected 4 skipped, got %d: %v", len(result.Skipped), result.Skipped)
+	}
+
+	// Verify reference files are specifically in the skipped list.
+	skippedMap := make(map[string]bool)
+	for _, f := range result.Skipped {
+		skippedMap[f] = true
+	}
+	for _, ref := range []string{
+		filepath.Join(".opencode", "references", "doc-scoring-model.md"),
+		filepath.Join(".opencode", "references", "example-report.md"),
+	} {
+		if !skippedMap[ref] {
+			t.Errorf("expected %s in skipped list", ref)
 		}
 	}
 }

--- a/specs/016-agent-context-reduction/checklists/requirements.md
+++ b/specs/016-agent-context-reduction/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Agent Context Reduction
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The Context section references specific byte counts and token estimates from the analysis. These are measurements of the current state, not implementation details — they define the "before" baseline for SC-001.
+- References to `.opencode/` paths in FR-002 and FR-004 describe the user-facing file organization convention, not implementation specifics. The exact paths are a planning-phase decision.
+- FR-007 mentions "scaffold copies" and "byte-identical" — this is a behavioral requirement on the distribution mechanism, not an implementation constraint.
+- The spec deliberately avoids specifying file names, directory structures, or which scaffolding mechanism to use. These are planning decisions.

--- a/specs/016-agent-context-reduction/data-model.md
+++ b/specs/016-agent-context-reduction/data-model.md
@@ -1,0 +1,113 @@
+# Data Model: Agent Context Reduction
+
+**Feature**: 016-agent-context-reduction
+**Date**: 2026-03-02
+
+## Overview
+
+This feature has no application-level data model. The "data model" consists of the file organization for externalized agent prompt content and the scaffold system's file classification rules.
+
+## File Organization
+
+### Before (current state)
+
+```text
+.opencode/
+├── agents/
+│   └── gaze-reporter.md       # 17,775 bytes — full agent prompt
+└── command/
+    └── gaze.md                 # 1,308 bytes — command dispatcher
+
+internal/scaffold/assets/       # Embedded copies (byte-identical)
+├── agents/
+│   └── gaze-reporter.md
+└── command/
+    └── gaze.md
+```
+
+### After (target state)
+
+```text
+.opencode/
+├── agents/
+│   └── gaze-reporter.md       # ~12,100 bytes — reduced prompt
+├── command/
+│   └── gaze.md                # 1,308 bytes — unchanged
+└── references/
+    ├── example-report.md      # ~3,400 bytes — canonical example (extracted)
+    └── doc-scoring-model.md   # ~2,400 bytes — scoring model (extracted)
+
+internal/scaffold/assets/       # Embedded copies (byte-identical)
+├── agents/
+│   └── gaze-reporter.md
+├── command/
+│   └── gaze.md
+└── references/
+    ├── example-report.md
+    └── doc-scoring-model.md
+```
+
+## Scaffold File Classification
+
+The scaffold system distinguishes two file categories based on subdirectory:
+
+| Subdirectory | Category | On `gaze init` (file exists) | On `gaze init` (file absent) |
+|-------------|----------|------------------------------|------------------------------|
+| `agents/` | User-owned | Skip (preserve customizations) | Create |
+| `command/` | User-owned | Skip (preserve customizations) | Create |
+| `references/` | Tool-owned | Overwrite if content differs | Create |
+
+### Overwrite-on-Diff Decision Flow (references/ only)
+
+```text
+[File exists?]
+    │
+    ├── No → Create file → result.Created
+    │
+    └── Yes
+         │
+         ├── [Force=true] → Overwrite → result.Overwritten
+         │
+         └── [Force=false]
+              │
+              ├── [Is tool-owned (references/)?]
+              │    │
+              │    ├── Yes → [Content differs?]
+              │    │          │
+              │    │          ├── Yes → Overwrite → result.Updated
+              │    │          │
+              │    │          └── No → Skip → result.Skipped
+              │    │
+              │    └── No → Skip → result.Skipped
+              │
+              └── (end)
+```
+
+### Result Type Extension
+
+The scaffold `Result` struct gains a new `Updated` field to distinguish overwrite-on-diff from force-overwrite:
+
+| Field | Meaning | When populated |
+|-------|---------|---------------|
+| `Created` | File did not exist, was written | Always (new files) |
+| `Skipped` | File exists, not modified | User-owned files without `--force`; tool-owned files with same content |
+| `Overwritten` | File exists, replaced via `--force` | Any file when `Force=true` |
+| `Updated` | Tool-owned file exists, content differs, replaced | `references/` files when content changed |
+
+## Reference File Content
+
+### example-report.md
+
+Content extracted from `## Example Output` section of the current agent prompt (lines 382-453). Contains:
+
+- Prose framing: instructions for adapting the example to actual project data
+- Markdown code block: 65-line fictional full-mode report demonstrating all 5 sections (CRAP Summary, Quality Summary, Classification Summary, Overall Health Assessment) with correct emoji markers, table structure, metadata format, and recommendation formatting
+
+### doc-scoring-model.md
+
+Content extracted from `### Document-Enhanced Classification` subsection of `## Full Mode` in the current agent prompt (lines 201-250). Contains:
+
+- Document Signal Sources table (5 rows: readme, architecture_doc, specify_file, api_doc, other_md)
+- AI Inference Signals table (3 rows: ai_pattern, ai_layer, ai_corroboration)
+- Contradiction Penalty rule
+- Classification Thresholds table (3 rows: ≥80 contractual, 50-79 ambiguous, <50 incidental)

--- a/specs/016-agent-context-reduction/plan.md
+++ b/specs/016-agent-context-reduction/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Agent Context Reduction
+
+**Branch**: `016-agent-context-reduction` | **Date**: 2026-03-02 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/016-agent-context-reduction/spec.md`
+
+## Summary
+
+Reduce the gaze-reporter agent prompt from ~17,775 bytes to ≤13,300 bytes by externalizing two large content blocks into on-demand reference files and deduplicating repeated quadrant labels. The canonical example output (3,367 bytes) and document-enhanced classification scoring model (2,395 bytes) are moved to `.opencode/references/` and read by the agent via the Read tool only when needed. The scaffold system (`internal/scaffold/scaffold.go`) is updated to support overwrite-on-diff behavior for tool-owned reference files while preserving skip-if-present behavior for user-owned agent and command files.
+
+## Technical Context
+
+**Language/Version**: Go 1.24+ (scaffold Go code changes); Markdown (agent prompt and reference files)
+**Primary Dependencies**: `embed.FS` (Go standard library), OpenCode agent runtime
+**Storage**: Filesystem only (embedded assets via `embed.FS`, `.opencode/` directory)
+**Testing**: Standard library `testing` package (`go test -race -count=1 -short ./...`)
+**Target Platform**: Any platform running OpenCode with gaze installed
+**Project Type**: Single CLI binary — agent prompt and scaffold changes
+**Performance Goals**: Agent prompt ≤13,300 bytes (≥25% reduction from 17,775 bytes)
+**Constraints**: Reference files must be readable by the gaze-reporter agent's Read tool; scaffold copies must be byte-identical to live `.opencode/` copies
+**Scale/Scope**: 4 files modified (agent prompt, scaffold.go, 2 test files), 4 new files created (2 reference files + 2 scaffold copies)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Research Check
+
+| Principle | Status | Assessment |
+|-----------|--------|------------|
+| **I. Accuracy** | PASS | This feature does not alter Gaze's analysis engine, side effect detection, CRAP scoring, or any analytical output. It only restructures how the reporting agent's instructions are stored and loaded. No risk of introducing false positives or false negatives. |
+| **II. Minimal Assumptions** | PASS | No changes to how Gaze analyzes host projects. No new user-facing annotations or restructuring required. The agent reads reference files transparently. The only assumption is that `.opencode/references/` is readable, which is guaranteed by the scaffold system. |
+| **III. Actionable Output** | PASS | Report content, format, and actionability are preserved identically. The same emoji markers, tables, recommendations, and metrics are produced. Only the storage location of the agent's formatting instructions changes. |
+
+**Gate result**: PASS — All three principles satisfied. This feature operates entirely outside the analysis domain.
+
+### Post-Design Check
+
+| Principle | Status | Assessment |
+|-----------|--------|------------|
+| **I. Accuracy** | PASS | Design confirms: zero changes to analysis engine. Agent prompt instructions are identical in content, only relocated. Reference files contain verbatim extracts from the existing prompt. |
+| **II. Minimal Assumptions** | PASS | Design confirms: no new user-facing requirements. `gaze init` automatically creates reference files. Overwrite-on-diff ensures reference files stay current without user action. Agent gracefully degrades if files are missing. |
+| **III. Actionable Output** | PASS | Design confirms: SC-004 explicitly requires formatting fidelity preservation. The Quick Reference Example remains inline in the prompt as a formatting anchor. The canonical example is available on-demand for additional precision. |
+
+**Post-design gate result**: PASS — No constitution concerns.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/016-agent-context-reduction/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0: Research decisions
+├── data-model.md        # Phase 1: File organization model
+├── quickstart.md        # Phase 1: Verification guide
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+.opencode/
+├── agents/
+│   └── gaze-reporter.md            # Modified: reduced prompt (~12,100 bytes)
+├── command/
+│   └── gaze.md                     # Unchanged
+└── references/                     # NEW directory
+    ├── example-report.md           # NEW: canonical example (extracted)
+    └── doc-scoring-model.md        # NEW: scoring model (extracted)
+
+internal/scaffold/
+├── scaffold.go                     # Modified: overwrite-on-diff for references/
+├── scaffold_test.go                # Modified: updated counts, new tests
+└── assets/
+    ├── agents/
+    │   └── gaze-reporter.md        # Modified: sync with .opencode/ copy
+    ├── command/
+    │   └── gaze.md                 # Unchanged
+    └── references/                 # NEW directory
+        ├── example-report.md       # NEW: scaffold copy
+        └── doc-scoring-model.md    # NEW: scaffold copy
+
+cmd/gaze/
+└── main_test.go                    # Modified: updated expected file counts
+```
+
+**Structure Decision**: No new Go source files. The feature adds 2 markdown reference files (with scaffold copies) and modifies 4 existing files (agent prompt, scaffold.go, 2 test files). The `references/` subdirectory under `.opencode/` and `internal/scaffold/assets/` is the only new directory.
+
+## Complexity Tracking
+
+> No Constitution Check violations. No complexity justification needed.

--- a/specs/016-agent-context-reduction/quickstart.md
+++ b/specs/016-agent-context-reduction/quickstart.md
@@ -1,0 +1,113 @@
+# Quickstart: Agent Context Reduction
+
+**Feature**: 016-agent-context-reduction
+**Date**: 2026-03-02
+
+## Prerequisites
+
+- Go 1.24+ installed
+- Gaze repository cloned and on the `016-agent-context-reduction` branch
+- OpenCode installed (for manual verification of `/gaze` command)
+
+## Implementation Steps
+
+### Step 1: Create reference files
+
+Create two new files under `.opencode/references/` and their scaffold copies under `internal/scaffold/assets/references/`:
+
+1. `.opencode/references/example-report.md` — extract the `## Example Output` section from the current agent prompt
+2. `.opencode/references/doc-scoring-model.md` — extract the `### Document-Enhanced Classification` subsection from `## Full Mode`
+
+### Step 2: Update the agent prompt
+
+Edit `.opencode/agents/gaze-reporter.md`:
+
+1. Remove the `## Example Output` section (lines 382-453)
+2. Replace with a `## Reference Files` section containing read instructions
+3. Remove the `### Document-Enhanced Classification` subsection (lines 201-250)
+4. Replace with an instruction to read `doc-scoring-model.md` in full mode
+5. Replace the quadrant label listing in CRAP Mode (lines 123-127) with a cross-reference
+
+### Step 3: Update the scaffold copy
+
+Copy the updated `.opencode/agents/gaze-reporter.md` to `internal/scaffold/assets/agents/gaze-reporter.md` to keep them byte-identical.
+
+### Step 4: Update scaffold logic
+
+Edit `internal/scaffold/scaffold.go` to add overwrite-on-diff behavior for `references/` files. Add `Updated` field to the `Result` struct.
+
+### Step 5: Update tests
+
+Update hardcoded file counts and expected file lists in:
+- `internal/scaffold/scaffold_test.go`
+- `cmd/gaze/main_test.go`
+
+Add tests for the new overwrite-on-diff behavior.
+
+## Verification
+
+### Prompt Size Check
+
+```bash
+wc -c .opencode/agents/gaze-reporter.md
+# Expected: ≤13,300 bytes (down from 17,775)
+```
+
+### Scaffold Sync Check
+
+```bash
+diff .opencode/agents/gaze-reporter.md internal/scaffold/assets/agents/gaze-reporter.md
+diff .opencode/references/example-report.md internal/scaffold/assets/references/example-report.md
+diff .opencode/references/doc-scoring-model.md internal/scaffold/assets/references/doc-scoring-model.md
+# All should show no differences
+```
+
+### Build and Test
+
+```bash
+go build ./cmd/gaze
+go test -race -count=1 -short ./...
+```
+
+### GoReleaser Validation
+
+```bash
+goreleaser check
+```
+
+### Manual Formatting Verification
+
+Run `/gaze crap ./...` in OpenCode and verify:
+- Report starts with `🔍 Gaze CRAP Report`
+- CRAP Summary uses `📊` marker
+- Quadrant distribution uses correct emoji-prefixed labels
+- Tables are properly formatted with right-aligned numeric columns
+- Metadata line shows project, branch, version, Go version, date
+
+Run `/gaze` (full mode) and verify:
+- All 5 sections present with correct emoji markers
+- Document-Enhanced Classification applies correct signal weights
+- Recommendations are severity-prefixed with correct emojis
+
+### Scaffold Overwrite Verification
+
+```bash
+# Fresh scaffold
+mkdir /tmp/test-scaffold && cd /tmp/test-scaffold
+go mod init test && gaze init
+
+# Verify reference files created
+ls .opencode/references/
+# Expected: example-report.md  doc-scoring-model.md
+
+# Modify a reference file
+echo "modified" > .opencode/references/example-report.md
+
+# Re-run scaffold (without --force)
+gaze init
+# Expected: example-report.md listed as "updated" (overwritten)
+# Expected: agent and command files listed as "skipped"
+
+# Verify agent file was NOT overwritten
+# (its content should still match the original scaffold)
+```

--- a/specs/016-agent-context-reduction/research.md
+++ b/specs/016-agent-context-reduction/research.md
@@ -1,0 +1,77 @@
+# Research: Agent Context Reduction
+
+**Feature**: 016-agent-context-reduction
+**Date**: 2026-03-02
+
+## Decision 1: Reference File Directory Structure
+
+**Decision**: Store reference files under `.opencode/references/` with scaffold copies at `internal/scaffold/assets/references/`.
+
+**Rationale**: The existing scaffold convention maps `internal/scaffold/assets/<subdir>/<file>` to `.opencode/<subdir>/<file>`. Using a `references/` subdirectory clearly separates tool-owned reference content (overwrite-on-diff) from user-customizable prompt files (skip-if-present) in `agents/` and `command/`. The directory name is descriptive without being overly specific — it can hold any on-demand reference content in the future.
+
+**Alternatives considered**:
+
+| Alternative | Status | Reason rejected |
+|-------------|--------|-----------------|
+| `.opencode/examples/` + `.opencode/references/` (two directories) | Viable but unnecessary | Both files serve the same role (externalized prompt content). Splitting by content type adds complexity without benefit. A single `references/` directory is simpler. |
+| `.opencode/gaze/` (tool-namespaced) | Viable | Reasonable if multiple tools shared `.opencode/`, but currently only gaze uses it. Adds an extra path level with no benefit. |
+| Root-level files (`.opencode/gaze-report-example.md`) | Rejected | Mixes reference files with agent/command directories. Harder to reason about overwrite behavior at the directory level. |
+
+## Decision 2: File Naming
+
+**Decision**: Use `example-report.md` for the canonical example and `doc-scoring-model.md` for the classification scoring model.
+
+**Rationale**: Names are descriptive, concise, and follow lowercase-with-hyphens convention consistent with the existing `.opencode/` files. The `example-` prefix distinguishes the example from other reference material. The `doc-` prefix on the scoring model clarifies this is the document-enhanced classification model (vs. mechanical classification).
+
+## Decision 3: Scaffold Overwrite-on-Diff Strategy
+
+**Decision**: Classify embedded assets into two categories by subdirectory: "user-owned" files (`agents/`, `command/`) retain skip-if-present behavior, while "tool-owned" files (`references/`) use overwrite-on-diff behavior. The distinction is encoded via a helper function that checks the subdirectory prefix.
+
+**Rationale**: The spec requires that reference files be overwritten when their content differs from the embedded version (FR-010), while agent and command files retain their existing skip-if-present behavior. The simplest approach is a per-subdirectory policy rather than a per-file registry:
+
+- `agents/*` and `command/*` → skip-if-present (user may customize)
+- `references/*` → overwrite-if-changed (tool-owned, not user-customizable)
+
+This is implemented as a small change to the `fs.WalkDir` callback in `scaffold.go`: when `exists && !opts.Force`, check if the file is in a tool-owned directory. If yes, compare content and overwrite if different. If no, skip as before.
+
+**Alternatives considered**:
+
+| Alternative | Status | Reason rejected |
+|-------------|--------|-----------------|
+| `Force` flag only (existing behavior) | Insufficient | `--force` overwrites everything including user-customized agent prompts. The spec requires selective overwrite. |
+| Explicit overwrite list in Options | Viable but rigid | Requires callers to enumerate which files to overwrite. Fragile when new reference files are added. Subdirectory convention is self-maintaining. |
+| Content hash comparison for all files | Overkill | The comparison is only needed for tool-owned files. Comparing user-owned files would add confusing "updated" messages for intentionally customized files. |
+
+## Decision 4: Prompt Instruction Wording for On-Demand Reads
+
+**Decision**: Add a `## Reference Files` section to the agent prompt with explicit "MUST read" instructions, specifying the relative path from the project root.
+
+**Rationale**: The agent prompt needs to tell the LLM exactly where to find the externalized content and when to read it. The instruction should:
+
+1. Use the project root-relative path (`.opencode/references/example-report.md`) so the agent can construct the absolute path using its working directory.
+2. Be unambiguous about timing: "Read before producing your first report" for the example, "Read only in full mode when docscan returns documents" for the scoring model.
+3. Include a fallback instruction for missing files (use Quick Reference Example inline, warn with `> ⚠️`).
+
+The instruction replaces the removed content at roughly the same location in the prompt, so the agent encounters it at the appropriate point in its instruction processing.
+
+## Decision 5: Canonical Example Extraction Boundaries
+
+**Decision**: Extract the entire `## Example Output` section (lines 382-453 of the current prompt), including the prose framing ("Below is a concrete example...") and the full markdown code block. The replacement instruction references the external file.
+
+**Rationale**: The prose framing is tightly coupled to the example — it sets expectations about how to use it ("Adapt the data to the actual project — do not copy these specific numbers"). Moving both keeps the external file self-contained. The Quick Reference Example (lines 34-59) remains inline in the prompt as the primary formatting guide.
+
+## Decision 6: Scoring Model Extraction Boundaries
+
+**Decision**: Extract the `### Document-Enhanced Classification` subsection from within `## Full Mode` (lines 201-250 of the current prompt). Replace with a 3-line instruction directing the agent to read the reference file.
+
+**Rationale**: This subsection is entirely self-contained — it defines signal sources, weights, inference patterns, contradiction penalties, and thresholds. The surrounding Full Mode instructions reference it by section name ("see the Document-Enhanced Classification section below"), so the replacement instruction maintains the same reference point. The `> ⚠️ No documentation found` fallback instruction stays inline (it's only 2 lines and provides the agent's behavior when docscan fails, which is needed even without the scoring model).
+
+## Decision 7: Quadrant Label Deduplication Location
+
+**Decision**: Remove the explicit quadrant label listing from the CRAP Mode section (lines 123-127). Replace with: "Use the quadrant labels shown in the Quick Reference Example above."
+
+**Rationale**: The labels appear in three places: Quick Reference Example (lines 52-55), CRAP Mode (lines 123-127), and Emoji Vocabulary table (lines 296-299). Removing from CRAP Mode is optimal because:
+
+- The Quick Reference Example is the first thing the agent sees — highest attention weight.
+- The Emoji Vocabulary table is a formal reference with clear Role/Usage columns — removing from there would lose structured context.
+- The CRAP Mode listing is the least structured — it's a sub-bullet list within a numbered list. Replacing with a cross-reference is natural and low-risk.

--- a/specs/016-agent-context-reduction/spec.md
+++ b/specs/016-agent-context-reduction/spec.md
@@ -1,0 +1,108 @@
+# Feature Specification: Agent Context Reduction
+
+**Feature Branch**: `016-agent-context-reduction`
+**Created**: 2026-03-02
+**Status**: Complete
+**Input**: User description: "Reduce gaze-reporter agent prompt context window usage by externalizing canonical example output and document-enhanced classification scoring model into on-demand local files, and deduplicating repeated quadrant label patterns"
+
+## Context
+
+The gaze-reporter agent prompt consumes approximately 17,775 bytes (~4,443 tokens) every time the `/gaze` command is invoked. This is loaded into the conversation context regardless of which mode (crap, quality, full) the user requests. Analysis shows that 63.9% of the prompt consists of three sections that could be loaded on-demand or deduplicated:
+
+1. **Canonical Example Output** (3,367 bytes, 18.9%) — a 65-line fictional report used as a formatting reference. Always loaded but only needed as a formatting guide.
+2. **Document-Enhanced Classification scoring model** (2,395 bytes, 13.5%) — signal tables and thresholds used only in full mode when docscan returns documents. Never needed for crap or quality modes.
+3. **Repeated quadrant labels** (~200 bytes) — Q1-Q4 emoji labels appear in 3 separate locations.
+
+The prompt also has a scaffold copy that must stay in sync.
+
+## User Scenarios & Testing
+
+### User Story 1 - On-Demand Canonical Example (Priority: P1)
+
+A developer runs `/gaze crap ./...` to check CRAP scores. The gaze-reporter agent loads its prompt into the context window. The canonical example output (3,367 bytes) is not embedded in the prompt — instead, the agent reads it from a local file only when it needs formatting reference. This saves ~3,100 bytes from the always-on prompt cost.
+
+**Why this priority**: The canonical example is the single largest contiguous block in the prompt (18.9%). Moving it to an on-demand file produces the biggest context savings with minimal complexity. Every invocation of `/gaze` benefits.
+
+**Independent Test**: Run `/gaze crap ./...` and verify the report output still follows the correct formatting pattern (emoji markers, table structure, metadata line, quadrant distribution). Compare against the canonical example to confirm formatting fidelity is preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** the gaze-reporter agent prompt without the inline canonical example, **When** the agent is invoked via `/gaze crap ./...`, **Then** the agent reads the canonical example from a local file and produces correctly formatted output matching the expected emoji markers, table structure, and metadata format.
+2. **Given** the canonical example file exists at the expected path, **When** the agent reads it during report generation, **Then** the file contents match the original canonical example that was previously inline in the prompt.
+3. **Given** a new project where `gaze init` is run, **When** the scaffolding completes, **Then** the canonical example file is created alongside the agent prompt and command files.
+
+---
+
+### User Story 2 - On-Demand Scoring Model (Priority: P2)
+
+A developer runs `/gaze quality ./...` to check test quality metrics. The document-enhanced classification scoring model (2,395 bytes) is not needed for this mode. By externalizing it to a local file, the prompt is smaller for crap and quality modes. When the developer later runs `/gaze` (full mode) and docscan returns documents, the agent reads the scoring model file on demand.
+
+**Why this priority**: The scoring model is only relevant in full mode with documentation present. Externalizing it saves ~2,100 bytes for the two most common modes (crap and quality) with zero formatting risk, since the content is loaded identically when needed.
+
+**Independent Test**: Run `/gaze quality ./...` and confirm the scoring model is not loaded. Then run `/gaze` (full mode) and verify classification output correctly applies document-enhanced scoring with proper signal weights and thresholds.
+
+**Acceptance Scenarios**:
+
+1. **Given** the gaze-reporter agent prompt without the inline scoring model, **When** the agent runs in crap mode, **Then** the scoring model file is not read (no unnecessary tool calls), and the CRAP report is produced correctly.
+2. **Given** the agent runs in full mode and docscan returns documentation files, **When** the agent needs to apply document-enhanced classification, **Then** it reads the scoring model from the local file and applies signal weights, AI inference signals, contradiction penalties, and classification thresholds correctly.
+3. **Given** a new project where `gaze init` is run, **When** the scaffolding completes, **Then** the scoring model file is created alongside the other scaffolded files.
+
+---
+
+### User Story 3 - Deduplicated Quadrant Labels (Priority: P3)
+
+The quadrant emoji labels (Q1-Q4) currently appear in three separate locations within the prompt: the Quick Reference Example, the CRAP Mode section, and the Emoji Vocabulary table. One of these three occurrences is replaced with a cross-reference, reducing redundancy by ~200 bytes.
+
+**Why this priority**: Small savings with very low risk. The labels remain in two locations (Quick Reference Example and Emoji Vocabulary), providing sufficient coverage for the agent to produce correct output.
+
+**Independent Test**: Run `/gaze crap ./...` and verify the quadrant distribution table uses the correct emoji-prefixed labels (Q1 Safe, Q2 Complex But Tested, Q4 Dangerous, Q3 Needs Tests) with proper emoji markers.
+
+**Acceptance Scenarios**:
+
+1. **Given** the deduplicated prompt with quadrant labels removed from the CRAP Mode section, **When** the agent produces a CRAP report with quadrant distribution, **Then** all four quadrant rows use the correct emoji-prefixed labels matching the Quick Reference Example.
+
+---
+
+### Edge Cases
+
+- What happens when the canonical example file is missing or unreadable? The agent should produce output using the Quick Reference Example in the prompt as its formatting guide and include a warning that the full example could not be loaded.
+- What happens when the scoring model file is missing during full mode? The agent should skip document-enhanced classification and use mechanical-only results, with a warning callout.
+- What happens when `gaze init` is run in a project that already has older scaffold files without the new reference files? The new files should be created. Reference files whose content differs from the embedded scaffold version should be overwritten with the latest version. Existing agent and command files follow their current skip-if-present behavior.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The gaze-reporter agent prompt MUST NOT contain the canonical example output inline. It MUST instead contain an instruction directing the agent to read the example from a local file.
+- **FR-002**: The canonical example MUST be stored in a local file accessible to the agent via the Read tool, at a path under `.opencode/`.
+- **FR-003**: The gaze-reporter agent prompt MUST NOT contain the Document-Enhanced Classification scoring model inline. It MUST instead contain an instruction directing the agent to read the scoring model from a local file when running in full mode with docscan results.
+- **FR-004**: The scoring model MUST be stored in a local file accessible to the agent via the Read tool, at a path under `.opencode/`.
+- **FR-005**: The quadrant emoji labels in the CRAP Mode section of the prompt MUST be replaced with a cross-reference to the Quick Reference Example, removing one of the three redundant listings.
+- **FR-006**: The `gaze init` scaffolding MUST create the new reference files (canonical example and scoring model) alongside the existing agent and command files.
+- **FR-007**: The scaffold copies MUST remain byte-identical to the live copies under `.opencode/`.
+- **FR-008**: The agent prompt instructions for reading external files MUST be explicit and mandatory (e.g., "Read this file before producing your first report").
+- **FR-009**: The agent MUST gracefully handle missing reference files — using inline fallbacks (Quick Reference Example) and warning callouts rather than failing silently.
+- **FR-010**: When `gaze init` runs and a reference file already exists with content that differs from the embedded scaffold version, it MUST overwrite the file with the latest version. Agent and command files retain their existing skip-if-present behavior.
+
+### Key Entities
+
+- **Agent Prompt**: The gaze-reporter system prompt loaded into the context window on every `/gaze` invocation. The primary artifact being optimized.
+- **Reference File**: A local file containing content externalized from the prompt, read on-demand by the agent via tool calls. Two instances: canonical example and scoring model.
+- **Scaffold Asset**: An embedded copy of a reference file distributed via `gaze init` for new projects.
+
+## Clarifications
+
+### Session 2026-03-02
+
+- Q: When `gaze init` runs and reference files already exist, should it skip them (like agent/command files) or overwrite them? → A: Overwrite reference files when content differs from the embedded scaffold version. Agent and command files keep their existing skip-if-present behavior.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: The always-on agent prompt size is reduced by at least 25% (from ~17,775 bytes to no more than 13,300 bytes).
+- **SC-002**: CRAP-mode and quality-mode invocations do not load the scoring model file (zero unnecessary tool calls for mode-irrelevant content).
+- **SC-003**: Full-mode invocations with docscan results load the scoring model and produce output with correct document-enhanced classification matching pre-change behavior.
+- **SC-004**: Report formatting fidelity is preserved — emoji markers, table structure, metadata format, quadrant labels, and grade-to-emoji mapping match the pre-change output for identical input data.
+- **SC-005**: The `gaze init` command scaffolds the new reference files into the correct directories without requiring user intervention.
+- **SC-006**: The scaffold copies and live `.opencode/` copies remain byte-identical after changes.

--- a/specs/016-agent-context-reduction/tasks.md
+++ b/specs/016-agent-context-reduction/tasks.md
@@ -1,0 +1,188 @@
+# Tasks: Agent Context Reduction
+
+**Input**: Design documents from `/specs/016-agent-context-reduction/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Tests**: No automated test tasks for the prompt changes — formatting fidelity is verified manually via `/gaze` invocations (see quickstart.md). Scaffold logic changes require Go test updates (included as implementation tasks).
+
+**Organization**: Tasks are grouped by user story. US1 and US2 modify the agent prompt and create reference files. US3 is a small prompt edit. Scaffold logic (Phase 2) is a blocking prerequisite since reference files must be scaffoldable before verifying the full workflow.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+```text
+.opencode/agents/gaze-reporter.md           # Agent prompt (live copy)
+.opencode/references/example-report.md      # NEW: canonical example
+.opencode/references/doc-scoring-model.md   # NEW: scoring model
+internal/scaffold/assets/                    # Embedded scaffold copies
+internal/scaffold/scaffold.go               # Scaffold logic
+internal/scaffold/scaffold_test.go          # Scaffold tests
+cmd/gaze/main_test.go                       # CLI tests
+```
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: No project initialization needed — this feature modifies existing files and adds new ones within the existing project structure.
+
+*Phase 1 is empty for this feature. Proceed directly to Phase 2.*
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Update scaffold logic to support overwrite-on-diff for tool-owned reference files. This must be complete before reference files can be properly scaffolded and tested.
+
+- [x] T001 Add an `Updated` field (`[]string`) to the `Result` struct in internal/scaffold/scaffold.go. This field tracks tool-owned files that were overwritten because their content differed from the embedded version.
+- [x] T002 Add a `isToolOwned(relPath string) bool` helper function in internal/scaffold/scaffold.go that returns `true` when the relative path starts with `"references/"`. This determines which files use overwrite-on-diff vs skip-if-present behavior.
+- [x] T003 Update the `fs.WalkDir` callback in the `Run` function in internal/scaffold/scaffold.go to implement overwrite-on-diff: when a file exists, `Force` is false, and `isToolOwned` returns true, read the existing file content, compare with the embedded content (after marker insertion), and overwrite if different (appending to `result.Updated`), or skip if identical (appending to `result.Skipped`). The existing skip-if-present path for user-owned files remains unchanged.
+- [x] T004 Update the summary output section of the `Run` function in internal/scaffold/scaffold.go to print `Updated` files (e.g., `"  updated: %s (content changed)\n"`).
+
+**Checkpoint**: Scaffold logic supports two file categories. Reference files will be auto-updated on `gaze init` when content changes. Agent/command files retain skip-if-present behavior.
+
+---
+
+## Phase 3: User Story 1 — On-Demand Canonical Example (Priority: P1) MVP
+
+**Goal**: Extract the canonical example output from the agent prompt into `.opencode/references/example-report.md` and replace inline content with a read instruction.
+
+**Independent Test**: Run `wc -c .opencode/agents/gaze-reporter.md` and verify the file is smaller by ~3,100 bytes. Run `diff` between `.opencode/references/example-report.md` and internal/scaffold/assets/references/example-report.md to confirm sync.
+
+### Implementation for User Story 1
+
+- [x] T005 [US1] Create .opencode/references/example-report.md by extracting the entire `## Example Output` section (lines 382-453) from .opencode/agents/gaze-reporter.md. Include both the prose framing paragraph ("Below is a concrete example...") and the full markdown code block. The file should be self-contained — readable without context from the agent prompt.
+- [x] T006 [US1] Remove the `## Example Output` section (lines 382-453) from .opencode/agents/gaze-reporter.md. In its place, add a `## Reference Files` section with the following instruction: "Before producing your first report, read the formatting reference from `.opencode/references/example-report.md` using the Read tool. This file contains the definitive example of the expected output format. If the file cannot be read, use the Quick Reference Example above as your formatting guide and include: `> ⚠️ Could not load full formatting reference.`"
+- [x] T007 [P] [US1] Create internal/scaffold/assets/references/example-report.md as a byte-identical copy of .opencode/references/example-report.md.
+- [x] T008 [US1] Copy .opencode/agents/gaze-reporter.md to internal/scaffold/assets/agents/gaze-reporter.md to keep the scaffold copy in sync after the example removal.
+
+**Checkpoint**: The canonical example is externalized. The prompt is ~3,100 bytes smaller. The scaffold includes the reference file. Formatting instructions reference the external file.
+
+---
+
+## Phase 4: User Story 2 — On-Demand Scoring Model (Priority: P2)
+
+**Goal**: Extract the Document-Enhanced Classification scoring model from the agent prompt into `.opencode/references/doc-scoring-model.md` and replace inline content with a conditional read instruction.
+
+**Independent Test**: Run `wc -c .opencode/agents/gaze-reporter.md` and verify the file is ≤13,300 bytes total. Run `diff` between `.opencode/references/doc-scoring-model.md` and its scaffold copy.
+
+### Implementation for User Story 2
+
+- [x] T009 [US2] Create .opencode/references/doc-scoring-model.md by extracting the `### Document-Enhanced Classification` subsection (lines 201-250, adjusted for T006 edits) from .opencode/agents/gaze-reporter.md. Include the Document Signal Sources table, AI Inference Signals table, Contradiction Penalty rule, and Classification Thresholds table. Keep the fallback warning instruction (`> ⚠️ No documentation found — classification uses mechanical signals only.`) inline in the prompt.
+- [x] T010 [US2] Remove the `### Document-Enhanced Classification` subsection from the `## Full Mode` section in .opencode/agents/gaze-reporter.md. Replace with a 3-line instruction: "If `gaze docscan` returns documentation files, read the document-enhanced classification scoring model from `.opencode/references/doc-scoring-model.md` using the Read tool. Apply the signal weights, thresholds, and contradiction penalties defined there. If the file cannot be read, skip document-enhanced scoring and use mechanical-only classification."
+- [x] T011 [P] [US2] Create internal/scaffold/assets/references/doc-scoring-model.md as a byte-identical copy of .opencode/references/doc-scoring-model.md.
+- [x] T012 [US2] Copy .opencode/agents/gaze-reporter.md to internal/scaffold/assets/agents/gaze-reporter.md to keep the scaffold copy in sync after the scoring model removal.
+
+**Checkpoint**: The scoring model is externalized. The prompt is ≤13,300 bytes. Full-mode runs will read the scoring model on demand. CRAP and quality modes never load it.
+
+---
+
+## Phase 5: User Story 3 — Deduplicated Quadrant Labels (Priority: P3)
+
+**Goal**: Remove one of three redundant quadrant label listings from the agent prompt.
+
+**Independent Test**: Verify quadrant labels still appear in the Quick Reference Example (lines 52-55) and Emoji Vocabulary table (lines 296-299, adjusted). Verify the CRAP Mode section now has a cross-reference instead of explicit labels.
+
+### Implementation for User Story 3
+
+- [x] T013 [US3] In .opencode/agents/gaze-reporter.md, locate the CRAP Mode section's quadrant label listing (4 lines defining Q1-Q4 with emojis, currently around lines 123-127 adjusted for prior edits). Replace these 4 lines with: "Use the quadrant labels shown in the Quick Reference Example above (🟢 Q1 — Safe, 🟡 Q2 — Complex But Tested, 🔴 Q4 — Dangerous, ⚪ Q3 — Needs Tests)."
+- [x] T014 [US3] Copy .opencode/agents/gaze-reporter.md to internal/scaffold/assets/agents/gaze-reporter.md to keep the scaffold copy in sync.
+
+**Checkpoint**: Quadrant labels appear in exactly 2 locations (Quick Reference Example + Emoji Vocabulary). CRAP Mode section uses a cross-reference. ~200 bytes saved.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Update tests, documentation, and validate the complete implementation.
+
+- [x] T015 Update all hardcoded file count assertions in internal/scaffold/scaffold_test.go from `2` to `4` (in TestRun_CreatesFiles, TestRun_SkipsExisting, TestRun_ForceOverwrites, TestRun_NoGoMod_PrintsWarning, TestAssetPaths_Returns2Files). Update expected file lists and maps to include `references/example-report.md` and `references/doc-scoring-model.md`.
+- [x] T016 Add a new test `TestRun_OverwriteOnDiff_ReferencesOnly` in internal/scaffold/scaffold_test.go that verifies: (a) first run creates all 4 files, (b) second run without `--force` skips user-owned files but also skips unchanged reference files, (c) after modifying a reference file on disk, third run without `--force` overwrites the changed reference file (appears in `result.Updated`) while still skipping user-owned files.
+- [x] T017 Add a new test `TestRun_OverwriteOnDiff_SkipsIdentical` in internal/scaffold/scaffold_test.go that verifies: when reference files exist with identical content to the embedded version, they appear in `result.Skipped` (not `Updated`).
+- [x] T018 Update expected file counts and file lists in cmd/gaze/main_test.go (TestRunInit_CreatesFiles and TestRunInit_ForceFlag) from 2 to 4 files, adding the two reference file paths.
+- [x] T019 [P] Verify prompt size meets SC-001 by running `wc -c .opencode/agents/gaze-reporter.md` and confirming ≤13,300 bytes.
+- [x] T020 [P] Verify scaffold sync meets SC-006 by running `diff` between all `.opencode/` files and their `internal/scaffold/assets/` counterparts.
+- [x] T021 Run `go test -race -count=1 -short ./...` to verify all tests pass after changes.
+- [x] T022 Run `go build ./cmd/gaze` to verify the binary builds with the new embedded assets.
+- [x] T023 [P] Update AGENTS.md "Recent Changes" section to add an entry for 016-agent-context-reduction documenting the prompt size reduction and scaffold overwrite-on-diff behavior.
+- [x] T024 [P] Update AGENTS.md "Spec Organization" section to add the 016-agent-context-reduction entry if missing.
+
+**Checkpoint**: All tests pass, documentation updated, prompt size verified. Feature is ready for manual formatting verification via `/gaze` commands.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Empty — no setup tasks
+- **Foundational (Phase 2)**: T001-T004 are sequential — each builds on the previous within scaffold.go. MUST complete before US1 work to ensure reference files can be scaffolded correctly.
+- **User Story 1 (Phase 3)**: Depends on Phase 2 (scaffold must support references/). T005-T008: T005 creates the reference file, T006 updates the prompt (can follow T005), T007 can run in parallel with T006 (different files), T008 depends on T006.
+- **User Story 2 (Phase 4)**: Depends on US1 (T006 adds the Reference Files section that T010 extends). T009-T012 follow the same pattern as US1.
+- **User Story 3 (Phase 5)**: Depends on US2 (T013 modifies the prompt after US2 edits are complete). T013-T014 are sequential.
+- **Polish (Phase 6)**: T015-T018 depend on all prompt and scaffold changes being complete. T019-T024 are validation and can run after T015-T018.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Depends on Phase 2 (scaffold overwrite-on-diff) — core extraction
+- **User Story 2 (P2)**: Depends on US1 (Reference Files section must exist before adding scoring model instruction)
+- **User Story 3 (P3)**: Depends on US2 (prompt must be in final form before dedup to get correct line references)
+
+### Parallel Opportunities
+
+- T007 can run in parallel with T006 (different files: scaffold copy vs prompt edit)
+- T011 can run in parallel with T010 (different files: scaffold copy vs prompt edit)
+- T019, T020, T023, T024 can all run in parallel (independent validation and documentation tasks)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After T005 (reference file created), launch in parallel:
+Task: "Remove Example Output section from agent prompt (T006)"
+Task: "Create scaffold copy of example-report.md (T007)"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 2: Scaffold overwrite-on-diff (T001-T004)
+2. Complete Phase 3: Extract canonical example (T005-T008)
+3. **STOP and VALIDATE**: Verify prompt size reduced by ~3,100 bytes, scaffold sync passes
+4. If formatting fidelity confirmed via manual test, proceed to US2
+
+### Incremental Delivery
+
+1. T001-T004 → Scaffold supports tool-owned files
+2. T005-T008 → Canonical example externalized (~3,100 bytes saved)
+3. T009-T012 → Scoring model externalized (~2,100 bytes saved)
+4. T013-T014 → Quadrant labels deduplicated (~200 bytes saved)
+5. T015-T024 → Tests, validation, documentation
+
+### Full Verification
+
+1. Run `wc -c .opencode/agents/gaze-reporter.md` → ≤13,300 bytes
+2. Run `diff` on all 4 file pairs → byte-identical
+3. Run `go test -race -count=1 -short ./...` → all pass
+4. Run `go build ./cmd/gaze` → builds cleanly
+5. Run `/gaze crap ./...` in OpenCode → correct formatting
+6. Run `/gaze` (full mode) in OpenCode → correct classification
+
+---
+
+## Notes
+
+- This feature modifies 1 Go source file (`scaffold.go`), 2 Go test files, and 1 markdown prompt file. It creates 4 new markdown files (2 reference files + 2 scaffold copies).
+- US2 depends on US1 because the `## Reference Files` section created by T006 is where T010 adds the scoring model instruction. Building the section incrementally avoids conflicts.
+- US3 depends on US2 to avoid line-number confusion — the prompt is edited from bottom to top (example at line 382 first, scoring model at line 201 second, quadrant labels at line 123 third).
+- The scaffold `TestEmbeddedAssetsMatchSource` drift detection test automatically validates sync for any new files added to `assets/` — no additional drift test is needed.
+- SC-002 (no scoring model load in crap/quality modes), SC-003 (correct classification in full mode), and SC-004 (formatting fidelity) are verified manually via `/gaze` invocations per quickstart.md — these are LLM behavioral properties that cannot be validated by automated Go tests.


### PR DESCRIPTION
## Summary

- Externalize canonical example output (3,100 bytes) and document-enhanced classification scoring model (2,400 bytes) into `.opencode/references/` files loaded on demand via Read tool, reducing the gaze-reporter agent prompt from 17,775 to 13,050 bytes (26.6% reduction)
- Add scaffold overwrite-on-diff behavior for tool-owned reference files (`references/` directory) while preserving skip-if-present for user-owned files (`agents/`, `command/`)
- Deduplicate quadrant labels to 2 locations (Quick Reference Example + Emoji Vocabulary table)

## Changes

### Scaffold (`internal/scaffold/`)
- `Result` struct gains `Updated []string` field for tracking overwrite-on-diff operations
- `isToolOwned(relPath)` helper classifies files by subdirectory: `references/` = tool-owned (overwrite-on-diff), `agents/`/`command/` = user-owned (skip-if-present)
- `WalkDir` callback implements overwrite-on-diff: when a tool-owned file exists with different content, it is replaced without `--force`
- `MkdirAll` guard added before overwrite-on-diff write for resilience
- `printSummary` `--force` hint scoped to user-owned files only (tool-owned files auto-update)
- Scaffold now manages 4 files (up from 2)

### Agent prompt (`.opencode/agents/gaze-reporter.md`)
- Removed `## Example Output` section → externalized to `.opencode/references/example-report.md`
- Removed `### Document-Enhanced Classification` subsection → externalized to `.opencode/references/doc-scoring-model.md`
- Added `## Reference Files` section with Read tool instructions and fallback behavior
- Replaced CRAP Mode quadrant listing with cross-reference to Quick Reference Example

### Tests
- `TestRun_OverwriteOnDiff_ReferencesOnly`: verifies create → skip-identical → overwrite-changed lifecycle, including post-overwrite content verification
- `TestRun_OverwriteOnDiff_SkipsIdentical`: verifies identical tool-owned files appear in `Skipped`, not `Updated`
- All existing file count assertions updated from 2 to 4
- Stale SC references cleaned from test GoDoc comments

### Verification
- Prompt size: 13,050 bytes ≤ 13,300 target ✅
- Scaffold sync: all 4 file pairs byte-identical ✅
- `go test -race -count=1 -short ./...` passes ✅
- `go build ./cmd/gaze` succeeds ✅
- Review council: APPROVE (all 3 reviewers) ✅

## Spec

`specs/016-agent-context-reduction/` — includes spec.md, plan.md, tasks.md, research.md, data-model.md, quickstart.md, checklists/