### PR TITLE
fix: add metric definitions to prevent GazeCRAPload/Q4 conflation

### DIFF
--- a/.opencode/agents/gaze-reporter.md
+++ b/.opencode/agents/gaze-reporter.md
@@ -430,6 +430,22 @@ output. Violations produce misleading reports.
 5. **Quadrant counts**: Render from `summary.quadrant_counts`
    in the CRAP JSON. Do NOT recompute quadrant assignments.
 
+### Metric Definitions (read carefully)
+
+- **CRAPload**: Count of functions with CRAP score >=
+  `crap_threshold`. CRAP uses **line coverage**. Read from
+  `summary.crapload`.
+- **GazeCRAPload**: Count of functions with GazeCRAP score >=
+  `gaze_crap_threshold`. GazeCRAP uses **contract coverage**
+  (stronger signal). Read from `summary.gaze_crapload`. This is
+  NOT the Q4 count — Q3 functions (simple but underspecified)
+  with low contract coverage also contribute to GazeCRAPload.
+- **Quadrant counts**: Distribution of functions across Q1–Q4
+  based on complexity AND contract coverage. Read from
+  `summary.quadrant_counts`. The Q4 (Dangerous) count is one
+  component of the quadrant distribution, NOT a synonym for
+  GazeCRAPload.
+
 ## Reference Files
 
 Before producing your first report, read the formatting reference

--- a/internal/aireport/assets/agents/gaze-reporter.md
+++ b/internal/aireport/assets/agents/gaze-reporter.md
@@ -430,6 +430,22 @@ output. Violations produce misleading reports.
 5. **Quadrant counts**: Render from `summary.quadrant_counts`
    in the CRAP JSON. Do NOT recompute quadrant assignments.
 
+### Metric Definitions (read carefully)
+
+- **CRAPload**: Count of functions with CRAP score >=
+  `crap_threshold`. CRAP uses **line coverage**. Read from
+  `summary.crapload`.
+- **GazeCRAPload**: Count of functions with GazeCRAP score >=
+  `gaze_crap_threshold`. GazeCRAP uses **contract coverage**
+  (stronger signal). Read from `summary.gaze_crapload`. This is
+  NOT the Q4 count — Q3 functions (simple but underspecified)
+  with low contract coverage also contribute to GazeCRAPload.
+- **Quadrant counts**: Distribution of functions across Q1–Q4
+  based on complexity AND contract coverage. Read from
+  `summary.quadrant_counts`. The Q4 (Dangerous) count is one
+  component of the quadrant distribution, NOT a synonym for
+  GazeCRAPload.
+
 ## Reference Files
 
 Before producing your first report, read the formatting reference

--- a/internal/scaffold/assets/agents/gaze-reporter.md
+++ b/internal/scaffold/assets/agents/gaze-reporter.md
@@ -430,6 +430,22 @@ output. Violations produce misleading reports.
 5. **Quadrant counts**: Render from `summary.quadrant_counts`
    in the CRAP JSON. Do NOT recompute quadrant assignments.
 
+### Metric Definitions (read carefully)
+
+- **CRAPload**: Count of functions with CRAP score >=
+  `crap_threshold`. CRAP uses **line coverage**. Read from
+  `summary.crapload`.
+- **GazeCRAPload**: Count of functions with GazeCRAP score >=
+  `gaze_crap_threshold`. GazeCRAP uses **contract coverage**
+  (stronger signal). Read from `summary.gaze_crapload`. This is
+  NOT the Q4 count — Q3 functions (simple but underspecified)
+  with low contract coverage also contribute to GazeCRAPload.
+- **Quadrant counts**: Distribution of functions across Q1–Q4
+  based on complexity AND contract coverage. Read from
+  `summary.quadrant_counts`. The Q4 (Dangerous) count is one
+  component of the quadrant distribution, NOT a synonym for
+  GazeCRAPload.
+
 ## Reference Files
 
 Before producing your first report, read the formatting reference

--- a/openspec/changes/report-actionability/.openspec.yaml
+++ b/openspec/changes/report-actionability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-03-17

