### PR TITLE
chore: phase 1 housekeeping — fix #34, #35, #36

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,25 @@ specs/
   020-report-coverprofile/       # spec.md, plan.md, tasks.md, research.md, data-model.md, quickstart.md, checklists/
 ```
 
-Branch names follow the same numbering pattern (e.g., `001-side-effect-detection`).
+OpenSpec changes use kebab-case names and are archived after merge under `openspec/changes/archive/`:
+
+```text
+openspec/
+  changes/
+    report-actionability/          # proposal.md, design.md, specs/, tasks.md (active)
+    reporter-fix-strategy-awareness/ # proposal.md, design.md, specs/, tasks.md (active)
+    archive/
+      2026-03-12-fix-xtools-go125-panic/
+      2026-03-13-assess-graceful-degradation/
+      2026-03-14-adapter-format-decomposition/
+      2026-03-14-crapload-analyze-decomposition/
+      2026-03-14-pipeline-step-testing/
+      2026-03-14-ssa-goroutine-panic/
+      2026-03-15-q4-complexity-reduction/
+  specs/                           # Main specs (synced from delta specs)
+```
+
+Branch names follow the same numbering pattern for Speckit (e.g., `001-side-effect-detection`) or kebab-case for OpenSpec (e.g., `assess-graceful-degradation`).
 
 ### Task Completion Bookkeeping
 

--- a/internal/analysis/mutation.go
+++ b/internal/analysis/mutation.go
@@ -7,7 +7,6 @@ import (
 	"go/token"
 	"go/types"
 	"log"
-	"log/slog"
 
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/ssa"
@@ -49,7 +48,7 @@ func BuildSSA(pkg *packages.Package) (ssaPkg *ssa.Package) {
 
 	if r := safeSSABuild(prog.Build); r != nil {
 		log.Printf("warning: SSA build skipped for %s: internal panic recovered", pkg.PkgPath)
-		slog.Debug("SSA panic value", "pkg", pkg.PkgPath, "panic", r)
+		log.Printf("debug: SSA panic value for %s: %v", pkg.PkgPath, r)
 		return nil
 	}
 

--- a/internal/quality/pairing.go
+++ b/internal/quality/pairing.go
@@ -5,7 +5,6 @@ import (
 	"go/ast"
 	"go/types"
 	"log"
-	"log/slog"
 	"sort"
 	"strings"
 
@@ -135,7 +134,7 @@ func BuildTestSSA(pkg *packages.Package) (program *ssa.Program, ssaPkg *ssa.Pack
 
 	if r := safeSSABuild(prog.Build); r != nil {
 		log.Printf("warning: SSA build skipped for %s: internal panic recovered", pkg.PkgPath)
-		slog.Debug("SSA panic value", "pkg", pkg.PkgPath, "panic", r)
+		log.Printf("debug: SSA panic value for %s: %v", pkg.PkgPath, r)
 		return nil, nil, fmt.Errorf("SSA build panicked for package %s: internal panic recovered", pkg.PkgPath)
 	}
 

--- a/specs/021-ssa-panic-recovery/research.md
+++ b/specs/021-ssa-panic-recovery/research.md
@@ -57,6 +57,13 @@ suppress by configuring the standard logger.
    `slog.Debug` with structured fields. However, gaze doesn't use `slog`
    anywhere yet, and introducing it for 2 log lines may be premature.
 
+> **Correction (issue #34):** `slog.Debug` was initially chosen for the
+> debug line but was unreachable in all deployment scenarios — gaze has
+> no mechanism (`--debug` flag, env var, or `slog.SetLogLoggerLevel` call)
+> to lower the default handler level from Info to Debug. Reverted to
+> `log.Printf("debug: ...")` for consistency with the selected approach
+> described above.
+
 ## R2: recover() Placement Strategy
 
 ### Decision


### PR DESCRIPTION
## Summary

Phase 1 of the [Gaze Roadmap](https://github.com/orgs/unbound-force/projects/1) — three trivial housekeeping fixes.

### #34 — Replace unreachable slog.Debug with log.Printf
- `internal/analysis/mutation.go`: `slog.Debug(...)` → `log.Printf("debug: ...")`
- `internal/quality/pairing.go`: same change
- Removed unused `log/slog` imports from both files
- The slog.Debug calls were no-ops because gaze has no mechanism to enable debug-level output

### #35 — Document openspec/ workflow in AGENTS.md
- Added directory listing for `openspec/changes/` and `openspec/changes/archive/` to the Spec Organization section
- Added note that OpenSpec branches use kebab-case names

### #36 — Correct spec 021 research.md R1
- Added correction block noting that slog.Debug was reverted to log.Printf due to unreachability

## Test plan

All affected packages pass: `go test -race -count=1 -short ./internal/analysis/ ./internal/quality/ ./internal/scaffold/`

Closes #34, closes #35, closes #36