### PR TITLE
fix: update Homebrew cask checksums after macOS signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,3 +139,52 @@ jobs:
           gh release upload "${GITHUB_REF_NAME}" --repo "$GITHUB_REPOSITORY" checksums.txt --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Homebrew cask checksums
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+
+          # Compute signed checksums
+          ARM64_SHA=$(shasum -a 256 "./signed/gaze_${VERSION}_darwin_arm64.tar.gz" | awk '{print $1}')
+          AMD64_SHA=$(shasum -a 256 "./signed/gaze_${VERSION}_darwin_amd64.tar.gz" | awk '{print $1}')
+
+          echo "darwin_arm64 SHA256: $ARM64_SHA"
+          echo "darwin_amd64 SHA256: $AMD64_SHA"
+
+          # Clone the Homebrew tap
+          git clone "https://x-access-token:${HOMEBREW_TAP_GITHUB_TOKEN}@github.com/unbound-force/homebrew-tap.git" tap
+          cd tap
+
+          CASK_FILE="Casks/gaze.rb"
+          if [ ! -f "$CASK_FILE" ]; then
+            echo "::error::Cask file not found: $CASK_FILE"
+            exit 1
+          fi
+
+          # Update darwin checksums in the cask file
+          # The cask has on_intel (amd64) then on_arm (arm64) blocks under on_macos
+          # Use awk to replace the correct sha256 values based on URL context
+          awk -v amd64="$AMD64_SHA" -v arm64="$ARM64_SHA" '
+            /darwin_amd64/ { found_amd64=1 }
+            /darwin_arm64/ { found_arm64=1 }
+            /sha256/ && found_amd64 {
+              sub(/sha256 "[^"]*"/, "sha256 \"" amd64 "\"")
+              found_amd64=0
+            }
+            /sha256/ && found_arm64 {
+              sub(/sha256 "[^"]*"/, "sha256 \"" arm64 "\"")
+              found_arm64=0
+            }
+            { print }
+          ' "$CASK_FILE" > "${CASK_FILE}.tmp"
+          mv "${CASK_FILE}.tmp" "$CASK_FILE"
+
+          # Commit and push
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$CASK_FILE"
+          git diff --cached --quiet && { echo "No checksum changes needed"; exit 0; }
+          git commit -m "Update macOS checksums for gaze v${VERSION} (post-signing)"
+          git push
+        env:
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Fixes Homebrew `brew upgrade` SHA-256 mismatch caused by the `sign-macos` job replacing release binaries with signed versions without updating the cask formula
- Adds an "Update Homebrew cask checksums" step to the `sign-macos` job that clones `unbound-force/homebrew-tap`, rewrites the darwin `sha256` values in `Casks/gaze.rb` to match the signed binaries, and pushes the update

## Root Cause

GoReleaser publishes the Homebrew cask with **pre-signing** checksums during the `release` job. The `sign-macos` job then replaces the darwin binaries with codesigned/notarized versions (different checksums) and updates `checksums.txt`, but never updates the cask formula. This causes every `brew upgrade` to fail with a SHA-256 mismatch.

The v1.2.6 cask in `unbound-force/homebrew-tap` has already been fixed manually ([commit](https://github.com/unbound-force/homebrew-tap/commit/d37e48507efe57a32f5b833867ce3be3994dc8b3)).