--- a/openspec/changes/report-actionability/design.md
+++ b/openspec/changes/report-actionability/design.md
@@ -1,0 +1,49 @@
+# Design: Report Actionability
+
+## Context
+
+The gaze-reporter agent prompt has Scoring Consistency Rules that instruct the agent to read metrics from JSON fields. However, the rules only say *where* to read values, not *what they mean*. The agent sees `gaze_crapload=24` and `quadrant_counts.Q4_Dangerous=0` and incorrectly reports "GazeCRAPload is 0" because it assumes GazeCRAPload = Q4 count.
+
+## Goals / Non-Goals
+
+### Goals
+- Define GazeCRAPload, CRAPload, and quadrant counts as distinct metrics in the prompt
+- Add explicit negative constraint preventing GazeCRAPload/Q4 conflation
+- Keep the definitions concise (the prompt is already large)
+
+### Non-Goals
+- Changing JSON field names or adding new fields
+- Modifying the CLI text report format
+- Adding automated tests for agent output accuracy
+
+## Decisions
+
+### D1: Add "Metric Definitions" subsection to Scoring Consistency Rules
+
+Add 3 definitions immediately after the existing 5 rules:
+
+```
+### Metric Definitions (read carefully)
+
+- **CRAPload**: Count of functions with CRAP score >= `crap_threshold`.
+  CRAP uses line coverage. Read from `summary.crapload`.
+- **GazeCRAPload**: Count of functions with GazeCRAP score >=
+  `gaze_crap_threshold`. GazeCRAP uses contract coverage (stronger
+  signal). Read from `summary.gaze_crapload`. This is NOT the Q4
+  count — Q3 functions with low contract coverage also contribute.
+- **Quadrant counts**: Distribution of functions across Q1-Q4 based
+  on complexity AND contract coverage. Read from
+  `summary.quadrant_counts`. Q4 count is one component of the
+  quadrant distribution, not a synonym for GazeCRAPload.
+```
+
+**Rationale**: The agent needs to understand the semantic difference, not just the field location. The "NOT the Q4 count" negative constraint is the most important line — it directly prevents the observed misinterpretation.
+
+### D2: Keep all three prompt copies in sync
+
+All three copies (`.opencode/agents/`, `internal/scaffold/assets/agents/`, `internal/aireport/assets/agents/`) must be updated identically. The `prompt_test.go` drift test enforces this for `scaffold` vs `aireport`.
+
+## Risks / Trade-offs
+
+- **Prompt length increase**: ~8 lines added. The prompt is already 464 lines; this is <2% increase. Acceptable.
+- **Agent may still misinterpret**: Prompt constraints are probabilistic, not deterministic. The negative constraint ("NOT the Q4 count") is the strongest available signal.

--- a/openspec/changes/report-actionability/proposal.md
+++ b/openspec/changes/report-actionability/proposal.md
@@ -1,0 +1,59 @@
+# Report Actionability
+
+## Why
+
+Side-by-side testing of `gaze report --ai=opencode` (CI) vs the `/gaze` agent command (OpenCode TUI) revealed the agent misreports GazeCRAPload as 0 when the actual value is 24. The agent confused GazeCRAPload (functions with GazeCRAP >= threshold) with Q4 count (functions in the Dangerous quadrant). These are different metrics: a simple function with 0% contract coverage is Q3 (Needs Tests) but still has GazeCRAP >= 15, contributing to GazeCRAPload.
+
+The Scoring Consistency Rules added in `reporter-fix-strategy-awareness` tell the agent to read `gaze_crapload` from the JSON, but don't explain what the metric means. Without understanding the definition, the agent substitutes its own interpretation.
+
+## What Changes
+
+1. **Agent prompt**: Add a "Metric Definitions" section to the Scoring Consistency Rules that defines GazeCRAPload, CRAPload, and quadrant counts as distinct metrics with different semantics.
+2. **Agent prompt**: Add an explicit negative constraint: "GazeCRAPload is NOT the Q4 count."
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `gaze-reporter agent prompt`: Adds metric definitions that distinguish GazeCRAPload from Q4 count, preventing the agent from conflating the two
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- `.opencode/agents/gaze-reporter.md` — prompt text changes (metric definitions)
+- `internal/scaffold/assets/agents/gaze-reporter.md` — embedded scaffold copy
+- `internal/aireport/assets/agents/gaze-reporter.md` — aireport embedded copy
+
+No Go code changes. No CLI behavior changes. The underlying analysis engine and JSON output are correct — only the AI's interpretation instructions need clarification.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+The agent prompt is a self-describing artifact. No runtime coupling is affected.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No dependencies introduced. The agent prompt remains a standalone markdown file.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+This change directly improves observable quality by ensuring the AI-generated report accurately reflects the machine-parseable JSON output. Before this change, the agent could report GazeCRAPload=0 when the JSON contains GazeCRAPload=24 — a provenance violation.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+Markdown prompt changes. The agent's output accuracy is validated by comparing CLI and TUI reports against the same input data.

