### PR TITLE
fix: relativize Score.File paths in JSON output

### DIFF
--- a/internal/crap/analyze.go
+++ b/internal/crap/analyze.go
@@ -134,6 +134,15 @@ func Analyze(patterns []string, moduleDir string, opts Options) (*Report, error)
 	// Step 5: Join complexity with coverage and compute CRAP.
 	scores := computeScores(complexityStats, coverMap, opts)
 
+	// Step 5b: Relativize file paths for portable JSON output.
+	// computeScores uses absolute paths for coverage lookups, but the
+	// final report should contain paths relative to the module root.
+	for i := range scores {
+		if rel, err := filepath.Rel(moduleDir, scores[i].File); err == nil {
+			scores[i].File = rel
+		}
+	}
+
 	// Step 6: Build summary.
 	summary := buildSummary(scores, opts)
 

--- a/internal/crap/crap_test.go
+++ b/internal/crap/crap_test.go
@@ -1494,3 +1494,39 @@ func TestWriteText_RemediationBreakdown(t *testing.T) {
 		t.Errorf("expected '[decompose]' label on worst offender, got:\n%s", out)
 	}
 }
+
+func TestAnalyze_RelativizesFilePaths(t *testing.T) {
+	modRoot := moduleRoot(t)
+
+	// Build a minimal coverage profile so Analyze can run.
+	profileContent := "mode: set\n" +
+		"github.com/unbound-force/gaze/internal/crap/crap.go:152.55,156.2 2 1\n"
+
+	profileFile := filepath.Join(t.TempDir(), "cover.out")
+	if err := os.WriteFile(profileFile, []byte(profileContent), 0o644); err != nil {
+		t.Fatalf("writing cover profile: %v", err)
+	}
+
+	opts := DefaultOptions()
+	opts.CoverProfile = profileFile
+
+	report, err := Analyze([]string{"./internal/crap"}, modRoot, opts)
+	if err != nil {
+		t.Fatalf("Analyze failed: %v", err)
+	}
+
+	// All Score.File paths must be relative (no leading /).
+	for _, s := range report.Scores {
+		if filepath.IsAbs(s.File) {
+			t.Errorf("Score.File is absolute, want relative: %q (function %s)", s.File, s.Function)
+		}
+	}
+
+	// RecommendedActions (if any) must also have relative paths.
+	for _, a := range report.Summary.RecommendedActions {
+		if filepath.IsAbs(a.File) {
+			t.Errorf("RecommendedAction.File is absolute, want relative: %q (function %s)",
+				a.File, a.Function)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Relativizes all `Score.File` paths against the module root directory after `computeScores()` returns, converting absolute paths to relative
- Fixes the `recommended_actions` section (and all other sections) emitting machine-specific absolute paths like `/Users/hbraswel/github/complytime/complyctl/cmd/...` in JSON output
- Adds `TestAnalyze_RelativizesFilePaths` to verify both `Score.File` and `RecommendedAction.File` are relative

## Context
Discovered during review of [complytime/complyctl#471](https://github.com/complytime/complyctl/pull/471). The regenerated `.gaze/baseline.json` contained 20 absolute paths in the new `recommended_actions` section, while `scores`, `worst_crap`, and `worst_gaze_crap` happened to appear relative depending on how the tool was invoked.

## Root cause
`computeScores()` sets `Score.File = stat.Pos.Filename`, where the filename comes from `gocyclo.Analyze()` which walks the filesystem using an absolute `moduleDir` from `os.Getwd()`. No relativization was applied before the scores were passed to `buildSummary()`, which propagates file paths into `worst_crap`, `worst_gaze_crap`, and `recommended_actions`.

## Fix
A `filepath.Rel(moduleDir, ...)` pass is added between `computeScores()` (which needs absolute paths for `lookupCoverage()` map matching) and `buildSummary()` (which propagates paths to all summary sections). This single fix point ensures all downstream consumers get relative paths.

## Verification
- `go build ./...` — clean
- `golangci-lint run ./internal/crap/...` — 0 issues
- All 6 `TestAnalyze_*` tests pass (including the new one)
- 87/88 total tests pass (1 pre-existing failure in `TestResolvePackagePaths_InvalidPattern` — unrelated `go list` behavior)