### PR TITLE
test: strengthen contract assertions for Q3 functions

### DIFF
--- a/internal/aireport/output_test.go
+++ b/internal/aireport/output_test.go
@@ -9,22 +9,33 @@ import (
 )
 
 // TestWriteStepSummary_EmptyPath verifies that an empty path emits a warning
-// and returns without writing anything.
+// identifying the specific condition and returns without writing anything.
 func TestWriteStepSummary_EmptyPath(t *testing.T) {
 	var stderr strings.Builder
 	WriteStepSummary("", "content", &stderr)
-	if !strings.Contains(stderr.String(), "warning") {
-		t.Errorf("expected warning for empty path, got: %q", stderr.String())
+	msg := stderr.String()
+	if !strings.Contains(msg, "warning") {
+		t.Errorf("expected warning for empty path, got: %q", msg)
+	}
+	if !strings.Contains(msg, "empty") {
+		t.Errorf("expected warning to mention 'empty', got: %q", msg)
 	}
 }
 
 // TestWriteStepSummary_RelativePath verifies that a relative path emits a
-// warning and returns without writing anything.
+// warning identifying the path and condition, and returns without writing.
 func TestWriteStepSummary_RelativePath(t *testing.T) {
 	var stderr strings.Builder
 	WriteStepSummary("relative/path/summary.md", "content", &stderr)
-	if !strings.Contains(stderr.String(), "warning") {
-		t.Errorf("expected warning for relative path, got: %q", stderr.String())
+	msg := stderr.String()
+	if !strings.Contains(msg, "warning") {
+		t.Errorf("expected warning for relative path, got: %q", msg)
+	}
+	if !strings.Contains(msg, "not an absolute path") {
+		t.Errorf("expected warning to mention 'not an absolute path', got: %q", msg)
+	}
+	if !strings.Contains(msg, "relative/path/summary.md") {
+		t.Errorf("expected warning to include the path, got: %q", msg)
 	}
 }
 
@@ -46,10 +57,12 @@ func TestWriteStepSummary_ExistingFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(data), existing) {
-		t.Errorf("expected existing content preserved, got: %s", data)
+	content := string(data)
+	// Verify append semantics: existing content must appear before appended.
+	if !strings.HasPrefix(content, existing) {
+		t.Errorf("expected content to start with existing text (append, not overwrite), got: %s", data)
 	}
-	if !strings.Contains(string(data), "# Appended") {
+	if !strings.Contains(content, "# Appended") {
 		t.Errorf("expected appended content, got: %s", data)
 	}
 	if stderr.String() != "" {
@@ -73,6 +86,15 @@ func TestWriteStepSummary_NonExistentFile(t *testing.T) {
 	if !strings.Contains(string(data), "# New content") {
 		t.Errorf("expected written content, got: %s", data)
 	}
+	// Verify file permissions (0644).
+	info, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("stat created file: %v", err)
+	}
+	perm := info.Mode().Perm()
+	if perm != 0644 {
+		t.Errorf("expected file permissions 0644, got %04o", perm)
+	}
 	if stderr.String() != "" {
 		t.Errorf("expected no warning, got: %q", stderr.String())
 	}
@@ -85,7 +107,6 @@ func TestWriteStepSummary_UnwritablePath(t *testing.T) {
 		t.Skip("chmod not reliable on Windows")
 	}
 	dir := t.TempDir()
-	// Make the directory unwritable so creating a file inside it fails.
 	if err := os.Chmod(dir, 0555); err != nil {
 		t.Fatal(err)
 	}
@@ -95,8 +116,12 @@ func TestWriteStepSummary_UnwritablePath(t *testing.T) {
 	var stderr strings.Builder
 	WriteStepSummary(p, "content", &stderr)
 
-	if !strings.Contains(stderr.String(), "warning") {
-		t.Errorf("expected warning for unwritable path, got: %q", stderr.String())
+	msg := stderr.String()
+	if !strings.Contains(msg, "warning") {
+		t.Errorf("expected warning for unwritable path, got: %q", msg)
+	}
+	if !strings.Contains(msg, "could not open") {
+		t.Errorf("expected warning to mention 'could not open', got: %q", msg)
 	}
 }
 
@@ -120,8 +145,12 @@ func TestWriteStepSummary_SymlinkPath(t *testing.T) {
 	WriteStepSummary(link, "content", &stderr)
 
 	// O_NOFOLLOW should cause ELOOP; warning emitted, no panic.
-	if !strings.Contains(stderr.String(), "warning") {
-		t.Errorf("expected warning for symlink path, got: %q", stderr.String())
+	msg := stderr.String()
+	if !strings.Contains(msg, "warning") {
+		t.Errorf("expected warning for symlink path, got: %q", msg)
+	}
+	if !strings.Contains(msg, "symlink") {
+		t.Errorf("expected warning to mention 'symlink', got: %q", msg)
 	}
 	// The target file must not have been written to.
 	data, _ := os.ReadFile(target)

--- a/internal/aireport/threshold_test.go
+++ b/internal/aireport/threshold_test.go
@@ -38,6 +38,15 @@ func TestEvaluateThresholds_ZeroThresholdWithZeroActual(t *testing.T) {
 	if !results[0].Passed {
 		t.Error("expected result.Passed=true")
 	}
+	if results[0].Name != "CRAPload" {
+		t.Errorf("expected Name=CRAPload, got %q", results[0].Name)
+	}
+	if results[0].Actual != 0 {
+		t.Errorf("expected Actual=0, got %d", results[0].Actual)
+	}
+	if results[0].Limit != 0 {
+		t.Errorf("expected Limit=0, got %d", results[0].Limit)
+	}
 }
 
 // TestEvaluateThresholds_ZeroThresholdWithPositiveActual verifies that *0 threshold
@@ -72,8 +81,20 @@ func TestEvaluateThresholds_BelowLimit(t *testing.T) {
 	if !passed {
 		t.Error("expected passed=true when actual < limit")
 	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
 	if !results[0].Passed {
 		t.Error("expected result.Passed=true")
+	}
+	if results[0].Name != "CRAPload" {
+		t.Errorf("expected Name=CRAPload, got %q", results[0].Name)
+	}
+	if results[0].Actual != 3 {
+		t.Errorf("expected Actual=3, got %d", results[0].Actual)
+	}
+	if results[0].Limit != 5 {
+		t.Errorf("expected Limit=5, got %d", results[0].Limit)
 	}
 }
 
@@ -87,8 +108,20 @@ func TestEvaluateThresholds_AboveLimit(t *testing.T) {
 	if passed {
 		t.Error("expected passed=false when actual > limit")
 	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
 	if results[0].Passed {
 		t.Error("expected result.Passed=false")
+	}
+	if results[0].Name != "CRAPload" {
+		t.Errorf("expected Name=CRAPload, got %q", results[0].Name)
+	}
+	if results[0].Actual != 8 {
+		t.Errorf("expected Actual=8, got %d", results[0].Actual)
+	}
+	if results[0].Limit != 5 {
+		t.Errorf("expected Limit=5, got %d", results[0].Limit)
 	}
 }
 
@@ -123,11 +156,29 @@ func TestEvaluateThresholds_AllThreeFields(t *testing.T) {
 	if !byName["CRAPload"].Passed {
 		t.Error("expected CRAPload to pass")
 	}
+	if byName["CRAPload"].Actual != 4 {
+		t.Errorf("expected CRAPload.Actual=4, got %d", byName["CRAPload"].Actual)
+	}
+	if byName["CRAPload"].Limit != 5 {
+		t.Errorf("expected CRAPload.Limit=5, got %d", byName["CRAPload"].Limit)
+	}
 	if byName["GazeCRAPload"].Passed {
 		t.Error("expected GazeCRAPload to fail")
 	}
+	if byName["GazeCRAPload"].Actual != 2 {
+		t.Errorf("expected GazeCRAPload.Actual=2, got %d", byName["GazeCRAPload"].Actual)
+	}
+	if byName["GazeCRAPload"].Limit != 1 {
+		t.Errorf("expected GazeCRAPload.Limit=1, got %d", byName["GazeCRAPload"].Limit)
+	}
 	if !byName["AvgContractCoverage"].Passed {
 		t.Error("expected AvgContractCoverage to pass")
+	}
+	if byName["AvgContractCoverage"].Actual != 60 {
+		t.Errorf("expected AvgContractCoverage.Actual=60, got %d", byName["AvgContractCoverage"].Actual)
+	}
+	if byName["AvgContractCoverage"].Limit != 50 {
+		t.Errorf("expected AvgContractCoverage.Limit=50, got %d", byName["AvgContractCoverage"].Limit)
 	}
 }
 
@@ -190,6 +241,54 @@ func TestEvaluateThresholds_NilPayload(t *testing.T) {
 	}
 	if len(results) != 1 || !results[0].Passed {
 		t.Errorf("unexpected results: %+v", results)
+	}
+}
+
+// TestEvaluateThresholds_MinContractCoverageDirection verifies that
+// MinContractCoverage uses >= (not <=). actual=60, limit=60 should
+// pass (60 >= 60 is true). actual=59, limit=60 should fail.
+func TestEvaluateThresholds_MinContractCoverageDirection(t *testing.T) {
+	// Boundary: actual == limit → should pass (>= semantics).
+	payload := &ReportPayload{
+		Summary: ReportSummary{AvgContractCoverage: 60},
+	}
+	cfg := ThresholdConfig{MinContractCoverage: intPtr(60)}
+	results, passed := EvaluateThresholds(cfg, payload)
+	if !passed {
+		t.Error("expected passed=true when actual=60 and limit=60 (>= semantics)")
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if !results[0].Passed {
+		t.Error("expected result.Passed=true at boundary")
+	}
+	if results[0].Name != "AvgContractCoverage" {
+		t.Errorf("expected Name=AvgContractCoverage, got %q", results[0].Name)
+	}
+	if results[0].Actual != 60 {
+		t.Errorf("expected Actual=60, got %d", results[0].Actual)
+	}
+	if results[0].Limit != 60 {
+		t.Errorf("expected Limit=60, got %d", results[0].Limit)
+	}
+
+	// Below boundary: actual < limit → should fail.
+	payload2 := &ReportPayload{
+		Summary: ReportSummary{AvgContractCoverage: 59},
+	}
+	results2, passed2 := EvaluateThresholds(cfg, payload2)
+	if passed2 {
+		t.Error("expected passed=false when actual=59 and limit=60")
+	}
+	if len(results2) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results2))
+	}
+	if results2[0].Passed {
+		t.Error("expected result.Passed=false below boundary")
+	}
+	if results2[0].Actual != 59 {
+		t.Errorf("expected Actual=59, got %d", results2[0].Actual)
 	}
 }
 

--- a/internal/docscan/scanner_test.go
+++ b/internal/docscan/scanner_test.go
@@ -38,12 +38,34 @@ func TestScan_FindsMarkdownFiles(t *testing.T) {
 		t.Fatalf("Scan() error: %v", err)
 	}
 
-	// Expect README.md, CHANGELOG.md, CONTRIBUTING.md,
+	// The fixture contains exactly 6 markdown files:
+	// README.md, CHANGELOG.md, CONTRIBUTING.md,
 	// docs/architecture.md, vendor/README.md, pkg/mypackage/doc.md
-	if len(docs) < 5 {
-		t.Errorf("expected >= 5 docs, got %d", len(docs))
+	if len(docs) != 6 {
+		t.Errorf("expected exactly 6 docs (no excludes), got %d", len(docs))
 		for _, d := range docs {
 			t.Logf("  %s (priority %d)", d.Path, d.Priority)
+		}
+	}
+
+	expected := map[string]bool{
+		"README.md":            false,
+		"CHANGELOG.md":         false,
+		"CONTRIBUTING.md":      false,
+		"docs/architecture.md": false,
+		"vendor/README.md":     false,
+		"pkg/mypackage/doc.md": false,
+	}
+	for _, d := range docs {
+		if _, ok := expected[d.Path]; ok {
+			expected[d.Path] = true
+		} else {
+			t.Errorf("unexpected file discovered: %q", d.Path)
+		}
+	}
+	for path, found := range expected {
+		if !found {
+			t.Errorf("expected file not discovered: %q", path)
 		}
 	}
 }
@@ -118,11 +140,14 @@ func TestScan_PriorityOrdering(t *testing.T) {
 		t.Fatal("expected documents, got none")
 	}
 
-	// First doc should be same-package priority.
+	// First doc should be same-package priority (pkg/mypackage/doc.md).
 	first := docs[0]
 	if first.Priority != docscan.PrioritySamePackage {
 		t.Errorf("first doc should be PrioritySamePackage (1), got priority %d (path: %s)",
 			first.Priority, first.Path)
+	}
+	if first.Path != "pkg/mypackage/doc.md" {
+		t.Errorf("first doc should be pkg/mypackage/doc.md, got %q", first.Path)
 	}
 
 	// Verify monotonically non-decreasing priority values.
@@ -131,6 +156,19 @@ func TestScan_PriorityOrdering(t *testing.T) {
 			t.Errorf("priority ordering violated at index %d: %d (%s) > %d (%s)",
 				i, docs[i-1].Priority, docs[i-1].Path,
 				docs[i].Priority, docs[i].Path)
+		}
+		// Within the same priority tier, verify alphabetical ordering.
+		if docs[i].Priority == docs[i-1].Priority && docs[i].Path < docs[i-1].Path {
+			t.Errorf("alphabetical ordering violated within tier %d at index %d: %q should come before %q",
+				docs[i].Priority, i, docs[i].Path, docs[i-1].Path)
+		}
+	}
+
+	// Verify that README.md gets PriorityModuleRoot.
+	for _, d := range docs {
+		if d.Path == "README.md" && d.Priority != docscan.PriorityModuleRoot {
+			t.Errorf("README.md should be PriorityModuleRoot (%d), got %d",
+				docscan.PriorityModuleRoot, d.Priority)
 		}
 	}
 }
@@ -150,9 +188,9 @@ func TestScan_EmptyRepo(t *testing.T) {
 	}
 }
 
-// TestScan_ContentIsPopulated verifies that Content field is
-// non-empty for discovered documents.
-func TestScan_ContentIsPopulated(t *testing.T) {
+// TestScan_ContentMatchesDisk verifies that Content field matches
+// the actual file content on disk for discovered documents.
+func TestScan_ContentMatchesDisk(t *testing.T) {
 	repo := repoFixture(t)
 	docs, err := docscan.Scan(repo, docscan.ScanOptions{
 		Config: config.DefaultConfig(),
@@ -163,6 +201,17 @@ func TestScan_ContentIsPopulated(t *testing.T) {
 	for _, d := range docs {
 		if d.Content == "" {
 			t.Errorf("document %q has empty content", d.Path)
+			continue
+		}
+		// Verify content matches the actual file on disk.
+		diskContent, err := os.ReadFile(filepath.Join(repo, d.Path))
+		if err != nil {
+			t.Errorf("reading %q from disk: %v", d.Path, err)
+			continue
+		}
+		if d.Content != string(diskContent) {
+			t.Errorf("document %q: content does not match disk (got %d bytes, disk has %d bytes)",
+				d.Path, len(d.Content), len(diskContent))
 		}
 	}
 }
@@ -293,5 +342,28 @@ func TestScan_SkipsHiddenDirs(t *testing.T) {
 		if d.Path == ".git/COMMIT_EDITMSG.md" {
 			t.Errorf(".git directory should be skipped, found: %s", d.Path)
 		}
+	}
+
+	// Positive assertion: README.md should be found.
+	found := false
+	for _, d := range docs {
+		if d.Path == "README.md" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected README.md to be found")
+	}
+}
+
+// TestScan_InvalidRepoRoot verifies that Scan returns an error for
+// a non-existent directory.
+func TestScan_InvalidRepoRoot(t *testing.T) {
+	_, err := docscan.Scan("/nonexistent/path/that/does/not/exist", docscan.ScanOptions{
+		Config: config.DefaultConfig(),
+	})
+	if err == nil {
+		t.Error("expected error for non-existent repoRoot, got nil")
 	}
 }


### PR DESCRIPTION
## Summary

- Strengthen contract-level assertions for the 3 Q3 functions (`WriteStepSummary`, `EvaluateThresholds`, `docscan.Scan`)
- Test-only changes -- no production code modified
- Closes the assertion quality gaps identified by gaze quality analysis

## What changed

### WriteStepSummary (contract coverage 0% -> comprehensive)
- Assert specific warning message content for each error branch (not just substring "warning")
- Verify file permissions (0644) on created files
- Verify append semantics via `HasPrefix` instead of `Contains`

### EvaluateThresholds (contract coverage 50% -> comprehensive)
- Assert `Name`, `Actual`, and `Limit` fields on every test (previously `Name` in 1/8, `Limit` in 0/8)
- New `MinContractCoverageDirection` test verifies `>=` semantics at boundary (actual==limit passes, actual<limit fails)

### Scan (contract coverage 67% -> comprehensive)
- Assert exact file set discovery (6 files, not `>= 5`)
- Verify content matches actual disk file content
- Assert specific priority values for known files (`pkg/mypackage/doc.md` = SamePackage, `README.md` = ModuleRoot)
- Verify within-tier alphabetical ordering
- New `InvalidRepoRoot` test verifies error return
- Positive assertion that `README.md` IS found in hidden-dir test

## Test plan

All 12 packages pass `go test -race -count=1 -short ./...`. Build and vet clean.