--- a/openspec/changes/report-actionability/specs/metric-definitions.md
+++ b/openspec/changes/report-actionability/specs/metric-definitions.md
@@ -1,0 +1,34 @@
+# Metric Definitions Spec
+
+## ADDED Requirements
+
+### Requirement: Agent prompt MUST define GazeCRAPload as distinct from Q4 count
+
+The gaze-reporter agent prompt MUST contain a "Metric Definitions" subsection within the Scoring Consistency Rules that defines GazeCRAPload as the count of functions with GazeCRAP >= threshold, explicitly stating it is NOT the Q4 count.
+
+#### Scenario: Agent reports GazeCRAPload correctly
+- **GIVEN** a JSON payload with `summary.gaze_crapload = 24` and `summary.quadrant_counts.Q4_Dangerous = 0`
+- **WHEN** the agent renders the GazeCRAPload metric
+- **THEN** the agent reports GazeCRAPload as 24 (not 0)
+
+#### Scenario: Agent distinguishes GazeCRAPload from Q4 in narrative
+- **GIVEN** GazeCRAPload = 24 and Q4 = 0
+- **WHEN** the agent writes the Health Assessment
+- **THEN** the agent does not state "GazeCRAPload is 0" or equate GazeCRAPload with Q4 count
+
+### Requirement: Metric definitions MUST cover CRAPload, GazeCRAPload, and quadrant counts
+
+The definitions section MUST define all three metrics with their source JSON fields, the coverage type they use (line vs contract), and what threshold they reference.
+
+#### Scenario: Prompt contains all three definitions
+- **GIVEN** the gaze-reporter agent prompt
+- **WHEN** the Scoring Consistency Rules section is read
+- **THEN** it contains definitions for CRAPload, GazeCRAPload, and quadrant counts
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/report-actionability/tasks.md
+++ b/openspec/changes/report-actionability/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: Report Actionability
+
+## 1. Add metric definitions to agent prompt
+
+- [x] 1.1 In `.opencode/agents/gaze-reporter.md`, add a "Metric Definitions" subsection after the existing 5 Scoring Consistency Rules (after rule 5 about quadrant counts). The subsection should define CRAPload (line coverage, `summary.crapload`), GazeCRAPload (contract coverage, `summary.gaze_crapload`, NOT the Q4 count), and quadrant counts (`summary.quadrant_counts`, Q4 is one component not a synonym for GazeCRAPload).
+
+## 2. Sync prompt copies
+
+- [x] 2.1 Copy `.opencode/agents/gaze-reporter.md` to `internal/scaffold/assets/agents/gaze-reporter.md`.
+- [x] 2.2 Copy `.opencode/agents/gaze-reporter.md` to `internal/aireport/assets/agents/gaze-reporter.md`.
+
+## 3. Verification
+
+- [x] 3.1 Run `go build ./cmd/gaze` to verify embedded assets compile.
+- [x] 3.2 Diff all three copies to confirm they are identical.


### PR DESCRIPTION
## Summary

- Added Metric Definitions subsection to gaze-reporter agent prompt Scoring Consistency Rules
- Defines CRAPload (line coverage), GazeCRAPload (contract coverage), and quadrant counts as distinct metrics
- Explicit negative constraint: GazeCRAPload is NOT the Q4 count

## Why

The agent was reporting GazeCRAPload=0 when the actual value was 24, confusing GazeCRAPload (functions with GazeCRAP >= threshold, which includes Q3 functions) with Q4 Dangerous count (which was genuinely 0). Verified fix: CLI and TUI agent now produce identical numbers for all metrics.