### PR TITLE
fix: add mode: subagent to agent frontmatter

### DIFF
--- a/.opencode/agents/gaze-reporter.md
+++ b/.opencode/agents/gaze-reporter.md
@@ -5,6 +5,7 @@ description: >
   metrics, side effect classifications, and overall project health.
   Supports three modes: crap (CRAP scores only), quality (test
   quality metrics only), and full (comprehensive health assessment).
+mode: subagent
 tools:
   read: true
   bash: true

--- a/.opencode/agents/gaze-test-generator.md
+++ b/.opencode/agents/gaze-test-generator.md
@@ -5,6 +5,7 @@ description: >
   complete, compilable Go test functions, improve documentation for
   classifier visibility, and restructure assertions for mapper
   accuracy. Works on any Go project gaze can analyze.
+mode: subagent
 tools:
   read: true
   bash: true

--- a/internal/aireport/assets/agents/gaze-reporter.md
+++ b/internal/aireport/assets/agents/gaze-reporter.md
@@ -5,6 +5,7 @@ description: >
   metrics, side effect classifications, and overall project health.
   Supports three modes: crap (CRAP scores only), quality (test
   quality metrics only), and full (comprehensive health assessment).
+mode: subagent
 tools:
   read: true
   bash: true

--- a/internal/scaffold/assets/agents/gaze-reporter.md
+++ b/internal/scaffold/assets/agents/gaze-reporter.md
@@ -5,6 +5,7 @@ description: >
   metrics, side effect classifications, and overall project health.
   Supports three modes: crap (CRAP scores only), quality (test
   quality metrics only), and full (comprehensive health assessment).
+mode: subagent
 tools:
   read: true
   bash: true

--- a/internal/scaffold/assets/agents/gaze-test-generator.md
+++ b/internal/scaffold/assets/agents/gaze-test-generator.md
@@ -5,6 +5,7 @@ description: >
   complete, compilable Go test functions, improve documentation for
   classifier visibility, and restructure assertions for mapper
   accuracy. Works on any Go project gaze can analyze.
+mode: subagent
 tools:
   read: true
   bash: true


### PR DESCRIPTION
## Summary

- Added `mode: subagent` to `gaze-reporter.md` and `gaze-test-generator.md` YAML frontmatter
- Updated all 3 copies of gaze-reporter.md (scaffold canonical, aireport fallback, live deployed) and both copies of gaze-test-generator.md (scaffold canonical, live deployed)

## Problem

Both agent files lacked a `mode:` field. OpenCode defaults agents without `mode` to `all`, making them appear as Tab-cyclable primary modes alongside Build and Plan. Users see 7+ modes instead of 2 after `gaze init`, with no explanation of what the extra modes are.

## Fix

Adding `mode: subagent` ensures these agents are only invokable via `/gaze`, `/gaze-fix`, or `@` mention -- not as primary modes in the Tab cycle.

All drift detection tests pass (`TestEmbeddedAssetsMatchSource`, `TestEmbeddedPromptMatchesScaffold`).

Closes #91