### PR TITLE
docs: add spec-first development requirement to constitution and AGENTS.md

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,36 +1,28 @@
 <!--
   SYNC IMPACT REPORT
   ==================
-  Version change: 1.0.0 → 1.1.0 (MINOR: new principle added)
-  Amendment date: 2026-03-05
-  Feature: 017-testing-persona
+  Version change: 1.1.0 → 1.2.0 (MINOR: workflow requirement added)
+  Amendment date: 2026-03-15
+  Feature: spec-first-guardrails
 
-  Added principles:
-    - IV. Testability (dual scope: Gaze internals + user codebase analysis)
+  Added workflow requirements:
+    - Spec-First Development (Development Workflow section)
+      All changes that modify production code, test code, agent prompts,
+      embedded assets, or CI configuration must be preceded by a spec
+      workflow. Narrow exemptions for constitution amendments, trivial
+      fixes, and emergency hotfixes.
 
   Unchanged principles:
     - I. Accuracy
     - II. Minimal Assumptions
     - III. Actionable Output
+    - IV. Testability
 
   Unchanged sections:
-    - Development Workflow
     - Governance
 
-  Templates requiring updates:
-    ✅ .specify/templates/plan-template.md — no changes needed;
-       Constitution Check section is generic and evaluates all active
-       principles dynamically.
-    ✅ .specify/templates/spec-template.md — no changes needed;
-       requirements format already uses MUST/SHOULD language.
-    ✅ .specify/templates/tasks-template.md — no changes needed;
-       task phases are feature-driven, not principle-specific.
-    ✅ .specify/templates/checklist-template.md — no changes needed.
-    ✅ .specify/templates/agent-file-template.md — no changes needed.
-    ✅ No command files in .specify/templates/commands/ (directory absent).
-    ✅ README.md — single-line placeholder; no principle refs to update.
-
   Previous version history:
+    - 1.1.0 (2026-03-05): Added Principle IV: Testability
     - 1.0.0 (2026-02-20): Initial ratification with 3 principles
 -->
 
@@ -115,6 +107,23 @@ trusted — by users or by Gaze itself.
 
 ## Development Workflow
 
+- **Spec-First Development**: All changes that modify production code,
+  test code, agent prompts, embedded assets, or CI configuration MUST
+  be preceded by a spec workflow (either the Speckit pipeline under
+  `specs/` or the OpenSpec pipeline under `openspec/changes/`). The
+  spec artifacts (proposal, design, tasks at minimum) MUST exist
+  before implementation begins. This ensures every change has a
+  planning record, a reviewable intent, and a traceable rationale.
+  Exempt from this requirement:
+    - Constitution amendments (governed by the Governance section below)
+    - Trivial fixes: typo corrections, comment-only changes, and
+      single-line formatting fixes that do not alter behavior
+    - Emergency hotfixes: critical production bugs where the fix is
+      a single well-understood correction (must be retroactively
+      documented)
+  When in doubt, use a spec. The cost of an unnecessary spec is
+  minutes; the cost of an unplanned change is rework, drift, and
+  broken CI.
 - **Branching**: All work MUST occur on feature branches. Direct
   commits to the main branch are prohibited except for trivial
   documentation fixes.
@@ -147,4 +156,4 @@ above.
   the Constitution Check gate MUST verify that the proposed work
   aligns with all active principles.
 
-**Version**: 1.1.0 | **Ratified**: 2026-02-20 | **Last Amended**: 2026-03-05
+**Version**: 1.2.0 | **Ratified**: 2026-02-20 | **Last Amended**: 2026-03-15

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,31 @@ Gaze is a static analysis tool for Go that detects observable side effects in fu
 
 **Rule**: A Pull Request is only "Ready for Human" once the `/review-council` command returns an **APPROVE** status from all four reviewers.
 
-## Speckit Workflow (Mandatory)
+## Spec-First Development (Mandatory)
 
-All non-trivial feature work **must** go through the Speckit pipeline. The constitution (`.specify/memory/constitution.md`) is the highest-authority document in this project — all work must align with it.
+All changes that modify production code, test code, agent prompts, embedded assets, or CI configuration **must** be preceded by a spec workflow. The constitution (`.specify/memory/constitution.md`) is the highest-authority document in this project — all work must align with it.
+
+Two spec workflows are available:
+
+| Workflow | Location | Best For |
+|----------|----------|----------|
+| **Speckit** | `specs/NNN-name/` | Numbered feature specs with the full pipeline (specify → clarify → plan → tasks → implement) |
+| **OpenSpec** | `openspec/changes/name/` | Targeted changes with lightweight artifacts (proposal → design → specs → tasks) via `/opsx-propose` and `/opsx-apply` |
+
+**What requires a spec** (no exceptions without explicit user override):
+- New features or capabilities
+- Refactoring that changes function signatures, extracts helpers, or moves code between packages
+- Test additions or assertion strengthening across multiple functions
+- Agent prompt changes (embedded assets under `internal/scaffold/assets/`)
+- CI workflow modifications
+- Data model changes (new struct fields, JSON schema updates)
+
+**What is exempt** (may be done directly):
+- Constitution amendments (governed by the constitution's own Governance section)
+- Typo corrections, comment-only changes, single-line formatting fixes
+- Emergency hotfixes for critical production bugs (must be retroactively documented)
+
+When an agent is unsure whether a change is trivial, it **must** ask the user rather than proceeding without a spec. The cost of an unnecessary spec is minutes; the cost of an unplanned change is rework, drift, and broken CI.
 
 ### Pipeline
 


### PR DESCRIPTION
## Summary

Add spec-first development as a constitutional requirement and tighten the AGENTS.md workflow definitions to prevent ad-hoc changes without planning artifacts.

## Motivation

During an extended quality improvement session, several changes were made directly without spec workflows:
- Agent prompt modifications (gaze-reporter.md) caused CI failures from scaffold drift detection
- Test assertion strengthening across multiple files had no planning record
- The inconsistency between spec-driven changes (which went smoothly) and ad-hoc changes (which caused problems) was clear

The existing AGENTS.md said "All non-trivial feature work must go through the Speckit pipeline" but "non-trivial" was undefined, and agents routinely classified their own work as trivial.

## Changes

### Constitution (v1.1.0 -> v1.2.0)

Added **Spec-First Development** to the Development Workflow section:
- All changes to production code, test code, agent prompts, embedded assets, or CI configuration must be preceded by a spec workflow
- Three narrow exemptions: constitution amendments, trivial fixes, emergency hotfixes
- "When in doubt, use a spec" guidance

### AGENTS.md

- Renamed "Speckit Workflow (Mandatory)" to **"Spec-First Development (Mandatory)"**
- Added comparison table documenting both workflows (Speckit under `specs/` and OpenSpec under `openspec/changes/`)
- Replaced vague "non-trivial feature work" with explicit lists of what requires and what is exempt from spec workflows
- Added "when in doubt, ask the user" directive for agents
