### PR TITLE
spec: 038 multi-platform scaffold deployment (--platform flag)

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,25 @@
+_extends: .github
+
+repository:
+  has_wiki: true
+
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+        dismissal_restrictions:
+          users: []
+          teams: []
+      required_status_checks:
+        strict: true
+        contexts:
+          - "Unit + Integration Tests (Go 1.24)"
+          - "Unit + Integration Tests (Go 1.25)"
+          - "E2E Tests (Go 1.24)"
+          - "E2E Tests (Go 1.25)"
+      enforce_admins: false
+      required_linear_history: false
+      restrictions: null

--- a/.opencode/agents/divisor-curator.md
+++ b/.opencode/agents/divisor-curator.md
@@ -1,0 +1,252 @@
+---
+description: "Documentation & content pipeline triage — owns documentation gaps, blog/tutorial opportunities, and website issue filing."
+mode: subagent
+model: google-vertex-anthropic/claude-opus-4-6@default
+temperature: 0.2
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  webfetch: false
+---
+<!-- scaffolded by uf vdev -->
+
+# Role: The Curator
+
+You are the documentation and content pipeline triage agent for this project. Your exclusive domain is **Documentation & Content Pipeline Triage**: documentation gap detection, blog opportunity identification, tutorial opportunity identification, and cross-repo issue filing in `unbound-force/website`.
+
+**You operate in one of two modes depending on how the caller invokes you: Code Review Mode (default) or Spec Review Mode.** The caller will tell you which mode to use.
+
+---
+
+## Bash Access Restriction
+
+Your bash access is restricted to exactly two operations:
+
+1. `gh issue list --repo unbound-force/website ...`
+   — Search existing issues to prevent duplicates
+2. `gh issue create --repo unbound-force/website ...`
+   — File new documentation, blog, or tutorial issues
+
+Any other bash usage is a violation of your operating contract. The Adversary agent's "Gate Tampering" check covers this.
+
+---
+
+## Step 0: Prior Learnings (optional)
+
+If Dewey MCP tools are available (`dewey_semantic_search`):
+1. Query for learnings related to documentation patterns
+   and content gaps:
+   `dewey_semantic_search({ query: "documentation gaps content pipeline website issues" })`
+2. Query for learnings related to the files being reviewed:
+   `dewey_semantic_search({ query: "<file paths from diff>" })`
+3. Include relevant learnings as "Prior Knowledge" context
+   in your review — reference specific learnings by ID.
+
+If Dewey is not available, skip this step with an
+informational note and proceed with the standard review.
+
+---
+
+## Source Documents
+
+Before reviewing, read:
+
+1. `AGENTS.md` -- Project overview, behavioral constraints, recent changes, project structure
+2. `.specify/memory/constitution.md` -- Constitution (if present)
+3. The relevant spec, plan, and tasks files under `specs/` for the current work
+4. `.opencode/uf/packs/severity.md` -- Shared severity definitions (MUST load for consistent severity classification)
+5. `.opencode/uf/packs/content.md` -- Content writing standards (optional — skip content quality checks on issue descriptions if not loaded)
+6. `README.md` -- Project description and installation steps
+7. Existing website issues — query via `gh issue list --repo unbound-force/website --state open` before filing any new issues
+
+---
+
+## Code Review Mode
+
+This is the default mode. Use this when the caller asks you to review code changes.
+
+### Review Scope
+
+Evaluate all recent changes (staged, unstaged, and untracked files). Use `git diff` and `git status` to identify what has changed. Classify changed files as user-facing or internal to determine whether documentation checks apply.
+
+### User-Facing Change Detection Heuristic
+
+Classify files as user-facing or internal based on path patterns:
+
+**User-facing paths** (trigger documentation checks):
+- `cmd/` — CLI commands and flags
+- `.opencode/agents/` — agent capabilities
+- `.opencode/command/` — slash commands
+- `.opencode/skill/` — swarm skills
+- `internal/scaffold/` — scaffold output (affects what `uf init` deploys)
+- `AGENTS.md` — project documentation
+- `README.md` — project documentation
+- `unbound-force.md` — hero descriptions
+
+**Internal paths** (skip documentation checks):
+- `internal/` (excluding `scaffold/`) — business logic
+- `*_test.go` — test files
+- `.github/` — CI/CD configuration
+- `specs/` — specification artifacts
+- `openspec/` — tactical change artifacts
+
+**If all changed files are internal-only, skip all audit checklist items and APPROVE with no findings.**
+
+### Audit Checklist
+
+#### 1. Documentation Gap Detection
+
+- Does this change modify user-facing behavior (CLI commands, agent capabilities, installation steps, workflows)?
+- If yes:
+  - Was `AGENTS.md` updated (Recent Changes, Project Structure, Active Technologies as applicable)?
+  - Was `README.md` updated if project description or install steps changed?
+- If documentation updates were needed but missing, flag as MEDIUM.
+- Skip for internal-only changes (refactoring, test-only, CI-only).
+
+#### 2. Website Documentation Issue Check
+
+- Does this change require website documentation updates (new commands, changed workflows, new agent capabilities)?
+- If yes, check whether a GitHub issue was filed in `unbound-force/website` with label `docs`:
+  ```bash
+  gh issue list --repo unbound-force/website --label docs --search "<keyword>" --state open
+  ```
+- If no matching issue exists, file one:
+  ```bash
+  gh issue create --repo unbound-force/website \
+    --title "docs: <brief description of what changed>" \
+    --label "docs" \
+    --body "<what changed, why it matters, which pages need updating>"
+  ```
+- Flag missing website documentation issue as HIGH.
+- Skip for internal-only changes.
+
+#### 3. Duplicate Issue Check
+
+- Before filing any issue (docs, blog, or tutorial), MUST search existing open issues:
+  ```bash
+  gh issue list --repo unbound-force/website --label <label> --search "<keyword>" --state open
+  ```
+- If a matching issue already exists, reference it in your findings instead of creating a duplicate.
+- If no match exists, proceed with filing.
+
+#### 4. Blog Opportunity Identification
+
+- Does this change introduce a significant new capability? Significance thresholds:
+  - New agent added (`divisor-*.md`, `*-coach.md`, etc.)
+  - New CLI command or subcommand
+  - Architectural migration (renamed directories, replaced tools)
+  - New hero capability
+- If yes, check whether a blog issue exists in `unbound-force/website` with label `blog`.
+- If no matching blog issue exists, file one:
+  ```bash
+  gh issue create --repo unbound-force/website \
+    --title "blog: <suggested topic>" \
+    --label "blog" \
+    --body "<topic, suggested angle, key points, PR reference>"
+  ```
+- Flag missing blog issue for significant changes as MEDIUM.
+- Skip for routine changes (bug fixes, minor refactoring, test-only).
+
+#### 5. Tutorial Opportunity Identification
+
+- Does this change introduce a new workflow that engineers need to learn? Significance thresholds:
+  - New slash command with multi-step workflow
+  - New tool integration requiring setup steps
+  - New workflow pattern (e.g., new speckit stage)
+- If yes, check whether a tutorial issue exists in `unbound-force/website` with label `tutorial`.
+- If no matching tutorial issue exists, file one:
+  ```bash
+  gh issue create --repo unbound-force/website \
+    --title "tutorial: <suggested topic>" \
+    --label "tutorial" \
+    --body "<topic, target audience, suggested structure, prerequisites>"
+  ```
+- Flag missing tutorial issue for workflow changes as MEDIUM.
+- Skip for changes that don't introduce new workflows.
+
+### Internal-Only Change Exemption
+
+Changes that are purely internal MUST NOT trigger any documentation or content findings:
+- Refactoring with no user-facing behavior change
+- Test-only changes (`*_test.go`)
+- CI/CD pipeline changes (`.github/`)
+- Spec artifacts (`specs/`, `openspec/`)
+- Dependency management (`go.mod`, `go.sum`)
+
+If all changed files fall into internal-only paths, produce no findings and APPROVE.
+
+---
+
+## Spec Review Mode
+
+Use this mode when the caller instructs you to review specification artifacts instead of code.
+
+### Review Scope
+
+Read **all files** under `specs/` recursively. Focus on documentation completeness within the specs themselves.
+
+### Audit Checklist
+
+#### 1. Documentation Completeness
+
+- Does the spec identify which documentation files need updating upon implementation?
+- Are there user-facing changes described in the spec that would require AGENTS.md, README.md, or website updates?
+- If the spec describes user-facing changes but does not mention documentation impact, flag as MEDIUM.
+
+#### 2. Content Coverage Assessment
+
+- Does the spec describe changes significant enough to warrant blog coverage?
+- Does the spec introduce workflows that would benefit from tutorials?
+- If content opportunities exist but are not acknowledged in the spec, note as LOW (informational).
+
+---
+
+## Output Format
+
+For each finding, provide:
+
+```
+### [SEVERITY] Finding Title
+
+**File**: `path/to/file:line` (or `specs/NNN-feature/artifact.md` in spec review mode)
+**Constraint**: Documentation Completeness / Content Pipeline
+**Description**: What documentation is missing and why it matters
+**Recommendation**: What to update or what issue to file
+```
+
+Severity levels: CRITICAL, HIGH, MEDIUM, LOW (per `.opencode/uf/packs/severity.md`)
+
+## Decision Criteria
+
+- **APPROVE** if all documentation is current, all required website issues exist (or were just filed), and no content opportunities were missed for significant changes.
+- **REQUEST CHANGES** if any documentation gap (MEDIUM+) or missing content issue (MEDIUM+) is found.
+
+End your review with a clear **APPROVE** or **REQUEST CHANGES** verdict and a summary of findings.
+
+## Graceful Degradation
+
+| Condition | Behavior |
+|-----------|----------|
+| `gh` not available | Report failure as a finding with the issue text you would have filed, so the developer can file it manually. Include the full `gh issue create` command in the recommendation. |
+| Website repo inaccessible | Report failure as a finding with the issue text for manual filing. Do not block the review — report the issue content and let the developer file it. |
+| Dewey not available | Skip Step 0 (Prior Learnings), proceed with standard review. Note the skip as informational. |
+| No content pack loaded | Skip content quality checks on issue descriptions. File issues with best-effort descriptions. |
+
+---
+
+## Out of Scope
+
+These domains are owned by other agents — do NOT produce findings for them:
+
+- **Writing documentation** → The Scribe (technical docs, READMEs, API docs)
+- **Writing blog posts** → The Herald (blog content, announcements)
+- **Writing PR communications** → The Envoy (release notes, PR descriptions)
+- **Code quality** → The Architect (conventions, patterns, DRY)
+- **Security** → The Adversary (secrets, CVEs, error handling)
+- **Test quality** → The Tester (coverage, assertions, isolation)
+- **Intent drift** → The Guard (plan alignment, zero-waste, constitution)
+- **Operational readiness** → The SRE (deployment, performance, config)
+
+The Curator identifies **what** needs documenting and files tracking issues. The Curator does NOT write the documentation, blog posts, or tutorials — that is the responsibility of the content agents (Scribe, Herald, Envoy) and the development team.

--- a/.opencode/command/cobalt-crush.md
+++ b/.opencode/command/cobalt-crush.md
@@ -7,6 +7,7 @@ description: >
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Command: /cobalt-crush

--- a/.opencode/command/constitution-check.md
+++ b/.opencode/command/constitution-check.md
@@ -4,6 +4,7 @@ agent: constitution-check
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 

--- a/.opencode/command/dewey-index.md
+++ b/.opencode/command/dewey-index.md
@@ -1,0 +1,34 @@
+---
+description: >
+  Trigger an incremental re-index of all configured content sources.
+  Updates the Dewey knowledge graph with new and changed content from
+  disk, GitHub, web, and code sources without leaving the OpenCode session.
+---
+
+# Command: /dewey-index
+
+## Description
+
+Trigger an incremental re-index of all configured content sources.
+Updates the Dewey knowledge graph with new and changed content from
+disk, GitHub, web, and code sources without leaving the OpenCode session.
+
+## Usage
+
+```
+/dewey-index
+/dewey-index disk-website
+```
+
+## Instructions
+
+Call the Dewey MCP tool `index` to re-index configured sources.
+
+If the user provided a source ID argument (e.g., `disk-website`),
+pass it as the `source_id` parameter to index only that source.
+
+If no argument is provided, call `index` with no parameters to
+index all configured sources.
+
+Display the returned summary showing sources processed, pages
+new/changed/deleted, embeddings generated, and elapsed time.

--- a/.opencode/command/dewey-reindex.md
+++ b/.opencode/command/dewey-reindex.md
@@ -1,0 +1,30 @@
+---
+description: >
+  Delete and rebuild all external source content in the Dewey index.
+  Preserves local vault content and stored learnings. Use when the
+  index appears stale or corrupted.
+---
+
+# Command: /dewey-reindex
+
+## Description
+
+Delete and rebuild all external source content in the Dewey index.
+Preserves local vault content and stored learnings. Use when the
+index appears stale or corrupted.
+
+## Usage
+
+```
+/dewey-reindex
+```
+
+## Instructions
+
+**Warning**: This deletes all external source content and rebuilds
+from scratch. Local vault content and stored learnings are preserved.
+
+Call the Dewey MCP tool `reindex` with no parameters.
+
+Display the returned summary showing pages deleted, sources
+re-indexed, new page counts, and elapsed time.

--- a/.opencode/command/finale.md
+++ b/.opencode/command/finale.md
@@ -6,6 +6,7 @@ description: >
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 
 # Command: /finale
 

--- a/.opencode/command/opsx-propose.md
+++ b/.opencode/command/opsx-propose.md
@@ -130,3 +130,15 @@ After completing all artifacts, summarize:
 - If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
 - If a change with that name already exists, ask if user wants to continue it or create a new one
 - Verify each artifact file exists after writing before proceeding to next
+
+## Guardrails
+
+- **NEVER implement code changes** — this command
+  creates artifacts ONLY (proposal, design, specs,
+  tasks)
+- **NEVER commit, push, or create PRs** — those are
+  /finale's responsibility
+- **NEVER run /opsx-apply or /cobalt-crush** — the
+  user decides when to implement
+- After artifacts are complete, STOP and prompt the
+  user to run /opsx-apply or /cobalt-crush

--- a/.opencode/command/review-council.md
+++ b/.opencode/command/review-council.md
@@ -3,6 +3,7 @@ description: Run the reviewer governance council to audit codebase or spec compl
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 # Command: /review-council
 
@@ -112,6 +113,7 @@ This table documents known Divisor persona roles and their focus areas. It is us
 | `divisor-guard` | The Guard | Intent drift/plan alignment, zero-waste mandate, constitution alignment, cross-component value [PACK] | Intent fidelity, scope discipline, inter-spec consistency, status accuracy, user value, constitution alignment |
 | `divisor-testing` | The Tester | Test architecture [PACK], coverage strategy, assertion depth, test isolation, regression protection, convention compliance [PACK] | Testability of requirements, test strategy coverage, fixture feasibility, coverage expectations, contract surface |
 | `divisor-sre` | The Operator | File permissions/config, efficiency/performance, release pipeline [PACK], dependency health [PACK], runtime observability, upgrade paths, operational docs, backup/recovery | Deployment feasibility, operational requirements, config management, dependency risk, maintenance burden |
+| `divisor-curator` | The Curator | Documentation gaps, blog/tutorial opportunities, website issue filing | Documentation completeness in specs, content coverage |
 
 For any discovered agent not in this table, delegate with a generic review prompt appropriate to the current review mode.
 

--- a/.opencode/command/speckit.analyze.md
+++ b/.opencode/command/speckit.analyze.md
@@ -3,6 +3,7 @@ description: Perform a non-destructive cross-artifact consistency and quality an
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 
@@ -186,3 +187,17 @@ Ask the user: "Would you like me to suggest concrete remediation edits for the t
 ## Context
 
 $ARGUMENTS
+
+## Guardrails
+
+- **NEVER modify source code** — this command updates
+  spec artifacts ONLY. Implementation changes belong in
+  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+- **NEVER modify test files, Go source, Markdown agents,
+  convention packs, or config files** outside the
+  `specs/NNN-*/` feature directory.
+- The ONLY files this command may write are:
+  - `FEATURE_SPEC` (the spec.md file)
+  - Files within `FEATURE_DIR` (spec artifacts:
+    plan.md, tasks.md, research.md, data-model.md,
+    quickstart.md, contracts/, checklists/)

--- a/.opencode/command/speckit.checklist.md
+++ b/.opencode/command/speckit.checklist.md
@@ -3,6 +3,7 @@ description: Generate a custom checklist for the current feature based on user r
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 
@@ -296,3 +297,17 @@ Sample items:
 - Correct: Validation of requirement quality
 - Wrong: "Does it do X?"
 - Correct: "Is X clearly specified?"
+
+## Guardrails
+
+- **NEVER modify source code** — this command updates
+  spec artifacts ONLY. Implementation changes belong in
+  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+- **NEVER modify test files, Go source, Markdown agents,
+  convention packs, or config files** outside the
+  `specs/NNN-*/` feature directory.
+- The ONLY files this command may write are:
+  - `FEATURE_SPEC` (the spec.md file)
+  - Files within `FEATURE_DIR` (spec artifacts:
+    plan.md, tasks.md, research.md, data-model.md,
+    quickstart.md, contracts/, checklists/)

--- a/.opencode/command/speckit.clarify.md
+++ b/.opencode/command/speckit.clarify.md
@@ -7,6 +7,7 @@ handoffs:
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 
@@ -183,3 +184,17 @@ Behavior rules:
 - If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
 
 Context for prioritization: $ARGUMENTS
+
+## Guardrails
+
+- **NEVER modify source code** — this command updates
+  spec artifacts ONLY. Implementation changes belong in
+  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+- **NEVER modify test files, Go source, Markdown agents,
+  convention packs, or config files** outside the
+  `specs/NNN-*/` feature directory.
+- The ONLY files this command may write are:
+  - `FEATURE_SPEC` (the spec.md file)
+  - Files within `FEATURE_DIR` (spec artifacts:
+    plan.md, tasks.md, research.md, data-model.md,
+    quickstart.md, contracts/, checklists/)

--- a/.opencode/command/speckit.constitution.md
+++ b/.opencode/command/speckit.constitution.md
@@ -7,6 +7,7 @@ handoffs:
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 
@@ -86,3 +87,17 @@ If the user supplies partial updates (e.g., only one principle revision), still 
 If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
 
 Do not create a new template; always operate on the existing `.specify/memory/constitution.md` file.
+
+## Guardrails
+
+- **NEVER modify source code** — this command updates
+  spec artifacts ONLY. Implementation changes belong in
+  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+- **NEVER modify test files, Go source, Markdown agents,
+  convention packs, or config files** outside the
+  `specs/NNN-*/` feature directory.
+- The ONLY files this command may write are:
+  - `FEATURE_SPEC` (the spec.md file)
+  - Files within `FEATURE_DIR` (spec artifacts:
+    plan.md, tasks.md, research.md, data-model.md,
+    quickstart.md, contracts/, checklists/)

--- a/.opencode/command/speckit.implement.md
+++ b/.opencode/command/speckit.implement.md
@@ -3,6 +3,7 @@ description: Execute the implementation plan by processing and executing all tas
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 
@@ -153,3 +154,17 @@ You **MUST** consider the user input before proceeding (if not empty).
      4. Then merge and switch branches
 
 Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit.tasks` first to regenerate the task list.
+
+## Guardrails
+
+- **NEVER modify source code** — this command updates
+  spec artifacts ONLY. Implementation changes belong in
+  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+- **NEVER modify test files, Go source, Markdown agents,
+  convention packs, or config files** outside the
+  `specs/NNN-*/` feature directory.
+- The ONLY files this command may write are:
+  - `FEATURE_SPEC` (the spec.md file)
+  - Files within `FEATURE_DIR` (spec artifacts:
+    plan.md, tasks.md, research.md, data-model.md,
+    quickstart.md, contracts/, checklists/)

--- a/.opencode/command/speckit.plan.md
+++ b/.opencode/command/speckit.plan.md
@@ -11,6 +11,7 @@ handoffs:
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 
@@ -107,3 +108,17 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 - Use absolute paths
 - ERROR on gate failures or unresolved clarifications
+
+## Guardrails
+
+- **NEVER modify source code** — this command updates
+  spec artifacts ONLY. Implementation changes belong in
+  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+- **NEVER modify test files, Go source, Markdown agents,
+  convention packs, or config files** outside the
+  `specs/NNN-*/` feature directory.
+- The ONLY files this command may write are:
+  - `FEATURE_SPEC` (the spec.md file)
+  - Files within `FEATURE_DIR` (spec artifacts:
+    plan.md, tasks.md, research.md, data-model.md,
+    quickstart.md, contracts/, checklists/)

--- a/.opencode/command/speckit.specify.md
+++ b/.opencode/command/speckit.specify.md
@@ -11,6 +11,7 @@ handoffs:
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 
@@ -283,3 +284,17 @@ Success criteria must be:
 - "Database can handle 1000 TPS" (implementation detail, use user-facing metric)
 - "React components render efficiently" (framework-specific)
 - "Redis cache hit rate above 80%" (technology-specific)
+
+## Guardrails
+
+- **NEVER modify source code** — this command updates
+  spec artifacts ONLY. Implementation changes belong in
+  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+- **NEVER modify test files, Go source, Markdown agents,
+  convention packs, or config files** outside the
+  `specs/NNN-*/` feature directory.
+- The ONLY files this command may write are:
+  - `FEATURE_SPEC` (the spec.md file)
+  - Files within `FEATURE_DIR` (spec artifacts:
+    plan.md, tasks.md, research.md, data-model.md,
+    quickstart.md, contracts/, checklists/)

--- a/.opencode/command/speckit.tasks.md
+++ b/.opencode/command/speckit.tasks.md
@@ -12,6 +12,7 @@ handoffs:
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 
@@ -153,3 +154,17 @@ Every task MUST strictly follow this format:
   - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
   - Each phase should be a complete, independently testable increment
 - **Final Phase**: Polish & Cross-Cutting Concerns
+
+## Guardrails
+
+- **NEVER modify source code** — this command updates
+  spec artifacts ONLY. Implementation changes belong in
+  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+- **NEVER modify test files, Go source, Markdown agents,
+  convention packs, or config files** outside the
+  `specs/NNN-*/` feature directory.
+- The ONLY files this command may write are:
+  - `FEATURE_SPEC` (the spec.md file)
+  - Files within `FEATURE_DIR` (spec artifacts:
+    plan.md, tasks.md, research.md, data-model.md,
+    quickstart.md, contracts/, checklists/)

--- a/.opencode/command/speckit.taskstoissues.md
+++ b/.opencode/command/speckit.taskstoissues.md
@@ -4,6 +4,7 @@ tools: ['github/github-mcp-server/issue_write']
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 
@@ -32,3 +33,17 @@ git config --get remote.origin.url
 
 > [!CAUTION]
 > UNDER NO CIRCUMSTANCES EVER CREATE ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL
+
+## Guardrails
+
+- **NEVER modify source code** — this command updates
+  spec artifacts ONLY. Implementation changes belong in
+  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+- **NEVER modify test files, Go source, Markdown agents,
+  convention packs, or config files** outside the
+  `specs/NNN-*/` feature directory.
+- The ONLY files this command may write are:
+  - `FEATURE_SPEC` (the spec.md file)
+  - Files within `FEATURE_DIR` (spec artifacts:
+    plan.md, tasks.md, research.md, data-model.md,
+    quickstart.md, contracts/, checklists/)

--- a/.opencode/command/uf-init.md
+++ b/.opencode/command/uf-init.md
@@ -7,6 +7,7 @@ description: >
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Command: /uf-init
@@ -311,7 +312,595 @@ customization), or at the end of the file if no natural
 insertion point exists. Do NOT insert this in command files --
 skills only (commands delegate to skills for behavior).
 
-### Step 5: Report Results
+### Step 5: Speckit Custom Commands
+
+Create the 4 UF-custom speckit commands that upstream
+`specify init` does not provide. For each file below:
+
+1. **Check** if the file exists in `.opencode/command/`
+2. **If it exists**: Report `⊘ <filename>: already exists (skipped)`
+3. **If it does not exist**: Create it with the content
+   described below. Report `✅ <filename>: created`
+
+#### speckit.analyze.md
+
+Create `.opencode/command/speckit.analyze.md` — a
+read-only cross-artifact consistency and quality analysis
+command. The command:
+- Runs after `/speckit.tasks` produces `tasks.md`
+- Loads spec.md, plan.md, tasks.md, and constitution
+- Performs 6 detection passes: duplication, ambiguity,
+  underspecification, constitution alignment, coverage
+  gaps, and inconsistency
+- Assigns severity (CRITICAL/HIGH/MEDIUM/LOW)
+- Produces a Markdown analysis report (no file writes)
+- Offers optional remediation suggestions
+
+Use this frontmatter:
+```yaml
+---
+description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation.
+---
+```
+
+#### speckit.checklist.md
+
+Create `.opencode/command/speckit.checklist.md` — a
+requirements quality validation command ("unit tests
+for English"). The command:
+- Generates checklists that test REQUIREMENTS quality,
+  not implementation behavior
+- Creates files in `FEATURE_DIR/checklists/[domain].md`
+- Items use question format: "Are [X] defined for [Y]?"
+- Items include quality dimension tags: [Completeness],
+  [Clarity], [Consistency], [Measurability], [Coverage]
+- Asks up to 3 clarifying questions before generating
+- Each run creates a NEW checklist file (never overwrites)
+
+Use this frontmatter:
+```yaml
+---
+description: Generate a custom checklist for the current feature based on user requirements.
+---
+```
+
+#### speckit.clarify.md
+
+Create `.opencode/command/speckit.clarify.md` — a spec
+ambiguity detection and resolution command. The command:
+- Scans spec.md for ambiguities across 10 taxonomy
+  categories (functional scope, data model, UX flow,
+  non-functional, integration, edge cases, constraints,
+  terminology, completion signals, placeholders)
+- Asks up to 5 targeted questions, one at a time
+- Provides recommended answers with reasoning
+- Integrates answers directly into spec.md sections
+- Records Q&A in a `## Clarifications` section
+
+Use this frontmatter:
+```yaml
+---
+description: Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec.
+---
+```
+
+#### speckit.taskstoissues.md
+
+Create `.opencode/command/speckit.taskstoissues.md` — a
+GitHub issue creation command. The command:
+- Reads tasks.md and creates GitHub issues for each task
+- Requires a GitHub remote URL (validates before creating)
+- Uses the GitHub MCP server for issue creation
+- NEVER creates issues in repos that don't match the
+  remote URL
+
+Use this frontmatter:
+```yaml
+---
+description: Convert existing tasks into actionable, dependency-ordered GitHub issues for the feature based on available design artifacts.
+tools: ['github/github-mcp-server/issue_write']
+---
+```
+
+All 4 commands MUST include the standard initialization
+step: run `.specify/scripts/bash/check-prerequisites.sh
+--json` from repo root and parse JSON for FEATURE_DIR.
+
+### Step 6: Speckit Command Guardrails
+
+Inject a `## Guardrails` section into ALL 9
+`.opencode/command/speckit.*.md` files. For each file:
+
+1. **Read** the file content
+2. **Check** if a `## Guardrails` section already exists
+   (search for the heading text `## Guardrails`)
+3. **If already present**: Report
+   `⊘ <filename>: guardrails already present (skipped)`
+4. **If not present**: Append the following block at the
+   very end of the file. Report
+   `✅ <filename>: guardrails injected`
+
+The guardrails block to append:
+
+```markdown
+
+## Guardrails
+
+- **NEVER modify source code** — this command updates
+  spec artifacts ONLY. Implementation changes belong in
+  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+- **NEVER modify test files, Go source, Markdown agents,
+  convention packs, or config files** outside the
+  `specs/NNN-*/` feature directory.
+- The ONLY files this command may write are:
+  - `FEATURE_SPEC` (the spec.md file)
+  - Files within `FEATURE_DIR` (spec artifacts:
+    plan.md, tasks.md, research.md, data-model.md,
+    quickstart.md, contracts/, checklists/)
+```
+
+The 9 target files are:
+- `speckit.specify.md`
+- `speckit.clarify.md`
+- `speckit.plan.md`
+- `speckit.tasks.md`
+- `speckit.analyze.md`
+- `speckit.checklist.md`
+- `speckit.implement.md`
+- `speckit.constitution.md`
+- `speckit.taskstoissues.md`
+
+**Note**: `speckit.implement.md` is an exception — it IS
+allowed to modify source code. However, the guardrails
+section is still injected for consistency. The implement
+command's own instructions override the guardrails where
+they conflict (implement's instructions explicitly say
+to write source code).
+
+### Step 7: Speckit UF Customizations
+
+Verify that UF-specific content is present in the
+upstream speckit commands. For each of the 5 upstream
+commands (`speckit.specify.md`, `speckit.plan.md`,
+`speckit.tasks.md`, `speckit.implement.md`,
+`speckit.constitution.md`):
+
+1. **Read** the file content
+2. **Check** for these UF-specific references:
+   - Dewey integration: does the file mention
+     `dewey_semantic_search` or `dewey_search` as tool
+     invocations? (Not just prose mentions of "Dewey")
+   - Constitution check: does the file reference
+     `.specify/memory/constitution.md` or the
+     Constitution Check gate?
+   - Review council: does `speckit.implement.md`
+     reference `/review-council` or the Divisor review
+     system?
+3. **If all references present**: Report
+   `⊘ <filename>: UF customizations present (skipped)`
+4. **If any reference missing**: Report which references
+   are missing but do NOT modify the file. These are
+   informational — the upstream commands may not include
+   UF-specific content, and that's acceptable.
+   Report `ℹ <filename>: missing [list] (informational)`
+
+This step is read-only — it verifies but does not modify.
+
+### Step 8: OpenSpec Command Guardrails
+
+For `.opencode/command/opsx-propose.md`:
+
+1. **Read** the file content
+2. **Check** if a `## Guardrails` section exists at the
+   end of the file (search for the heading text
+   `## Guardrails`)
+3. **If already present**: Report
+   `⊘ opsx-propose.md: guardrails already present (skipped)`
+4. **If not present**: Append the following block at the
+   very end of the file. Report
+   `✅ opsx-propose.md: guardrails injected`
+
+The guardrails block to append:
+
+```markdown
+
+## Guardrails
+
+- **NEVER implement code changes** — this command
+  creates artifacts ONLY (proposal, design, specs,
+  tasks)
+- **NEVER commit, push, or create PRs** — those are
+  /finale's responsibility
+- **NEVER run /opsx-apply or /cobalt-crush** — the
+  user decides when to implement
+- After artifacts are complete, STOP and prompt the
+  user to run /opsx-apply or /cobalt-crush
+```
+
+### Step 9: AGENTS.md Behavioral Guidance
+
+For the repo's `AGENTS.md` file, inject standardized
+behavioral guidance sections if not already present.
+
+1. **Check** if `AGENTS.md` exists at the repo root.
+   If not, report `⊘ AGENTS.md: not found (skipped)`
+   and skip this entire step.
+
+2. **Read** the full contents of `AGENTS.md`.
+
+3. For each of the 8 guidance blocks below, in the order
+   listed (Core Mission first, Knowledge Retrieval last):
+   a. Check if the detection phrase (or semantic
+      equivalent heading) exists in the file
+   b. If present: report `⊘ <block>: already present
+      (skipped)`
+   c. If not present: find the appropriate insertion
+      point per the placement guidance and append the
+      block text. Report `✅ <block>: injected`
+
+4. After processing all 8 blocks, save the file once.
+
+**Injection order** (optimized for document flow):
+1. Core Mission
+2. Gatekeeping Value Protection
+3. Workflow Phase Boundaries
+4. CI Parity Gate
+5. Review Council PR Prerequisite
+6. Spec-First Development
+7. Website Documentation Sync Gate
+8. Knowledge Retrieval
+
+#### Block 1: Core Mission
+
+**Detection phrases**: `## Core Mission`, or both
+`Strategic Architecture` AND `Outcome Orientation`
+present in the same section.
+
+**Placement**: After `## Project Overview`, before
+`## Behavioral Constraints`. If neither heading exists,
+append near the top of the file after any frontmatter
+and title.
+
+**Text to inject**:
+
+```markdown
+## Core Mission
+
+- **Strategic Architecture**: Engineers shift from manual
+  coding to directing an "infinite supply of junior
+  developers" (AI agents).
+- **Outcome Orientation**: Focus on conveying business
+  value and user intent rather than low-level technical
+  sub-tasks.
+- **Intent-to-Context**: Treat specs and rules as the
+  medium through which human intent is manifested into
+  code.
+```
+
+#### Block 2: Gatekeeping Value Protection
+
+**Detection phrases**: `Gatekeeping Value Protection`
+heading, or `MUST NOT modify values that serve as
+quality`.
+
+**Placement**: Inside `## Behavioral Constraints`
+section. If `## Behavioral Constraints` does not exist,
+create it and place it after `## Core Mission` (or after
+`## Project Overview` if Core Mission is absent).
+
+**Text to inject**:
+
+```markdown
+### Gatekeeping Value Protection
+
+Agents MUST NOT modify values that serve as quality or
+governance gates to make an implementation pass. The
+following categories are protected:
+
+1. **Coverage thresholds and CRAP scores** — minimum
+   coverage percentages, CRAP score limits, coverage
+   ratchets
+2. **Severity definitions and auto-fix policies** —
+   CRITICAL/HIGH/MEDIUM/LOW boundaries, auto-fix
+   eligibility rules
+3. **Convention pack rule classifications** —
+   MUST/SHOULD/MAY designations on convention pack rules
+   (downgrading MUST to SHOULD is prohibited)
+4. **CI flags and linter configuration** — `-race`,
+   `-count=1`, `govulncheck`, `golangci-lint` rules,
+   pinned action SHAs
+5. **Agent temperature and tool-access settings** —
+   frontmatter `temperature`, `tools.write`, `tools.edit`,
+   `tools.bash` restrictions
+6. **Constitution MUST rules** — any MUST rule in
+   `.specify/memory/constitution.md` or hero constitutions
+7. **Review iteration limits and worker concurrency** —
+   max review iterations, max concurrent Swarm workers,
+   retry limits
+8. **Workflow gate markers** — `<!-- spec-review: passed
+   -->`, task completion checkboxes used as gates, phase
+   checkpoint requirements
+
+**What to do instead**: When an implementation cannot
+meet a gate, the agent MUST stop, report which gate is
+blocking and why, and let the human decide whether to
+adjust the gate or rework the implementation. Modifying
+a gate without explicit human authorization is a
+constitution violation (CRITICAL severity).
+```
+
+#### Block 3: Workflow Phase Boundaries
+
+**Detection phrases**: `Workflow Phase Boundaries`
+heading, or `MUST NOT cross workflow phase boundaries`.
+
+**Placement**: Inside `## Behavioral Constraints`,
+after Gatekeeping Value Protection (if present). If
+`## Behavioral Constraints` does not exist, create it.
+
+**Text to inject**:
+
+```markdown
+### Workflow Phase Boundaries
+
+Agents MUST NOT cross workflow phase boundaries:
+
+- **Specify/Clarify/Plan/Tasks/Analyze/Checklist** phases:
+  spec artifacts ONLY (`specs/NNN-*/` directory). No
+  source code, test, agent, command, or config changes.
+- **Implement** phase: source code changes allowed,
+  guided by spec artifacts.
+- **Review** phase: findings and minor fixes only. No new
+  features.
+
+A phase boundary violation is treated as a process error.
+The agent MUST stop and report the violation rather than
+proceeding with out-of-phase changes.
+```
+
+#### Block 4: CI Parity Gate
+
+**Detection phrases**: `CI Parity Gate` heading or bold
+text, or `replicate the CI checks locally`.
+
+**Placement**: Inside `## Behavioral Constraints` or
+`## Technical Guardrails`, after Workflow Phase
+Boundaries (if present). If neither section exists,
+create `## Behavioral Constraints` and place it there.
+
+**Text to inject**:
+
+```markdown
+### CI Parity Gate
+
+Before marking any implementation task complete or
+declaring a PR ready, agents MUST replicate the CI checks
+locally. Read `.github/workflows/` to identify the exact
+commands CI runs, then execute those same commands. Any
+failure is a blocking error — a task is not complete
+until all CI-equivalent checks pass locally. Do not rely
+on a memorized list of commands; always derive them from
+the workflow files, which are the source of truth.
+```
+
+#### Block 5: Review Council PR Prerequisite
+
+**Detection phrases**: Both `Review Council` AND
+`PR Prerequisite` present, or `/review-council` as a
+command reference in a PR workflow context.
+
+**Placement**: After behavioral constraints, before
+build commands or testing conventions. If no clear
+anchor exists, append after the last behavioral
+constraint block.
+
+**Text to inject**:
+
+```markdown
+### Review Council as PR Prerequisite
+
+Before submitting a pull request, agents **must** run
+`/review-council` and resolve all REQUEST CHANGES
+findings until all reviewers return APPROVE. There must
+be **minimal to no code changes** between the council's
+APPROVE verdict and the PR submission — the council
+reviews the final code, not a draft that changes
+afterward.
+
+Workflow:
+
+1. Complete all implementation tasks
+2. Run CI checks locally (build, test, vet)
+3. Run `/review-council` — fix any findings, re-run
+   until APPROVE
+4. Commit, push, and submit PR immediately after council
+   APPROVE
+5. Do NOT make further code changes between APPROVE and
+   PR submission
+
+Exempt from council review:
+
+- Constitution amendments (governance documents, not code)
+- Documentation-only changes (README, AGENTS.md, spec
+  artifacts)
+- Emergency hotfixes (must be retroactively reviewed)
+```
+
+#### Block 6: Spec-First Development
+
+**Detection phrases**: `Spec-First Development` heading,
+or `preceded by a spec workflow`.
+
+**Placement**: After behavioral constraints, before
+build commands. If no clear anchor exists, append after
+the last behavioral constraint or workflow rule block.
+
+**Text to inject**:
+
+```markdown
+## Spec-First Development
+
+All changes that modify production code, test code, agent
+prompts, embedded assets, or CI configuration **must** be
+preceded by a spec workflow. The constitution
+(`.specify/memory/constitution.md`) is the highest-
+authority document in this project — all work must align
+with it.
+
+Two spec workflows are available:
+
+| Workflow | Location | Best For |
+|----------|----------|----------|
+| **Speckit** | `specs/NNN-name/` | Numbered feature specs with the full pipeline |
+| **OpenSpec** | `openspec/changes/name/` | Targeted changes with lightweight artifacts |
+
+**What requires a spec** (no exceptions without explicit
+user override):
+
+- New features or capabilities
+- Refactoring that changes function signatures, extracts
+  helpers, or moves code between packages
+- Test additions or assertion strengthening across
+  multiple functions
+- Agent prompt changes
+- CI workflow modifications
+- Data model changes (new struct fields, schema updates)
+
+**What is exempt** (may be done directly):
+
+- Constitution amendments (governed by the constitution's
+  own Governance section)
+- Typo corrections, comment-only changes, single-line
+  formatting fixes
+- Emergency hotfixes for critical production bugs (must
+  be retroactively documented)
+
+When an agent is unsure whether a change is trivial, it
+**must** ask the user rather than proceeding without a
+spec. The cost of an unnecessary spec is minutes; the
+cost of an unplanned change is rework, drift, and broken
+CI.
+```
+
+#### Block 7: Website Documentation Sync Gate
+
+**Detection phrases**: `Website Documentation` AND
+`Gate` in a heading, or `gh issue create --repo` with
+`unbound-force/website`.
+
+**Placement**: Near documentation validation gate or
+spec commit gate. If no clear anchor exists, append
+after Spec-First Development.
+
+**Text to inject**:
+
+````markdown
+### Website Documentation Gate
+
+When a change affects user-facing behavior, hero
+capabilities, CLI commands, or workflows, a GitHub issue
+**MUST** be created in the `unbound-force/website`
+repository to track required documentation or website
+updates. The issue must be created before the
+implementing PR is merged.
+
+```bash
+gh issue create --repo unbound-force/website \
+  --title "docs: <brief description of what changed>" \
+  --body "<what changed, why it matters, which pages
+          need updating>"
+```
+
+**Exempt changes** (no website issue needed):
+- Internal refactoring with no user-facing behavior
+  change
+- Test-only changes
+- CI/CD pipeline changes
+- Spec artifacts (specs are internal planning documents)
+
+**Examples requiring a website issue**:
+- New CLI command or flag added
+- Hero capabilities changed (new agent, removed feature)
+- Installation steps changed (`uf setup` flow)
+- New convention pack added
+- Breaking changes to any user-facing workflow
+````
+
+#### Block 8: Knowledge Retrieval
+
+**Detection phrases**: `## Knowledge Retrieval` heading,
+or `dewey_semantic_search` as a tool reference (in a
+table or code block, not just prose), or
+`Tool Selection Matrix`.
+
+**Placement**: After coding conventions, before testing
+conventions. If neither section exists, append near the
+end of the file before any appendix or changelog.
+
+**Text to inject**:
+
+```markdown
+## Knowledge Retrieval
+
+Agents SHOULD prefer Dewey MCP tools over grep/glob/read
+for cross-repo context, design decisions, and
+architectural patterns. Dewey provides semantic search
+across all indexed Markdown files, specs, and web
+documentation — returning ranked results with provenance
+metadata that grep cannot match.
+
+### Tool Selection Matrix
+
+| Query Intent | Dewey Tool | When to Use |
+|-------------|-----------|-------------|
+| Conceptual understanding | `dewey_semantic_search` | "How does X work?" |
+| Keyword lookup | `dewey_search` | Known terms, FR numbers |
+| Read specific page | `dewey_get_page` | Known document path |
+| Relationship discovery | `dewey_find_connections` | "How are X and Y related?" |
+| Similar documents | `dewey_similar` | "Find specs like this one" |
+| Tag-based discovery | `dewey_find_by_tag` | "All pages tagged #decision" |
+| Property queries | `dewey_query_properties` | "All specs with status: draft" |
+| Filtered semantic | `dewey_semantic_search_filtered` | Semantic search within source type |
+| Graph navigation | `dewey_traverse` | Dependency chain walking |
+
+### When to Fall Back to grep/glob/read
+
+Use direct file operations instead of Dewey when:
+- **Dewey is unavailable** — MCP tools return errors or
+  are not configured
+- **Exact string matching is needed** — searching for a
+  specific error message, variable name, or code pattern
+- **Specific file path is known** — reading a file you
+  already know the path to (use Read directly)
+- **Binary/non-Markdown content** — Dewey indexes
+  Markdown; use grep for Go source, JSON, YAML, etc.
+
+### Graceful Degradation (3-Tier Pattern)
+
+**Tier 3 (Full Dewey)** — semantic + structured search:
+- `dewey_semantic_search` — natural language queries
+- `dewey_search` — keyword queries
+- `dewey_get_page`, `dewey_find_connections`,
+  `dewey_traverse` — structured navigation
+- `dewey_find_by_tag`, `dewey_query_properties` —
+  metadata queries
+
+**Tier 2 (Graph-only, no embedding model)** — structured
+search only:
+- `dewey_search` — keyword queries (no embeddings needed)
+- `dewey_get_page`, `dewey_traverse`,
+  `dewey_find_connections` — graph navigation
+- `dewey_find_by_tag`, `dewey_query_properties` —
+  metadata queries
+- Semantic search unavailable — use exact keyword matches
+
+**Tier 1 (No Dewey)** — direct file access:
+- Use Read tool for direct file access
+- Use Grep for keyword search across the codebase
+- Use Glob for file pattern matching
+```
+
+### Step 10: Report Results
 
 After processing all customizations, display a summary:
 
@@ -334,6 +923,32 @@ After processing all customizations, display a summary:
 ### 3-Tier Degradation (Skills only)
   [status] [filename]: [action]
   ...
+
+### Speckit Custom Commands
+  [status] [filename]: [action]
+  ...
+
+### Speckit Command Guardrails
+  [status] [filename]: [action]
+  ...
+
+### Speckit UF Customizations
+  [status] [filename]: [action]
+  ...
+
+### OpenSpec Command Guardrails
+  [status] [filename]: [action]
+  ...
+
+### AGENTS.md Guidance
+  [status] Core Mission: [action]
+  [status] Gatekeeping Value Protection: [action]
+  [status] Workflow Phase Boundaries: [action]
+  [status] CI Parity Gate: [action]
+   [status] Review Council PR Prerequisite: [action]
+   [status] Spec-First Development: [action]
+   [status] Website Documentation Sync Gate: [action]
+  [status] Knowledge Retrieval: [action]
 
 ### Summary
 Applied: N | Already present: N | Errors: N
@@ -359,3 +974,49 @@ modified (had at least one `✅` insertion):
 
 Finally, remind the user:
 > Run `git diff` to review all changes before committing.
+
+### Next Steps
+
+After customizations are applied:
+
+- Run `/cobalt-crush` to start implementing — it
+  auto-detects your active workflow (Speckit or OpenSpec)
+  and delegates to the correct implementation command.
+  Preferred over calling `/opsx-apply` directly.
+
+### Tool Delegation (Spec 027)
+
+As of Spec 027, `uf init` delegates workspace initialization
+to external CLIs when they are available:
+
+- **Speckit**: `.specify/` is created by `specify init` (not
+  embedded). If `specify` is in PATH and `.specify/` does not
+  exist, `uf init` calls `specify init` automatically.
+  Post-init customization of Speckit scripts/templates is
+  handled by the `specify` CLI itself.
+
+- **OpenSpec**: `openspec/config.yaml` and base structure are
+  created by `openspec init --tools opencode` (not embedded).
+  The custom OpenSpec schema (`openspec/schemas/unbound-force/`)
+  is still deployed from embedded assets. If `openspec` is in
+  PATH and `openspec/config.yaml` does not exist, `uf init`
+  calls `openspec init --tools opencode` automatically.
+
+- **Gaze**: Gaze agent files (e.g., `gaze-reporter.md`) are
+  created by `gaze init` (not embedded). If `gaze` is in PATH
+  and `.opencode/agents/gaze-reporter.md` does not exist,
+  `uf init` calls `gaze init` automatically.
+
+All delegations are optional — if a tool is not installed,
+`uf init` skips its delegation silently (Constitution
+Principle II — Composability First).
+
+### When to Re-run
+
+Re-run `/uf-init` after:
+- Running `uf init` or `uf setup` (new tool versions
+  may reset third-party files)
+- Updating the OpenSpec CLI (`npm update`)
+- Upgrading the `uf` binary (`brew upgrade unbound-force`
+  — new versions may add scaffold files that need
+  customization)

--- a/.opencode/command/unleash.md
+++ b/.opencode/command/unleash.md
@@ -1,11 +1,13 @@
 ---
 description: >
-  Run the full Speckit pipeline autonomously: clarify
-  ambiguities with Dewey, generate plan and tasks, review
-  specs, implement with parallel Swarm workers, review code,
-  store learnings, and present demo instructions. Exits to
-  the human only when it genuinely needs human judgment.
+  Run the full Speckit or OpenSpec pipeline autonomously:
+  clarify ambiguities with Dewey, generate plan and tasks,
+  review specs, implement with parallel Swarm workers,
+  review code, store learnings, and present demo
+  instructions. Exits to the human only when it genuinely
+  needs human judgment.
 ---
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 
@@ -13,12 +15,13 @@ description: >
 
 ## Description
 
-Autonomous Speckit pipeline execution. Takes a spec from
-draft to demo-ready code in a single command. Orchestrates
-8 steps: clarify, plan, tasks, spec review, implement,
-code review, retrospective, and demo. Exits gracefully
-when human judgment is needed and resumes from where it
-left off on re-run.
+Autonomous pipeline execution for both Speckit (strategic)
+and OpenSpec (tactical) changes. Takes a spec from draft
+to demo-ready code in a single command. Orchestrates 8
+steps: clarify, plan, tasks, spec review, implement, code
+review, retrospective, and demo. Exits gracefully when
+human judgment is needed and resumes from where it left
+off on re-run.
 
 ## Usage
 
@@ -53,65 +56,91 @@ git rev-parse --abbrev-ref HEAD
 
 - If on `main`: **STOP** with error:
   > "Cannot run /unleash on main. Must be on a Speckit
-  > feature branch (`NNN-*`). Run `/speckit.specify`
-  > first."
+  > (`NNN-*`) or OpenSpec (`opsx/*`) feature branch."
 
-- If on `opsx/*`: **STOP** with error:
-  > "/unleash is for Speckit strategic specs only. Use
-  > `/opsx:apply` for OpenSpec tactical changes."
+- If on `opsx/*`: **OpenSpec mode detected.**
+  Extract the change name from the branch:
+  `opsx/<name>` → `<name>`.
+  Set `FEATURE_DIR = openspec/changes/<name>/`.
+  Set `WORKFLOW_TIER = openspec`.
 
-- If the branch does not match `NNN-*` (digits followed
-  by a dash): **STOP** with error:
+  Check if `FEATURE_DIR/tasks.md` exists. If not:
+  **STOP** with error:
+  > "No tasks.md found for change `<name>`. Run
+  > `/opsx-propose` first."
+
+  Announce: "Detected OpenSpec change: `<name>`"
+
+- If the branch matches `NNN-*` (digits followed by a
+  dash): **Speckit mode detected.**
+
+  Validate that spec.md exists by running from the repo
+  root:
+
+  ```bash
+  .specify/scripts/bash/check-prerequisites.sh --json --require-spec
+  ```
+
+  If the script fails or no spec.md is found: **STOP**
+  with error:
+  > "No spec.md found in the feature directory. Run
+  > `/speckit.specify` first."
+
+  Extract the `FEATURE_DIR` from the JSON output. This
+  is the working directory for all subsequent steps.
+  Set `WORKFLOW_TIER = speckit`.
+
+- If the branch does not match `NNN-*` or `opsx/*`:
+  **STOP** with error:
   > "Unrecognized branch pattern. /unleash requires a
-  > Speckit feature branch (`NNN-*`). Run
-  > `/speckit.specify` to create one."
-
-Validate that spec.md exists by running from the repo
-root:
-
-```bash
-.specify/scripts/bash/check-prerequisites.sh --json --require-spec
-```
-
-If the script fails or no spec.md is found: **STOP**
-with error:
-> "No spec.md found in the feature directory. Run
-> `/speckit.specify` first."
-
-Extract the `FEATURE_DIR` from the JSON output. This is
-the working directory for all subsequent steps.
+  > Speckit feature branch (`NNN-*`) or OpenSpec branch
+  > (`opsx/*`). Run `/speckit.specify` or
+  > `/opsx-propose` to create one."
 
 ### 2. Resumability Detection
 
 Probe filesystem state to determine which steps are
 already complete. Check in order:
 
-1. **Clarify done?** Read spec.md in the feature
-   directory. Check for `[NEEDS CLARIFICATION]` markers.
+**If `WORKFLOW_TIER = openspec`**: checks 1-3 are always
+"done" — these artifacts were created by `/opsx-propose`.
+Skip directly to check 4.
+
+1. **Clarify done?** *(Speckit only)* Read spec.md in
+   the feature directory. Check for
+   `[NEEDS CLARIFICATION]` markers.
    - If NO markers exist AND (a `## Clarifications`
      section exists in spec.md OR plan.md exists in the
      feature directory): clarify is done.
    - Otherwise: clarify is needed.
 
-2. **Plan done?** Check if `plan.md` exists in the
-   feature directory.
+2. **Plan done?** *(Speckit only)* Check if `plan.md`
+   exists in the feature directory.
 
-3. **Tasks done?** Check if `tasks.md` exists in the
-   feature directory.
+3. **Tasks done?** *(Speckit only)* Check if `tasks.md`
+   exists in the feature directory.
 
-4. **Spec review done?** Read `tasks.md` and check for
-   the `<!-- spec-review: passed -->` HTML comment marker.
+4. **Spec review done?** Read `FEATURE_DIR/tasks.md`
+   and check for the `<!-- spec-review: passed -->` HTML
+   comment marker.
 
-5. **Implementation done?** Read `tasks.md` and check
-   if all task checkboxes are `[x]` (no `- [ ]` lines
-   remain in the task phases).
+5. **Implementation done?** Read `FEATURE_DIR/tasks.md`
+   and check if all task checkboxes are `[x]` (no
+   `- [ ]` lines remain in the task phases).
 
-6. **Code review done?** Derive the build and test
-   commands from `.github/workflows/` (read the CI
-   workflow files to identify the exact commands). Run
-   them. If all pass, code review is a candidate.
+6. **Code review done?** Read `FEATURE_DIR/tasks.md`
+   and check for the `<!-- code-review: passed -->` HTML
+   comment marker.
 
-Display the detection results:
+Display the detection results. For OpenSpec mode:
+
+```
+Detected: OpenSpec mode — artifacts from /opsx-propose
+  clarify ✓ (skipped)  plan ✓ (skipped)  tasks ✓ (skipped)
+  spec-review [status]  implement [status]  code-review [status]
+```
+
+For Speckit mode:
 
 ```
 Detected: clarify ✓ plan ✓ tasks ✓ spec-review ✗
@@ -126,6 +155,10 @@ skip directly to step 7 (retrospective) since it is
 idempotent.
 
 ### 3. Step 1 -- Clarify
+
+**If `WORKFLOW_TIER = openspec`**: skip this step.
+Announce: "OpenSpec mode — clarify handled by
+/opsx-propose."
 
 Scan spec.md in the feature directory for
 `[NEEDS CLARIFICATION]` markers.
@@ -198,6 +231,10 @@ needed" and proceed to step 2.
 
 ### 4. Step 2 -- Plan
 
+**If `WORKFLOW_TIER = openspec`**: skip this step.
+Announce: "OpenSpec mode — plan handled by
+/opsx-propose."
+
 Generate the implementation plan by delegating to the
 `cobalt-crush-dev` agent.
 
@@ -214,6 +251,10 @@ Generate the implementation plan by delegating to the
    > Check the agent output for errors."
 
 ### 5. Step 3 -- Tasks
+
+**If `WORKFLOW_TIER = openspec`**: skip this step.
+Announce: "OpenSpec mode — tasks handled by
+/opsx-propose."
 
 Generate the task list by delegating to the
 `cobalt-crush-dev` agent.
@@ -242,18 +283,21 @@ analysis + quality validation) in a single pass.
 2. Delegate to the `cobalt-crush-dev` agent via the Task
    tool with the review council's instructions, adding
    the explicit mode override: "Run in **Spec Review
-   Mode** -- review the spec artifacts, not code."
+   Mode** -- review the spec artifacts in `FEATURE_DIR`,
+   not code." The review council auto-detects the
+   workflow tier from the branch name (`opsx/*` vs
+   `NNN-*`).
 3. Collect the review results.
 
 **Processing results**:
 
 - If all reviewers APPROVE: write the spec review marker
-  to `tasks.md`:
+  to `FEATURE_DIR/tasks.md`:
   ```
   <!-- spec-review: passed -->
   ```
-  Append this marker at the very end of `tasks.md`.
-  Proceed to step 5.
+  Append this marker at the very end of
+  `FEATURE_DIR/tasks.md`. Proceed to step 5.
 
 - If only LOW and MEDIUM findings exist: auto-fix them
   (the review council handles this per its hybrid fix
@@ -282,7 +326,8 @@ analysis + quality validation) in a single pass.
 
 ### 7. Step 5 -- Implement
 
-Parse `tasks.md` for phases and execute tasks.
+Parse `FEATURE_DIR/tasks.md` for phases and execute
+tasks.
 
 **Derive build/test commands**: Read all files in
 `.github/workflows/` to identify the exact CI commands
@@ -437,7 +482,8 @@ Divisor agent reviews.
 2. Delegate to the `cobalt-crush-dev` agent via the Task
    tool with the review council's instructions, adding
    the explicit mode override: "Run in **Code Review
-   Mode** -- review the implementation code."
+   Mode** -- review the implementation code in
+   `FEATURE_DIR`."
 3. Collect the review results.
 
 **If Gaze is not installed**: the review council will
@@ -447,8 +493,15 @@ quality data.
 
 **Processing results**:
 
-- If all reviewers APPROVE (and CI passes): proceed to
-  step 7.
+- If all reviewers APPROVE (and CI passes):
+  Write the code review marker to
+  `FEATURE_DIR/tasks.md`:
+  ```
+  <!-- code-review: passed -->
+  ```
+  Append this marker at the very end of
+  `FEATURE_DIR/tasks.md` (after the spec-review marker
+  if present). Proceed to step 7.
 
 - If findings exist: attempt to fix them. For each
   iteration (up to 3 total):
@@ -522,14 +575,24 @@ memory.
 
 Present structured demo instructions to the developer.
 
-1. **What Was Built**: read the spec's user story titles
-   and descriptions from spec.md. Summarize what was
-   implemented.
+1. **What Was Built**:
+   - **If `WORKFLOW_TIER = speckit`**: read the spec's
+     user story titles and descriptions from
+     `FEATURE_DIR/spec.md`. Summarize what was
+     implemented.
+   - **If `WORKFLOW_TIER = openspec`**: read the change
+     proposal from `FEATURE_DIR/proposal.md`. Summarize
+     what was implemented.
 
-2. **How to Verify**: read `quickstart.md` from the
-   feature directory if it exists. If not, generate
-   verification steps from the acceptance scenarios in
-   spec.md.
+2. **How to Verify**:
+   - **If `WORKFLOW_TIER = speckit`**: read
+     `FEATURE_DIR/quickstart.md` if it exists. If not,
+     generate verification steps from the acceptance
+     scenarios in `FEATURE_DIR/spec.md`.
+   - **If `WORKFLOW_TIER = openspec`**: generate
+     verification steps from the acceptance scenarios
+     in `FEATURE_DIR/tasks.md`. OpenSpec changes do not
+     have a `quickstart.md`.
 
 3. **Key Files Changed**: run:
    ```bash
@@ -575,7 +638,7 @@ Format the output as:
 ## Guardrails
 
 - **NEVER run on `main`** -- the command is for Speckit
-  feature branches only
+  (`NNN-*`) and OpenSpec (`opsx/*`) feature branches
 - **NEVER skip spec review exit on HIGH/CRITICAL** --
   these findings block implementation to prevent wasted
   effort on a flawed spec

--- a/.opencode/skill/speckit-workflow/SKILL.md
+++ b/.opencode/skill/speckit-workflow/SKILL.md
@@ -8,6 +8,7 @@ tags:
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Speckit Workflow — Swarm Skill

--- a/.opencode/uf/packs/content.md
+++ b/.opencode/uf/packs/content.md
@@ -4,6 +4,7 @@ language: Any
 version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 
 # Convention Pack: Content (Documentation, Blog, PR/Comms)
 

--- a/.opencode/uf/packs/default.md
+++ b/.opencode/uf/packs/default.md
@@ -5,6 +5,7 @@ version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: Default (Language-Agnostic)

--- a/.opencode/uf/packs/go.md
+++ b/.opencode/uf/packs/go.md
@@ -5,6 +5,7 @@ version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: Go

--- a/.opencode/uf/packs/severity.md
+++ b/.opencode/uf/packs/severity.md
@@ -2,6 +2,7 @@
 description: "Shared severity level definitions for all Divisor Council personas."
 ---
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 
 # Severity Convention Pack
 

--- a/.opencode/uf/packs/typescript.md
+++ b/.opencode/uf/packs/typescript.md
@@ -5,6 +5,7 @@ version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: TypeScript

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,59 @@ Gaze is a static analysis tool for Go that detects observable side effects in fu
 - **Intent Drift Detection**: Evaluation must detect when the implementation drifts away from the original human-written "Statement of Intent."
 - **Automated Governance**: Primary feedback is provided via automated constraints, reserving human energy for high-level security and logic.
 
+### Gatekeeping Value Protection
+
+Agents MUST NOT modify values that serve as quality or
+governance gates to make an implementation pass. The
+following categories are protected:
+
+1. **Coverage thresholds and CRAP scores** — minimum
+   coverage percentages, CRAP score limits, coverage
+   ratchets
+2. **Severity definitions and auto-fix policies** —
+   CRITICAL/HIGH/MEDIUM/LOW boundaries, auto-fix
+   eligibility rules
+3. **Convention pack rule classifications** —
+   MUST/SHOULD/MAY designations on convention pack rules
+   (downgrading MUST to SHOULD is prohibited)
+4. **CI flags and linter configuration** — `-race`,
+   `-count=1`, `govulncheck`, `golangci-lint` rules,
+   pinned action SHAs
+5. **Agent temperature and tool-access settings** —
+   frontmatter `temperature`, `tools.write`, `tools.edit`,
+   `tools.bash` restrictions
+6. **Constitution MUST rules** — any MUST rule in
+   `.specify/memory/constitution.md` or hero constitutions
+7. **Review iteration limits and worker concurrency** —
+   max review iterations, max concurrent Swarm workers,
+   retry limits
+8. **Workflow gate markers** — `<!-- spec-review: passed
+   -->`, task completion checkboxes used as gates, phase
+   checkpoint requirements
+
+**What to do instead**: When an implementation cannot
+meet a gate, the agent MUST stop, report which gate is
+blocking and why, and let the human decide whether to
+adjust the gate or rework the implementation. Modifying
+a gate without explicit human authorization is a
+constitution violation (CRITICAL severity).
+
+### Workflow Phase Boundaries
+
+Agents MUST NOT cross workflow phase boundaries:
+
+- **Specify/Clarify/Plan/Tasks/Analyze/Checklist** phases:
+  spec artifacts ONLY (`specs/NNN-*/` directory). No
+  source code, test, agent, command, or config changes.
+- **Implement** phase: source code changes allowed,
+  guided by spec artifacts.
+- **Review** phase: findings and minor fixes only. No new
+  features.
+
+A phase boundary violation is treated as a process error.
+The agent MUST stop and report the violation rather than
+proceeding with out-of-phase changes.
+
 ## Technical Guardrails
 
 - **WORM Persistence**: Use Write-Once-Read-Many patterns where data integrity is paramount.
@@ -188,6 +241,36 @@ All spec artifacts (`spec.md`, `plan.md`, `tasks.md`, and any other files under 
 
 A mandatory gate at the planning phase. The constitution's four core principles — Accuracy, Minimal Assumptions, Actionable Output, and Testability — must each receive a PASS before proceeding. Constitution violations are automatically CRITICAL severity and non-negotiable.
 
+### Website Documentation Gate
+
+When a change affects user-facing behavior, hero
+capabilities, CLI commands, or workflows, a GitHub issue
+**MUST** be created in the `unbound-force/website`
+repository to track required documentation or website
+updates. The issue must be created before the
+implementing PR is merged.
+
+```bash
+gh issue create --repo unbound-force/website \
+  --title "docs: <brief description of what changed>" \
+  --body "<what changed, why it matters, which pages
+          need updating>"
+```
+
+**Exempt changes** (no website issue needed):
+- Internal refactoring with no user-facing behavior
+  change
+- Test-only changes
+- CI/CD pipeline changes
+- Spec artifacts (specs are internal planning documents)
+
+**Examples requiring a website issue**:
+- New CLI command or flag added
+- Hero capabilities changed (new agent, removed feature)
+- Installation steps changed (`uf setup` flow)
+- New convention pack added
+- Breaking changes to any user-facing workflow
+
 ## Build & Test Commands
 
 ```bash
@@ -259,6 +342,65 @@ All business logic lives under `internal/` and cannot be imported externally.
 - **No global state**: The logger is the only package-level variable. Prefer functional style.
 - **Constants**: Use string-typed constants for enumerations (`SideEffectType`, `Tier`, `Quadrant`).
 - **JSON tags**: Required on all struct fields intended for serialization.
+
+## Knowledge Retrieval
+
+Agents SHOULD prefer Dewey MCP tools over grep/glob/read
+for cross-repo context, design decisions, and
+architectural patterns. Dewey provides semantic search
+across all indexed Markdown files, specs, and web
+documentation — returning ranked results with provenance
+metadata that grep cannot match.
+
+### Tool Selection Matrix
+
+| Query Intent | Dewey Tool | When to Use |
+|-------------|-----------|-------------|
+| Conceptual understanding | `dewey_semantic_search` | "How does X work?" |
+| Keyword lookup | `dewey_search` | Known terms, FR numbers |
+| Read specific page | `dewey_get_page` | Known document path |
+| Relationship discovery | `dewey_find_connections` | "How are X and Y related?" |
+| Similar documents | `dewey_similar` | "Find specs like this one" |
+| Tag-based discovery | `dewey_find_by_tag` | "All pages tagged #decision" |
+| Property queries | `dewey_query_properties` | "All specs with status: draft" |
+| Filtered semantic | `dewey_semantic_search_filtered` | Semantic search within source type |
+| Graph navigation | `dewey_traverse` | Dependency chain walking |
+
+### When to Fall Back to grep/glob/read
+
+Use direct file operations instead of Dewey when:
+- **Dewey is unavailable** — MCP tools return errors or
+  are not configured
+- **Exact string matching is needed** — searching for a
+  specific error message, variable name, or code pattern
+- **Specific file path is known** — reading a file you
+  already know the path to (use Read directly)
+- **Binary/non-Markdown content** — Dewey indexes
+  Markdown; use grep for Go source, JSON, YAML, etc.
+
+### Graceful Degradation (3-Tier Pattern)
+
+**Tier 3 (Full Dewey)** — semantic + structured search:
+- `dewey_semantic_search` — natural language queries
+- `dewey_search` — keyword queries
+- `dewey_get_page`, `dewey_find_connections`,
+  `dewey_traverse` — structured navigation
+- `dewey_find_by_tag`, `dewey_query_properties` —
+  metadata queries
+
+**Tier 2 (Graph-only, no embedding model)** — structured
+search only:
+- `dewey_search` — keyword queries (no embeddings needed)
+- `dewey_get_page`, `dewey_traverse`,
+  `dewey_find_connections` — graph navigation
+- `dewey_find_by_tag`, `dewey_query_properties` —
+  metadata queries
+- Semantic search unavailable — use exact keyword matches
+
+**Tier 1 (No Dewey)** — direct file access:
+- Use Read tool for direct file access
+- Use Grep for keyword search across the codebase
+- Use Glob for file pattern matching
 
 ## Testing Conventions
 

--- a/internal/aireport/compact.go
+++ b/internal/aireport/compact.go
@@ -1,0 +1,385 @@
+package aireport
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/unbound-force/gaze/internal/crap"
+	"github.com/unbound-force/gaze/internal/docscan"
+	"github.com/unbound-force/gaze/internal/report"
+	"github.com/unbound-force/gaze/internal/taxonomy"
+)
+
+// compactPayload mirrors ReportPayload but includes the summary with JSON
+// tags (not json:"-") and uses compact representations for each section.
+type compactPayload struct {
+	Summary  compactSummary  `json:"summary"`
+	CRAP     json.RawMessage `json:"crap"`
+	Quality  json.RawMessage `json:"quality"`
+	Classify json.RawMessage `json:"classify"`
+	Docscan  json.RawMessage `json:"docscan"`
+	Errors   PayloadErrors   `json:"errors"`
+}
+
+// compactSummary mirrors ReportSummary with JSON tags so it appears in
+// the compact payload output.
+type compactSummary struct {
+	CRAPload            int      `json:"crapload"`
+	GazeCRAPload        int      `json:"gaze_crapload"`
+	AvgContractCoverage int      `json:"avg_contract_coverage"`
+	SSADegraded         bool     `json:"ssa_degraded"`
+	SSADegradedPackages []string `json:"ssa_degraded_packages"`
+	Contractual         int      `json:"contractual"`
+	Ambiguous           int      `json:"ambiguous"`
+	Incidental          int      `json:"incidental"`
+}
+
+// compactDocscanEntry retains only the path and priority from a
+// docscan.DocumentFile, stripping the Content field which dominates
+// payload size.
+type compactDocscanEntry struct {
+	Path     string           `json:"path"`
+	Priority docscan.Priority `json:"priority"`
+}
+
+// compactQualityReport mirrors taxonomy.QualityReport but uses
+// compactContractCoverage (ID arrays instead of full SideEffect objects)
+// and AmbiguousEffectIDs instead of AmbiguousEffects.
+type compactQualityReport struct {
+	TestFunction                 string                          `json:"test_function"`
+	TestLocation                 string                          `json:"test_location"`
+	TargetFunction               taxonomy.FunctionTarget         `json:"target_function"`
+	ContractCoverage             compactContractCoverage         `json:"contract_coverage"`
+	OverSpecification            taxonomy.OverSpecificationScore `json:"over_specification"`
+	AmbiguousEffectIDs           []string                        `json:"ambiguous_effect_ids"`
+	UnmappedAssertions           []taxonomy.AssertionMapping     `json:"unmapped_assertions"`
+	AssertionCount               int                             `json:"assertion_count"`
+	AssertionDetectionConfidence int                             `json:"assertion_detection_confidence"`
+	Metadata                     taxonomy.Metadata               `json:"metadata"`
+}
+
+// compactContractCoverage replaces Gaps and DiscardedReturns (full
+// SideEffect slices) with GapIDs and DiscardedReturnIDs (string slices),
+// preserving hints and scalar fields.
+type compactContractCoverage struct {
+	Percentage           float64  `json:"percentage"`
+	CoveredCount         int      `json:"covered_count"`
+	TotalContractual     int      `json:"total_contractual"`
+	GapIDs               []string `json:"gap_ids"`
+	GapHints             []string `json:"gap_hints,omitempty"`
+	DiscardedReturnIDs   []string `json:"discarded_return_ids"`
+	DiscardedReturnHints []string `json:"discarded_return_hints,omitempty"`
+}
+
+// compactClassifyResult mirrors report.JSONReport but uses
+// compactAnalysisResult with compactClassification on side effects.
+type compactClassifyResult struct {
+	Version string                  `json:"version"`
+	Results []compactAnalysisResult `json:"results"`
+}
+
+// compactAnalysisResult mirrors taxonomy.AnalysisResult but uses
+// compactSideEffect with stripped classification signals.
+type compactAnalysisResult struct {
+	Target      taxonomy.FunctionTarget `json:"target"`
+	SideEffects []compactSideEffect     `json:"side_effects"`
+	Metadata    taxonomy.Metadata       `json:"metadata"`
+}
+
+// compactSideEffect mirrors taxonomy.SideEffect but uses
+// compactClassification (no Signals).
+type compactSideEffect struct {
+	ID             string                  `json:"id"`
+	Type           taxonomy.SideEffectType `json:"type"`
+	Tier           taxonomy.Tier           `json:"tier"`
+	Location       string                  `json:"location"`
+	Description    string                  `json:"description"`
+	Target         string                  `json:"target"`
+	Classification *compactClassification  `json:"classification,omitempty"`
+}
+
+// compactClassification retains Label, Confidence, and Reasoning
+// but omits Signals to reduce payload size.
+type compactClassification struct {
+	Label      taxonomy.ClassificationLabel `json:"label"`
+	Confidence int                          `json:"confidence"`
+	Reasoning  string                       `json:"reasoning,omitempty"`
+}
+
+// compactCRAPReport mirrors crap.Report but uses compactCRAPSummary
+// which omits WorstCrap, WorstGazeCrap, and RecommendedActions.
+type compactCRAPReport struct {
+	Scores  []crap.Score       `json:"scores"`
+	Summary compactCRAPSummary `json:"summary"`
+}
+
+// compactCRAPSummary mirrors crap.Summary but omits WorstCRAP,
+// WorstGazeCRAP, and RecommendedActions to reduce payload size.
+type compactCRAPSummary struct {
+	TotalFunctions      int                      `json:"total_functions"`
+	AvgComplexity       float64                  `json:"avg_complexity"`
+	AvgLineCoverage     float64                  `json:"avg_line_coverage"`
+	AvgCRAP             float64                  `json:"avg_crap"`
+	CRAPload            int                      `json:"crapload"`
+	CRAPThreshold       float64                  `json:"crap_threshold"`
+	GazeCRAPload        *int                     `json:"gaze_crapload,omitempty"`
+	GazeCRAPThreshold   *float64                 `json:"gaze_crap_threshold,omitempty"`
+	AvgGazeCRAP         *float64                 `json:"avg_gaze_crap,omitempty"`
+	AvgContractCoverage *float64                 `json:"avg_contract_coverage,omitempty"`
+	QuadrantCounts      map[crap.Quadrant]int    `json:"quadrant_counts,omitempty"`
+	FixStrategyCounts   map[crap.FixStrategy]int `json:"fix_strategy_counts,omitempty"`
+	SSADegradedPackages []string                 `json:"ssa_degraded_packages,omitempty"`
+}
+
+// compactQualityOutput mirrors the quality.qualityOutput structure
+// but uses compactQualityReport and compactPackageSummary.
+type compactQualityOutput struct {
+	Reports []compactQualityReport `json:"quality_reports"`
+	Summary *compactPackageSummary `json:"quality_summary"`
+}
+
+// compactPackageSummary mirrors taxonomy.PackageSummary but omits
+// WorstCoverageTests to reduce payload size.
+type compactPackageSummary struct {
+	TotalTests                   int      `json:"total_tests"`
+	AverageContractCoverage      float64  `json:"average_contract_coverage"`
+	TotalOverSpecifications      int      `json:"total_over_specifications"`
+	AssertionDetectionConfidence int      `json:"assertion_detection_confidence"`
+	SSADegraded                  bool     `json:"ssa_degraded"`
+	SSADegradedPackages          []string `json:"ssa_degraded_packages,omitempty"`
+}
+
+// CompactForAI produces a reduced JSON representation of the payload
+// for the AI adapter text path. It strips large fields (docscan content,
+// classification signals, worst offender lists) and replaces full
+// SideEffect objects with ID strings to fit within model context windows.
+//
+// The full json.Marshal output is unaffected — this method produces a
+// separate compact encoding.
+//
+// Nil fields (step failures) pass through as JSON null. Empty arrays
+// are preserved as [] (not null).
+func (p *ReportPayload) CompactForAI() ([]byte, error) {
+	cp := compactPayload{
+		Summary: compactSummary{
+			CRAPload:            p.Summary.CRAPload,
+			GazeCRAPload:        p.Summary.GazeCRAPload,
+			AvgContractCoverage: p.Summary.AvgContractCoverage,
+			SSADegraded:         p.Summary.SSADegraded,
+			SSADegradedPackages: p.Summary.SSADegradedPackages,
+			Contractual:         p.Summary.Contractual,
+			Ambiguous:           p.Summary.Ambiguous,
+			Incidental:          p.Summary.Incidental,
+		},
+		Errors: p.Errors,
+	}
+
+	// CRAP: unmarshal, strip worst offender lists, re-marshal.
+	if p.CRAP != nil {
+		compactCRAP, err := compactCRAPField(p.CRAP)
+		if err != nil {
+			return nil, fmt.Errorf("compacting CRAP: %w", err)
+		}
+		cp.CRAP = compactCRAP
+	}
+
+	// Quality: unmarshal, replace gaps/discarded returns with IDs,
+	// replace ambiguous effects with IDs, strip worst coverage tests.
+	if p.Quality != nil {
+		compactQuality, err := compactQualityField(p.Quality)
+		if err != nil {
+			return nil, fmt.Errorf("compacting quality: %w", err)
+		}
+		cp.Quality = compactQuality
+	}
+
+	// Classify: unmarshal, strip signals from classifications.
+	if p.Classify != nil {
+		compactClassify, err := compactClassifyField(p.Classify)
+		if err != nil {
+			return nil, fmt.Errorf("compacting classify: %w", err)
+		}
+		cp.Classify = compactClassify
+	}
+
+	// Docscan: unmarshal, strip content.
+	if p.Docscan != nil {
+		compactDocscan, err := compactDocscanField(p.Docscan)
+		if err != nil {
+			return nil, fmt.Errorf("compacting docscan: %w", err)
+		}
+		cp.Docscan = compactDocscan
+	}
+
+	return json.Marshal(cp)
+}
+
+// compactCRAPField unmarshals a crap.Report, strips WorstCRAP,
+// WorstGazeCRAP, and RecommendedActions, and re-marshals.
+func compactCRAPField(raw json.RawMessage) (json.RawMessage, error) {
+	var full crap.Report
+	if err := json.Unmarshal(raw, &full); err != nil {
+		return nil, fmt.Errorf("unmarshalling CRAP report: %w", err)
+	}
+
+	compact := compactCRAPReport{
+		Scores: full.Scores,
+		Summary: compactCRAPSummary{
+			TotalFunctions:      full.Summary.TotalFunctions,
+			AvgComplexity:       full.Summary.AvgComplexity,
+			AvgLineCoverage:     full.Summary.AvgLineCoverage,
+			AvgCRAP:             full.Summary.AvgCRAP,
+			CRAPload:            full.Summary.CRAPload,
+			CRAPThreshold:       full.Summary.CRAPThreshold,
+			GazeCRAPload:        full.Summary.GazeCRAPload,
+			GazeCRAPThreshold:   full.Summary.GazeCRAPThreshold,
+			AvgGazeCRAP:         full.Summary.AvgGazeCRAP,
+			AvgContractCoverage: full.Summary.AvgContractCoverage,
+			QuadrantCounts:      full.Summary.QuadrantCounts,
+			FixStrategyCounts:   full.Summary.FixStrategyCounts,
+			SSADegradedPackages: full.Summary.SSADegradedPackages,
+		},
+	}
+
+	return json.Marshal(compact)
+}
+
+// qualityOutput mirrors the quality package's top-level JSON structure.
+// Defined here to avoid importing the unexported type.
+type qualityOutput struct {
+	Reports []taxonomy.QualityReport `json:"quality_reports"`
+	Summary *taxonomy.PackageSummary `json:"quality_summary"`
+}
+
+// compactQualityField unmarshals quality reports, replaces Gaps and
+// DiscardedReturns with ID arrays, replaces AmbiguousEffects with ID
+// arrays, strips WorstCoverageTests, and re-marshals.
+func compactQualityField(raw json.RawMessage) (json.RawMessage, error) {
+	var full qualityOutput
+	if err := json.Unmarshal(raw, &full); err != nil {
+		return nil, fmt.Errorf("unmarshalling quality report: %w", err)
+	}
+
+	compactReports := make([]compactQualityReport, len(full.Reports))
+	for i, r := range full.Reports {
+		compactReports[i] = compactQualityReport{
+			TestFunction:                 r.TestFunction,
+			TestLocation:                 r.TestLocation,
+			TargetFunction:               r.TargetFunction,
+			ContractCoverage:             projectContractCoverage(r.ContractCoverage),
+			OverSpecification:            r.OverSpecification,
+			AmbiguousEffectIDs:           extractEffectIDs(r.AmbiguousEffects),
+			UnmappedAssertions:           r.UnmappedAssertions,
+			AssertionCount:               r.AssertionCount,
+			AssertionDetectionConfidence: r.AssertionDetectionConfidence,
+			Metadata:                     r.Metadata,
+		}
+	}
+
+	var compactSummary *compactPackageSummary
+	if full.Summary != nil {
+		compactSummary = &compactPackageSummary{
+			TotalTests:                   full.Summary.TotalTests,
+			AverageContractCoverage:      full.Summary.AverageContractCoverage,
+			TotalOverSpecifications:      full.Summary.TotalOverSpecifications,
+			AssertionDetectionConfidence: full.Summary.AssertionDetectionConfidence,
+			SSADegraded:                  full.Summary.SSADegraded,
+			SSADegradedPackages:          full.Summary.SSADegradedPackages,
+		}
+	}
+
+	out := compactQualityOutput{
+		Reports: compactReports,
+		Summary: compactSummary,
+	}
+	return json.Marshal(out)
+}
+
+// projectContractCoverage converts a full ContractCoverage into a
+// compact form with ID arrays instead of full SideEffect objects.
+func projectContractCoverage(cc taxonomy.ContractCoverage) compactContractCoverage {
+	return compactContractCoverage{
+		Percentage:           cc.Percentage,
+		CoveredCount:         cc.CoveredCount,
+		TotalContractual:     cc.TotalContractual,
+		GapIDs:               extractEffectIDs(cc.Gaps),
+		GapHints:             cc.GapHints,
+		DiscardedReturnIDs:   extractEffectIDs(cc.DiscardedReturns),
+		DiscardedReturnHints: cc.DiscardedReturnHints,
+	}
+}
+
+// extractEffectIDs extracts the ID field from a slice of SideEffect.
+// Returns an empty non-nil slice when effects is empty, and nil when
+// effects is nil, preserving the distinction in JSON output.
+func extractEffectIDs(effects []taxonomy.SideEffect) []string {
+	if effects == nil {
+		return nil
+	}
+	ids := make([]string, len(effects))
+	for i, e := range effects {
+		ids[i] = e.ID
+	}
+	return ids
+}
+
+// compactClassifyField unmarshals a classify result, strips Signals
+// from each side effect's classification, and re-marshals.
+func compactClassifyField(raw json.RawMessage) (json.RawMessage, error) {
+	var full report.JSONReport
+	if err := json.Unmarshal(raw, &full); err != nil {
+		return nil, fmt.Errorf("unmarshalling classify result: %w", err)
+	}
+
+	compact := compactClassifyResult{
+		Version: full.Version,
+		Results: make([]compactAnalysisResult, len(full.Results)),
+	}
+
+	for i, r := range full.Results {
+		compactEffects := make([]compactSideEffect, len(r.SideEffects))
+		for j, se := range r.SideEffects {
+			compactEffects[j] = compactSideEffect{
+				ID:          se.ID,
+				Type:        se.Type,
+				Tier:        se.Tier,
+				Location:    se.Location,
+				Description: se.Description,
+				Target:      se.Target,
+			}
+			if se.Classification != nil {
+				compactEffects[j].Classification = &compactClassification{
+					Label:      se.Classification.Label,
+					Confidence: se.Classification.Confidence,
+					Reasoning:  se.Classification.Reasoning,
+				}
+			}
+		}
+		compact.Results[i] = compactAnalysisResult{
+			Target:      r.Target,
+			SideEffects: compactEffects,
+			Metadata:    r.Metadata,
+		}
+	}
+
+	return json.Marshal(compact)
+}
+
+// compactDocscanField unmarshals docscan entries and strips the
+// Content field, keeping only Path and Priority.
+func compactDocscanField(raw json.RawMessage) (json.RawMessage, error) {
+	var full []docscan.DocumentFile
+	if err := json.Unmarshal(raw, &full); err != nil {
+		return nil, fmt.Errorf("unmarshalling docscan: %w", err)
+	}
+
+	compact := make([]compactDocscanEntry, len(full))
+	for i, d := range full {
+		compact[i] = compactDocscanEntry{
+			Path:     d.Path,
+			Priority: d.Priority,
+		}
+	}
+
+	return json.Marshal(compact)
+}

--- a/internal/aireport/compact_test.go
+++ b/internal/aireport/compact_test.go
@@ -1,0 +1,1245 @@
+package aireport
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/unbound-force/gaze/internal/taxonomy"
+)
+
+// buildFullPayload constructs a fully-populated ReportPayload for testing.
+// Each section contains realistic data with known field values.
+func buildFullPayload(t *testing.T) *ReportPayload {
+	t.Helper()
+
+	// CRAP section with worst offender lists and recommended actions.
+	crapJSON := mustMarshal(t, map[string]interface{}{
+		"scores": []map[string]interface{}{
+			{
+				"package": "github.com/example/pkg", "function": "DoWork",
+				"file": "pkg/work.go", "line": 10, "complexity": 8,
+				"line_coverage": 75.0, "crap": 12.5,
+			},
+		},
+		"summary": map[string]interface{}{
+			"total_functions": 1, "avg_complexity": 8.0,
+			"avg_line_coverage": 75.0, "avg_crap": 12.5,
+			"crapload": 1, "crap_threshold": 15.0,
+			"worst_crap": []map[string]interface{}{
+				{"package": "github.com/example/pkg", "function": "DoWork",
+					"file": "pkg/work.go", "line": 10, "complexity": 8,
+					"line_coverage": 75.0, "crap": 12.5},
+			},
+			"worst_gaze_crap": []map[string]interface{}{
+				{"package": "github.com/example/pkg", "function": "DoWork",
+					"file": "pkg/work.go", "line": 10, "complexity": 8,
+					"line_coverage": 75.0, "crap": 12.5},
+			},
+			"recommended_actions": []map[string]interface{}{
+				{"function": "DoWork", "package": "github.com/example/pkg",
+					"file": "pkg/work.go", "line": 10,
+					"fix_strategy": "add_tests", "crap": 12.5, "complexity": 8},
+			},
+		},
+	})
+
+	// Quality section with full SideEffect objects in gaps and ambiguous effects.
+	qualityJSON := mustMarshal(t, map[string]interface{}{
+		"quality_reports": []map[string]interface{}{
+			{
+				"test_function": "TestDoWork",
+				"test_location": "pkg/work_test.go:15",
+				"target_function": map[string]interface{}{
+					"package": "github.com/example/pkg", "function": "DoWork",
+					"signature": "func DoWork() error", "location": "pkg/work.go:10",
+				},
+				"contract_coverage": map[string]interface{}{
+					"percentage": 50.0, "covered_count": 1, "total_contractual": 2,
+					"gaps": []map[string]interface{}{
+						{"id": "se-aabbccdd", "type": "ErrorReturn", "tier": "P0",
+							"location": "pkg/work.go:20", "description": "returns error",
+							"target": "error"},
+					},
+					"gap_hints": []string{"assert err != nil"},
+					"discarded_returns": []map[string]interface{}{
+						{"id": "se-11223344", "type": "ReturnValue", "tier": "P0",
+							"location": "pkg/work.go:25", "description": "returns int",
+							"target": "int"},
+					},
+					"discarded_return_hints": []string{"capture return value"},
+				},
+				"over_specification": map[string]interface{}{
+					"count": 0, "ratio": 0.0,
+					"incidental_assertions": []interface{}{},
+					"suggestions":           []interface{}{},
+				},
+				"ambiguous_effects": []map[string]interface{}{
+					{"id": "se-55667788", "type": "LogWrite", "tier": "P2",
+						"location": "pkg/work.go:30", "description": "writes to log",
+						"target": "logger",
+						"classification": map[string]interface{}{
+							"label": "ambiguous", "confidence": 55,
+							"signals": []map[string]interface{}{
+								{"source": "naming", "weight": 10},
+							},
+							"reasoning": "unclear intent",
+						}},
+				},
+				"unmapped_assertions":            []interface{}{},
+				"assertion_count":                3,
+				"assertion_detection_confidence": 85,
+				"metadata": map[string]interface{}{
+					"gaze_version": "dev", "go_version": "go1.24",
+					"duration_ms": 100, "warnings": []interface{}{},
+				},
+			},
+		},
+		"quality_summary": map[string]interface{}{
+			"total_tests": 1, "average_contract_coverage": 50.0,
+			"total_over_specifications":      0,
+			"assertion_detection_confidence": 85,
+			"ssa_degraded":                   false,
+			"worst_coverage_tests": []map[string]interface{}{
+				{
+					"test_function": "TestDoWork",
+					"test_location": "pkg/work_test.go:15",
+					"target_function": map[string]interface{}{
+						"package": "github.com/example/pkg", "function": "DoWork",
+						"signature": "func DoWork() error", "location": "pkg/work.go:10",
+					},
+					"contract_coverage": map[string]interface{}{
+						"percentage": 50.0, "covered_count": 1, "total_contractual": 2,
+						"gaps": []interface{}{}, "discarded_returns": []interface{}{},
+					},
+					"over_specification": map[string]interface{}{
+						"count": 0, "ratio": 0.0,
+						"incidental_assertions": []interface{}{},
+						"suggestions":           []interface{}{},
+					},
+					"ambiguous_effects":              []interface{}{},
+					"unmapped_assertions":            []interface{}{},
+					"assertion_count":                3,
+					"assertion_detection_confidence": 85,
+					"metadata": map[string]interface{}{
+						"gaze_version": "dev", "go_version": "go1.24",
+						"duration_ms": 100, "warnings": []interface{}{},
+					},
+				},
+			},
+		},
+	})
+
+	// Classify section with signals on side effects.
+	classifyJSON := mustMarshal(t, map[string]interface{}{
+		"version": "dev",
+		"results": []map[string]interface{}{
+			{
+				"target": map[string]interface{}{
+					"package": "github.com/example/pkg", "function": "DoWork",
+					"signature": "func DoWork() error", "location": "pkg/work.go:10",
+				},
+				"side_effects": []map[string]interface{}{
+					{
+						"id": "se-aabbccdd", "type": "ErrorReturn", "tier": "P0",
+						"location": "pkg/work.go:20", "description": "returns error",
+						"target": "error",
+						"classification": map[string]interface{}{
+							"label": "contractual", "confidence": 90,
+							"signals": []map[string]interface{}{
+								{"source": "interface", "weight": 25},
+								{"source": "naming", "weight": 15},
+								{"source": "godoc", "weight": 20,
+									"source_file": "pkg/work.go",
+									"excerpt":     "DoWork returns an error",
+									"reasoning":   "GoDoc mentions error return"},
+							},
+							"reasoning": "error return is contractual",
+						},
+					},
+				},
+				"metadata": map[string]interface{}{
+					"gaze_version": "dev", "go_version": "go1.24",
+					"duration_ms": 50, "warnings": []interface{}{},
+				},
+			},
+		},
+	})
+
+	// Docscan section with content.
+	docscanJSON := mustMarshal(t, []map[string]interface{}{
+		{"path": "README.md", "content": "# Project\nSome content here.", "priority": 2},
+		{"path": "CONTRIBUTING.md", "content": "# Contributing\nGuidelines.", "priority": 3},
+	})
+
+	return &ReportPayload{
+		Summary: ReportSummary{
+			CRAPload:            1,
+			GazeCRAPload:        0,
+			AvgContractCoverage: 50,
+			SSADegraded:         false,
+			Contractual:         1,
+			Ambiguous:           1,
+			Incidental:          0,
+		},
+		CRAP:     crapJSON,
+		Quality:  qualityJSON,
+		Classify: classifyJSON,
+		Docscan:  docscanJSON,
+		Errors:   PayloadErrors{},
+	}
+}
+
+// mustMarshal marshals v to json.RawMessage, failing the test on error.
+func mustMarshal(t *testing.T, v interface{}) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("mustMarshal: %v", err)
+	}
+	return json.RawMessage(data)
+}
+
+// TestCompactForAI_ValidJSON verifies that a fully populated payload
+// produces valid JSON from CompactForAI.
+func TestCompactForAI_ValidJSON(t *testing.T) {
+	payload := buildFullPayload(t)
+	data, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	if !json.Valid(data) {
+		t.Fatalf("CompactForAI produced invalid JSON: %s", data)
+	}
+
+	// Verify it can be unmarshalled into a generic map.
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal compact JSON: %v", err)
+	}
+
+	// Verify all top-level keys are present.
+	for _, key := range []string{"summary", "crap", "quality", "classify", "docscan", "errors"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("missing top-level key %q in compact JSON", key)
+		}
+	}
+}
+
+// TestCompactForAI_Summary verifies that summary fields appear with
+// correct JSON keys in the compact output.
+func TestCompactForAI_Summary(t *testing.T) {
+	payload := buildFullPayload(t)
+	data, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	var summary map[string]interface{}
+	if err := json.Unmarshal(m["summary"], &summary); err != nil {
+		t.Fatalf("Unmarshal summary: %v", err)
+	}
+
+	expectedKeys := []string{
+		"crapload", "gaze_crapload", "avg_contract_coverage",
+		"ssa_degraded", "ssa_degraded_packages",
+		"contractual", "ambiguous", "incidental",
+	}
+	for _, key := range expectedKeys {
+		if _, ok := summary[key]; !ok {
+			t.Errorf("missing summary key %q", key)
+		}
+	}
+
+	// Verify values.
+	v, ok := summary["crapload"].(float64)
+	if !ok {
+		t.Fatal("crapload is not a number")
+	}
+	if int(v) != 1 {
+		t.Errorf("crapload = %v, want 1", v)
+	}
+	v, ok = summary["avg_contract_coverage"].(float64)
+	if !ok {
+		t.Fatal("avg_contract_coverage is not a number")
+	}
+	if int(v) != 50 {
+		t.Errorf("avg_contract_coverage = %v, want 50", v)
+	}
+	v, ok = summary["contractual"].(float64)
+	if !ok {
+		t.Fatal("contractual is not a number")
+	}
+	if int(v) != 1 {
+		t.Errorf("contractual = %v, want 1", v)
+	}
+}
+
+// TestCompactForAI_DocscanContentStripped verifies that docscan entries
+// have their Content field stripped, keeping only Path and Priority.
+func TestCompactForAI_DocscanContentStripped(t *testing.T) {
+	// Build payload with 3 docs, each with 10KB content.
+	bigContent := strings.Repeat("x", 10*1024)
+	docscanJSON := mustMarshal(t, []map[string]interface{}{
+		{"path": "README.md", "content": bigContent, "priority": 2},
+		{"path": "CONTRIBUTING.md", "content": bigContent, "priority": 3},
+		{"path": "docs/ARCH.md", "content": bigContent, "priority": 3},
+	})
+
+	payload := &ReportPayload{
+		Docscan: docscanJSON,
+		Errors:  PayloadErrors{},
+	}
+
+	data, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	// Content must not appear in compact output.
+	if strings.Contains(string(data), bigContent[:100]) {
+		t.Error("compact output still contains docscan content")
+	}
+
+	// Parse docscan array.
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	var docs []map[string]interface{}
+	if err := json.Unmarshal(m["docscan"], &docs); err != nil {
+		t.Fatalf("Unmarshal docscan: %v", err)
+	}
+
+	if len(docs) != 3 {
+		t.Fatalf("docscan length = %d, want 3", len(docs))
+	}
+
+	for i, doc := range docs {
+		if _, ok := doc["content"]; ok {
+			t.Errorf("doc[%d] still has content field", i)
+		}
+		if _, ok := doc["path"]; !ok {
+			t.Errorf("doc[%d] missing path field", i)
+		}
+		if _, ok := doc["priority"]; !ok {
+			t.Errorf("doc[%d] missing priority field", i)
+		}
+	}
+}
+
+// TestCompactForAI_DocscanEmpty verifies that an empty docscan array
+// stays [] (not null) in compact output.
+func TestCompactForAI_DocscanEmpty(t *testing.T) {
+	payload := &ReportPayload{
+		Docscan: json.RawMessage(`[]`),
+		Errors:  PayloadErrors{},
+	}
+
+	data, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if string(m["docscan"]) != "[]" {
+		t.Errorf("docscan = %s, want []", m["docscan"])
+	}
+}
+
+// TestCompactForAI_DocscanNil verifies that nil docscan stays null
+// in compact output.
+func TestCompactForAI_DocscanNil(t *testing.T) {
+	payload := &ReportPayload{
+		Docscan: nil,
+		Errors:  PayloadErrors{},
+	}
+
+	data, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if string(m["docscan"]) != "null" {
+		t.Errorf("docscan = %s, want null", m["docscan"])
+	}
+}
+
+// TestCompactForAI_QualityGapsReducedToIDs verifies that contract
+// coverage gaps are replaced with gap_ids (string array).
+func TestCompactForAI_QualityGapsReducedToIDs(t *testing.T) {
+	payload := buildFullPayload(t)
+	data, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	// Parse quality reports.
+	reports := extractQualityReports(t, data)
+	if len(reports) == 0 {
+		t.Fatal("no quality reports in compact output")
+	}
+
+	cc, ok := reports[0]["contract_coverage"].(map[string]interface{})
+	if !ok {
+		t.Fatal("contract_coverage is not an object")
+	}
+
+	// Must have gap_ids, not gaps.
+	if _, ok := cc["gaps"]; ok {
+		t.Error("compact quality still has 'gaps' field (should be 'gap_ids')")
+	}
+	gapIDs, ok := cc["gap_ids"].([]interface{})
+	if !ok {
+		t.Fatal("compact quality missing 'gap_ids' field")
+	}
+	if len(gapIDs) != 1 {
+		t.Fatalf("gap_ids length = %d, want 1", len(gapIDs))
+	}
+	gapID, ok := gapIDs[0].(string)
+	if !ok {
+		t.Fatal("gap_ids[0] is not a string")
+	}
+	if gapID != "se-aabbccdd" {
+		t.Errorf("gap_ids[0] = %v, want se-aabbccdd", gapID)
+	}
+}
+
+// TestCompactForAI_QualityDiscardedReturnsReducedToIDs verifies that
+// discarded_returns are replaced with discarded_return_ids.
+func TestCompactForAI_QualityDiscardedReturnsReducedToIDs(t *testing.T) {
+	payload := buildFullPayload(t)
+	data, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	reports := extractQualityReports(t, data)
+	if len(reports) == 0 {
+		t.Fatal("no quality reports in compact output")
+	}
+
+	cc, ok := reports[0]["contract_coverage"].(map[string]interface{})
+	if !ok {
+		t.Fatal("contract_coverage is not an object")
+	}
+
+	if _, ok := cc["discarded_returns"]; ok {
+		t.Error("compact quality still has 'discarded_returns' field")
+	}
+	drIDs, ok := cc["discarded_return_ids"].([]interface{})
+	if !ok {
+		t.Fatal("compact quality missing 'discarded_return_ids' field")
+	}
+	if len(drIDs) != 1 {
+		t.Fatalf("discarded_return_ids length = %d, want 1", len(drIDs))
+	}
+	drID, ok := drIDs[0].(string)
+	if !ok {
+		t.Fatal("discarded_return_ids[0] is not a string")
+	}
+	if drID != "se-11223344" {
+		t.Errorf("discarded_return_ids[0] = %v, want se-11223344", drIDs[0])
+	}
+}
+
+// TestCompactForAI_QualityAmbiguousEffectsReducedToIDs verifies that
+// ambiguous_effects are replaced with ambiguous_effect_ids.
+func TestCompactForAI_QualityAmbiguousEffectsReducedToIDs(t *testing.T) {
+	payload := buildFullPayload(t)
+	data, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	reports := extractQualityReports(t, data)
+	if len(reports) == 0 {
+		t.Fatal("no quality reports in compact output")
+	}
+
+	if _, ok := reports[0]["ambiguous_effects"]; ok {
+		t.Error("compact quality still has 'ambiguous_effects' field")
+	}
+	aeIDs, ok := reports[0]["ambiguous_effect_ids"].([]interface{})
+	if !ok {
+		t.Fatal("compact quality missing 'ambiguous_effect_ids' field")
+	}
+	if len(aeIDs) != 1 {
+		t.Fatalf("ambiguous_effect_ids length = %d, want 1", len(aeIDs))
+	}
+	aeID, ok := aeIDs[0].(string)
+	if !ok {
+		t.Fatal("ambiguous_effect_ids[0] is not a string")
+	}
+	if aeID != "se-55667788" {
+		t.Errorf("ambiguous_effect_ids[0] = %v, want se-55667788", aeID)
+	}
+}
+
+// TestCompactForAI_QualityHintsPreserved verifies that gap_hints and
+// discarded_return_hints are preserved in compact output.
+func TestCompactForAI_QualityHintsPreserved(t *testing.T) {
+	payload := buildFullPayload(t)
+	data, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	reports := extractQualityReports(t, data)
+	if len(reports) == 0 {
+		t.Fatal("no quality reports in compact output")
+	}
+
+	cc, ok := reports[0]["contract_coverage"].(map[string]interface{})
+	if !ok {
+		t.Fatal("contract_coverage is not an object")
+	}
+
+	gapHints, ok := cc["gap_hints"].([]interface{})
+	if !ok {
+		t.Fatal("compact quality missing 'gap_hints' field")
+	}
+	if len(gapHints) != 1 {
+		t.Fatalf("gap_hints length = %d, want 1", len(gapHints))
+	}
+	hint, ok := gapHints[0].(string)
+	if !ok || hint != "assert err != nil" {
+		t.Errorf("gap_hints = %v, want [\"assert err != nil\"]", gapHints)
+	}
+
+	drHints, ok := cc["discarded_return_hints"].([]interface{})
+	if !ok {
+		t.Fatal("compact quality missing 'discarded_return_hints' field")
+	}
+	if len(drHints) != 1 {
+		t.Fatalf("discarded_return_hints length = %d, want 1", len(drHints))
+	}
+	drHint, ok := drHints[0].(string)
+	if !ok || drHint != "capture return value" {
+		t.Errorf("discarded_return_hints = %v, want [\"capture return value\"]", drHints)
+	}
+}
+
+// TestCompactForAI_QualityCrossRefResilience verifies that when
+// classify is nil, quality gaps still produce IDs from the quality
+// data alone (no cross-reference dependency).
+func TestCompactForAI_QualityCrossRefResilience(t *testing.T) {
+	payload := buildFullPayload(t)
+	payload.Classify = nil // Simulate classify step failure.
+
+	data, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	reports := extractQualityReports(t, data)
+	if len(reports) == 0 {
+		t.Fatal("no quality reports in compact output")
+	}
+
+	cc, ok := reports[0]["contract_coverage"].(map[string]interface{})
+	if !ok {
+		t.Fatal("contract_coverage is not an object")
+	}
+	gapIDs, ok := cc["gap_ids"].([]interface{})
+	if !ok {
+		t.Fatal("compact quality missing 'gap_ids' when classify is nil")
+	}
+	if len(gapIDs) != 1 {
+		t.Errorf("gap_ids length = %d, want 1 (resilient to nil classify)", len(gapIDs))
+	}
+}
+
+// TestCompactForAI_ClassifySignalsStripped verifies that classification
+// signals are omitted while label, confidence, and reasoning are preserved.
+func TestCompactForAI_ClassifySignalsStripped(t *testing.T) {
+	payload := buildFullPayload(t)
+	data, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	var classify map[string]interface{}
+	if err := json.Unmarshal(m["classify"], &classify); err != nil {
+		t.Fatalf("Unmarshal classify: %v", err)
+	}
+
+	results, ok := classify["results"].([]interface{})
+	if !ok || len(results) == 0 {
+		t.Fatal("no classify results in compact output")
+	}
+
+	result, ok := results[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("classify result is not an object")
+	}
+	effects, ok := result["side_effects"].([]interface{})
+	if !ok || len(effects) == 0 {
+		t.Fatal("no side effects in compact classify")
+	}
+
+	effect, ok := effects[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("side effect is not an object")
+	}
+	cls, ok := effect["classification"].(map[string]interface{})
+	if !ok {
+		t.Fatal("classification is not an object")
+	}
+
+	// Signals must be absent.
+	if _, ok := cls["signals"]; ok {
+		t.Error("compact classify still has 'signals' field")
+	}
+
+	// Label, confidence, reasoning must be present.
+	label, ok := cls["label"].(string)
+	if !ok || label != "contractual" {
+		t.Errorf("label = %v, want contractual", cls["label"])
+	}
+	conf, ok := cls["confidence"].(float64)
+	if !ok || int(conf) != 90 {
+		t.Errorf("confidence = %v, want 90", cls["confidence"])
+	}
+	reasoning, ok := cls["reasoning"].(string)
+	if !ok || reasoning != "error return is contractual" {
+		t.Errorf("reasoning = %v, want 'error return is contractual'", cls["reasoning"])
+	}
+}
+
+// TestCompactForAI_CRAPWorstOffendersOmitted verifies that worst_crap,
+// worst_gaze_crap, and recommended_actions are omitted from the compact
+// CRAP summary.
+func TestCompactForAI_CRAPWorstOffendersOmitted(t *testing.T) {
+	payload := buildFullPayload(t)
+	data, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	s := string(data)
+	if strings.Contains(s, "worst_crap") {
+		t.Error("compact CRAP still contains 'worst_crap'")
+	}
+	if strings.Contains(s, "worst_gaze_crap") {
+		t.Error("compact CRAP still contains 'worst_gaze_crap'")
+	}
+	if strings.Contains(s, "recommended_actions") {
+		t.Error("compact CRAP still contains 'recommended_actions'")
+	}
+
+	// Verify other summary fields are preserved.
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	var crapData map[string]json.RawMessage
+	if err := json.Unmarshal(m["crap"], &crapData); err != nil {
+		t.Fatalf("Unmarshal crap: %v", err)
+	}
+	var summary map[string]interface{}
+	if err := json.Unmarshal(crapData["summary"], &summary); err != nil {
+		t.Fatalf("Unmarshal crap summary: %v", err)
+	}
+	craploadVal, ok := summary["crapload"].(float64)
+	if !ok || int(craploadVal) != 1 {
+		t.Errorf("crap summary crapload = %v, want 1", summary["crapload"])
+	}
+}
+
+// TestCompactForAI_QualitySummaryDedup verifies that worst_coverage_tests
+// is omitted from the compact quality summary.
+func TestCompactForAI_QualitySummaryDedup(t *testing.T) {
+	payload := buildFullPayload(t)
+	data, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	if strings.Contains(string(data), "worst_coverage_tests") {
+		t.Error("compact quality still contains 'worst_coverage_tests'")
+	}
+
+	// Verify quality summary scalar fields are preserved.
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	var quality map[string]json.RawMessage
+	if err := json.Unmarshal(m["quality"], &quality); err != nil {
+		t.Fatalf("Unmarshal quality: %v", err)
+	}
+	var summary map[string]interface{}
+	if err := json.Unmarshal(quality["quality_summary"], &summary); err != nil {
+		t.Fatalf("Unmarshal quality summary: %v", err)
+	}
+	totalTests, ok := summary["total_tests"].(float64)
+	if !ok || int(totalTests) != 1 {
+		t.Errorf("quality summary total_tests = %v, want 1", summary["total_tests"])
+	}
+}
+
+// TestCompactForAI_AllStepsFailed verifies that when all steps failed
+// (all data fields nil, all error fields populated), CompactForAI
+// produces valid JSON.
+func TestCompactForAI_AllStepsFailed(t *testing.T) {
+	crapErr := "crap failed"
+	qualErr := "quality failed"
+	classErr := "classify failed"
+	docErr := "docscan failed"
+
+	payload := &ReportPayload{
+		CRAP:     nil,
+		Quality:  nil,
+		Classify: nil,
+		Docscan:  nil,
+		Errors: PayloadErrors{
+			CRAP:     &crapErr,
+			Quality:  &qualErr,
+			Classify: &classErr,
+			Docscan:  &docErr,
+		},
+	}
+
+	data, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	if !json.Valid(data) {
+		t.Fatalf("invalid JSON from all-failed payload: %s", data)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	// Data fields must be null.
+	for _, key := range []string{"crap", "quality", "classify", "docscan"} {
+		if string(m[key]) != "null" {
+			t.Errorf("%s = %s, want null", key, m[key])
+		}
+	}
+
+	// Errors must be populated.
+	var errs map[string]interface{}
+	if err := json.Unmarshal(m["errors"], &errs); err != nil {
+		t.Fatalf("Unmarshal errors: %v", err)
+	}
+	for _, key := range []string{"crap", "quality", "classify", "docscan"} {
+		if errs[key] == nil {
+			t.Errorf("errors.%s should be non-null", key)
+		}
+	}
+}
+
+// TestCompactForAI_StepFailurePreserved verifies that when a single
+// step fails (Quality nil with error), the quality field is null and
+// the error is present, while other fields are compacted normally.
+func TestCompactForAI_StepFailurePreserved(t *testing.T) {
+	qualErr := "SSA construction failed"
+	payload := buildFullPayload(t)
+	payload.Quality = nil
+	payload.Errors.Quality = &qualErr
+
+	data, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if string(m["quality"]) != "null" {
+		t.Errorf("quality = %s, want null", m["quality"])
+	}
+
+	// CRAP should still be compacted (not null).
+	if string(m["crap"]) == "null" {
+		t.Error("crap should not be null when only quality failed")
+	}
+
+	// Error should be present.
+	var errs map[string]interface{}
+	if err := json.Unmarshal(m["errors"], &errs); err != nil {
+		t.Fatalf("Unmarshal errors: %v", err)
+	}
+	qualErrVal, ok := errs["quality"].(string)
+	if !ok {
+		t.Fatal("errors.quality should be a non-null string")
+	}
+	if qualErrVal != qualErr {
+		t.Errorf("errors.quality = %v, want %q", qualErrVal, qualErr)
+	}
+}
+
+// TestCompactForAI_SizeBudget verifies that a synthetic payload with
+// ~200 functions, ~100 test-target pairs, and ~30 docs compacts under
+// 300KB.
+func TestCompactForAI_SizeBudget(t *testing.T) {
+	// Build a large CRAP section with 200 scores.
+	scores := make([]map[string]interface{}, 200)
+	for i := range scores {
+		scores[i] = map[string]interface{}{
+			"package":  fmt.Sprintf("github.com/example/pkg%d", i),
+			"function": fmt.Sprintf("Func%d", i),
+			"file":     fmt.Sprintf("pkg%d/file.go", i),
+			"line":     i + 1, "complexity": 5 + (i % 20),
+			"line_coverage": 50.0 + float64(i%50),
+			"crap":          10.0 + float64(i%30),
+		}
+	}
+	crapJSON := mustMarshal(t, map[string]interface{}{
+		"scores": scores,
+		"summary": map[string]interface{}{
+			"total_functions": 200, "avg_complexity": 15.0,
+			"avg_line_coverage": 75.0, "avg_crap": 20.0,
+			"crapload": 50, "crap_threshold": 15.0,
+			"worst_crap":          scores[:10],
+			"worst_gaze_crap":     scores[:10],
+			"recommended_actions": scores[:20],
+		},
+	})
+
+	// Build quality with 100 test-target pairs, each with gaps.
+	qualReports := make([]map[string]interface{}, 100)
+	for i := range qualReports {
+		qualReports[i] = map[string]interface{}{
+			"test_function": fmt.Sprintf("TestFunc%d", i),
+			"test_location": fmt.Sprintf("pkg/file_test.go:%d", i+1),
+			"target_function": map[string]interface{}{
+				"package":   fmt.Sprintf("github.com/example/pkg%d", i),
+				"function":  fmt.Sprintf("Func%d", i),
+				"signature": fmt.Sprintf("func Func%d() error", i),
+				"location":  fmt.Sprintf("pkg/file.go:%d", i+1),
+			},
+			"contract_coverage": map[string]interface{}{
+				"percentage": 50.0, "covered_count": 1, "total_contractual": 2,
+				"gaps": []map[string]interface{}{
+					{"id": fmt.Sprintf("se-%08x", i), "type": "ErrorReturn",
+						"tier": "P0", "location": fmt.Sprintf("pkg/file.go:%d", i+10),
+						"description": "returns error", "target": "error"},
+				},
+				"gap_hints":         []string{"assert err"},
+				"discarded_returns": []interface{}{},
+			},
+			"over_specification": map[string]interface{}{
+				"count": 0, "ratio": 0.0,
+				"incidental_assertions": []interface{}{},
+				"suggestions":           []interface{}{},
+			},
+			"ambiguous_effects":              []interface{}{},
+			"unmapped_assertions":            []interface{}{},
+			"assertion_count":                2,
+			"assertion_detection_confidence": 90,
+			"metadata": map[string]interface{}{
+				"gaze_version": "dev", "go_version": "go1.24",
+				"duration_ms": 10, "warnings": []interface{}{},
+			},
+		}
+	}
+	qualityJSON := mustMarshal(t, map[string]interface{}{
+		"quality_reports": qualReports,
+		"quality_summary": map[string]interface{}{
+			"total_tests": 100, "average_contract_coverage": 50.0,
+			"total_over_specifications":      0,
+			"assertion_detection_confidence": 90,
+			"ssa_degraded":                   false,
+			"worst_coverage_tests":           qualReports[:5],
+		},
+	})
+
+	// Build docscan with 30 docs, each with 10KB content.
+	docs := make([]map[string]interface{}, 30)
+	bigContent := strings.Repeat("Documentation content. ", 500) // ~11KB
+	for i := range docs {
+		docs[i] = map[string]interface{}{
+			"path":     fmt.Sprintf("docs/doc%d.md", i),
+			"content":  bigContent,
+			"priority": 3,
+		}
+	}
+	docscanJSON := mustMarshal(t, docs)
+
+	// Classify with 200 results, each with 3 signals.
+	classifyResults := make([]map[string]interface{}, 200)
+	for i := range classifyResults {
+		classifyResults[i] = map[string]interface{}{
+			"target": map[string]interface{}{
+				"package":   fmt.Sprintf("github.com/example/pkg%d", i),
+				"function":  fmt.Sprintf("Func%d", i),
+				"signature": fmt.Sprintf("func Func%d() error", i),
+				"location":  fmt.Sprintf("pkg/file.go:%d", i+1),
+			},
+			"side_effects": []map[string]interface{}{
+				{
+					"id": fmt.Sprintf("se-%08x", i), "type": "ErrorReturn",
+					"tier": "P0", "location": fmt.Sprintf("pkg/file.go:%d", i+10),
+					"description": "returns error", "target": "error",
+					"classification": map[string]interface{}{
+						"label": "contractual", "confidence": 90,
+						"signals": []map[string]interface{}{
+							{"source": "interface", "weight": 25},
+							{"source": "naming", "weight": 15},
+							{"source": "godoc", "weight": 20,
+								"source_file": "pkg/file.go",
+								"excerpt":     "Returns an error when the operation fails",
+								"reasoning":   "GoDoc explicitly documents error return"},
+						},
+						"reasoning": "error return is contractual",
+					},
+				},
+			},
+			"metadata": map[string]interface{}{
+				"gaze_version": "dev", "go_version": "go1.24",
+				"duration_ms": 10, "warnings": []interface{}{},
+			},
+		}
+	}
+	classifyJSON := mustMarshal(t, map[string]interface{}{
+		"version": "dev",
+		"results": classifyResults,
+	})
+
+	payload := &ReportPayload{
+		Summary:  ReportSummary{CRAPload: 50, GazeCRAPload: 10, AvgContractCoverage: 50},
+		CRAP:     crapJSON,
+		Quality:  qualityJSON,
+		Classify: classifyJSON,
+		Docscan:  docscanJSON,
+		Errors:   PayloadErrors{},
+	}
+
+	// Verify full marshal is large.
+	fullData, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	t.Logf("Full payload size: %d bytes", len(fullData))
+
+	// Compact must be under 300KB.
+	compactData, err := payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+	t.Logf("Compact payload size: %d bytes", len(compactData))
+
+	if len(compactData) > 300*1024 {
+		t.Errorf("compact payload = %d bytes, want <= %d bytes (300KB)",
+			len(compactData), 300*1024)
+	}
+
+	// Compact must be significantly smaller than full.
+	if len(compactData) >= len(fullData) {
+		t.Errorf("compact (%d) should be smaller than full (%d)",
+			len(compactData), len(fullData))
+	}
+}
+
+// TestCompactForAI_FullMarshalUnchanged verifies that json.Marshal on
+// the same payload still produces the full output with content, signals,
+// and worst offender lists — CompactForAI does not mutate the payload.
+func TestCompactForAI_FullMarshalUnchanged(t *testing.T) {
+	payload := buildFullPayload(t)
+
+	// Capture full marshal before compact.
+	fullBefore, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json.Marshal (before): %v", err)
+	}
+
+	// Run compact.
+	_, err = payload.CompactForAI()
+	if err != nil {
+		t.Fatalf("CompactForAI: %v", err)
+	}
+
+	// Full marshal after compact must be identical.
+	fullAfter, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json.Marshal (after): %v", err)
+	}
+
+	if string(fullBefore) != string(fullAfter) {
+		t.Error("json.Marshal output changed after CompactForAI — payload was mutated")
+	}
+
+	// Verify full output still contains content, signals, worst lists.
+	s := string(fullAfter)
+	if !strings.Contains(s, "content") {
+		t.Error("full marshal missing 'content' (docscan)")
+	}
+	if !strings.Contains(s, "signals") {
+		t.Error("full marshal missing 'signals' (classify)")
+	}
+	if !strings.Contains(s, "worst_crap") {
+		t.Error("full marshal missing 'worst_crap' (CRAP)")
+	}
+}
+
+// TestExtractEffectIDs verifies the nil/empty/populated behavior of
+// extractEffectIDs, which must preserve the distinction between nil
+// (JSON null) and empty (JSON []) slices.
+func TestExtractEffectIDs(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []taxonomy.SideEffect
+		want   []string // nil means expect nil output
+		wantNl bool     // true = expect nil result (vs non-nil empty)
+	}{
+		{
+			name:   "nil input returns nil output",
+			input:  nil,
+			want:   nil,
+			wantNl: true,
+		},
+		{
+			name:   "empty slice returns empty non-nil slice",
+			input:  []taxonomy.SideEffect{},
+			want:   []string{},
+			wantNl: false,
+		},
+		{
+			name: "populated slice extracts ID strings",
+			input: []taxonomy.SideEffect{
+				{ID: "se-aabbccdd", Type: "ErrorReturn", Tier: "P0"},
+				{ID: "se-11223344", Type: "ReturnValue", Tier: "P0"},
+				{ID: "se-55667788", Type: "LogWrite", Tier: "P2"},
+			},
+			want:   []string{"se-aabbccdd", "se-11223344", "se-55667788"},
+			wantNl: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractEffectIDs(tt.input)
+
+			// Check nil vs non-nil distinction.
+			if tt.wantNl {
+				if got != nil {
+					t.Fatalf("extractEffectIDs(%v) = %v, want nil", tt.input, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("extractEffectIDs(%v) = nil, want non-nil empty slice", tt.input)
+			}
+
+			// Check length.
+			if len(got) != len(tt.want) {
+				t.Fatalf("extractEffectIDs length = %d, want %d", len(got), len(tt.want))
+			}
+
+			// Check values.
+			for i, wantID := range tt.want {
+				if got[i] != wantID {
+					t.Errorf("extractEffectIDs[%d] = %q, want %q", i, got[i], wantID)
+				}
+			}
+		})
+	}
+}
+
+// TestRunTextPath_CompactPayloadReceived verifies that the compact payload
+// produced by CompactForAI is what the AI adapter actually receives when
+// runTextPath is called. This is an integration test between the compact
+// encoding and the text path plumbing.
+func TestRunTextPath_CompactPayloadReceived(t *testing.T) {
+	payload := buildFullPayload(t)
+
+	fa := &FakeAdapter{Response: "# Report\n\nFormatted output."}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	opts := RunnerOptions{
+		Format:  "text",
+		Adapter: fa,
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+	}
+
+	err := runTextPath(payload, opts)
+	if err != nil {
+		t.Fatalf("runTextPath: %v", err)
+	}
+
+	// FakeAdapter must have been called exactly once.
+	if len(fa.Calls) != 1 {
+		t.Fatalf("expected 1 adapter call, got %d", len(fa.Calls))
+	}
+
+	adapterPayload := fa.Calls[0].Payload
+
+	// The adapter payload must be valid JSON.
+	if !json.Valid(adapterPayload) {
+		t.Fatalf("adapter received invalid JSON: %s", adapterPayload)
+	}
+
+	// Parse into a generic map for field assertions.
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(adapterPayload, &m); err != nil {
+		t.Fatalf("Unmarshal adapter payload: %v", err)
+	}
+
+	// Assertion 1: no "content" in docscan entries.
+	var docs []map[string]interface{}
+	if err := json.Unmarshal(m["docscan"], &docs); err != nil {
+		t.Fatalf("Unmarshal docscan: %v", err)
+	}
+	for i, doc := range docs {
+		if _, ok := doc["content"]; ok {
+			t.Errorf("docscan[%d] still has 'content' field in adapter payload", i)
+		}
+	}
+
+	// Assertion 2: no "signals" in classify side effect classifications.
+	var classify map[string]interface{}
+	if err := json.Unmarshal(m["classify"], &classify); err != nil {
+		t.Fatalf("Unmarshal classify: %v", err)
+	}
+	results, ok := classify["results"].([]interface{})
+	if !ok || len(results) == 0 {
+		t.Fatal("no classify results in adapter payload")
+	}
+	result, ok := results[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("classify result is not an object")
+	}
+	effects, ok := result["side_effects"].([]interface{})
+	if !ok || len(effects) == 0 {
+		t.Fatal("no side effects in classify result")
+	}
+	effect, ok := effects[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("side effect is not an object")
+	}
+	cls, ok := effect["classification"].(map[string]interface{})
+	if !ok {
+		t.Fatal("classification is not an object")
+	}
+	if _, ok := cls["signals"]; ok {
+		t.Error("classify classification still has 'signals' in adapter payload")
+	}
+
+	// Assertion 3: no "worst_crap" in CRAP summary.
+	if strings.Contains(string(m["crap"]), `"worst_crap"`) {
+		t.Error("CRAP section still contains 'worst_crap' in adapter payload")
+	}
+
+	// Assertion 4: "summary" key present at top level.
+	if _, ok := m["summary"]; !ok {
+		t.Error("adapter payload missing top-level 'summary' key")
+	}
+}
+
+// TestCompactForAI_MalformedInput verifies that CompactForAI returns a
+// descriptive error when a section contains malformed JSON, and that the
+// error message identifies which section failed.
+func TestCompactForAI_MalformedInput(t *testing.T) {
+	malformed := json.RawMessage(`{not valid json}`)
+
+	tests := []struct {
+		name    string
+		payload *ReportPayload
+		wantSub string // substring expected in error message
+	}{
+		{
+			name: "malformed CRAP",
+			payload: &ReportPayload{
+				CRAP:   malformed,
+				Errors: PayloadErrors{},
+			},
+			wantSub: "CRAP",
+		},
+		{
+			name: "malformed quality",
+			payload: &ReportPayload{
+				Quality: malformed,
+				Errors:  PayloadErrors{},
+			},
+			wantSub: "quality",
+		},
+		{
+			name: "malformed classify",
+			payload: &ReportPayload{
+				Classify: malformed,
+				Errors:   PayloadErrors{},
+			},
+			wantSub: "classify",
+		},
+		{
+			name: "malformed docscan",
+			payload: &ReportPayload{
+				Docscan: malformed,
+				Errors:  PayloadErrors{},
+			},
+			wantSub: "docscan",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.payload.CompactForAI()
+			if err == nil {
+				t.Fatalf("CompactForAI with malformed %s: expected error, got nil", tt.name)
+			}
+			errMsg := err.Error()
+			// Error message must identify the section that failed.
+			// The compact.go wraps errors with section context like
+			// "compacting CRAP:", "compacting quality:", etc.
+			if !strings.Contains(strings.ToLower(errMsg), strings.ToLower(tt.wantSub)) {
+				t.Errorf("error %q does not contain section name %q", errMsg, tt.wantSub)
+			}
+		})
+	}
+}
+
+// extractQualityReports parses the compact JSON and returns the
+// quality_reports array as generic maps.
+func extractQualityReports(t *testing.T, data []byte) []map[string]interface{} {
+	t.Helper()
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal top-level: %v", err)
+	}
+
+	var quality map[string]json.RawMessage
+	if err := json.Unmarshal(m["quality"], &quality); err != nil {
+		t.Fatalf("Unmarshal quality: %v", err)
+	}
+
+	var reports []map[string]interface{}
+	if err := json.Unmarshal(quality["quality_reports"], &reports); err != nil {
+		t.Fatalf("Unmarshal quality_reports: %v", err)
+	}
+
+	return reports
+}

--- a/internal/aireport/payload.go
+++ b/internal/aireport/payload.go
@@ -47,6 +47,14 @@ type ReportSummary struct {
 
 // ReportPayload is the combined analysis data passed to the AI adapter
 // and written to stdout in --format=json mode.
+//
+// Dual serialization paths:
+//   - json.Marshal produces the full payload for --format=json output,
+//     preserving all fields (signals, worst offender lists, docscan content).
+//   - CompactForAI produces a reduced payload for the AI adapter text path,
+//     stripping large fields (docscan content, classification signals,
+//     worst offender lists) and replacing full SideEffect objects with ID
+//     strings to fit within model context windows.
 type ReportPayload struct {
 	// Summary holds pre-extracted threshold-relevant values, populated during
 	// pipeline execution. Used by EvaluateThresholds to avoid unmarshalling

--- a/internal/aireport/runner.go
+++ b/internal/aireport/runner.go
@@ -96,10 +96,11 @@ func runJSONPath(payload *ReportPayload, opts RunnerOptions) error {
 func runTextPath(payload *ReportPayload, opts RunnerOptions) error {
 	_, _ = fmt.Fprintln(opts.Stderr, "Formatting report...")
 
-	payloadBytes, err := json.Marshal(payload)
+	payloadBytes, err := payload.CompactForAI()
 	if err != nil {
-		return fmt.Errorf("marshalling payload for AI adapter: %w", err)
+		return fmt.Errorf("compacting payload for AI adapter: %w", err)
 	}
+	_, _ = fmt.Fprintf(opts.Stderr, "Payload: %d bytes (compact)\n", len(payloadBytes))
 
 	timeout := opts.AdapterCfg.Timeout
 	if timeout <= 0 {

--- a/internal/analysis/bench_test.go
+++ b/internal/analysis/bench_test.go
@@ -123,9 +123,10 @@ func TestSC004_SingleFunctionPerformance(t *testing.T) {
 	// recover() to catch goroutine-scoped panics, issue #33) serializes
 	// SSA construction across transitive dependencies. Combined with
 	// parallel test execution during full suite runs (./...) which
-	// competes for CPU, we use a 10s threshold.
+	// competes for CPU, we use a 15s threshold. Raised from 10s after
+	// consistent ~11.5s runs on GitHub Actions ubuntu-latest runners.
 	// The 500ms target applies to production (non-race) builds.
-	const maxDuration = 10 * time.Second
+	const maxDuration = 15 * time.Second
 
 	testCases := []struct {
 		pkg      string
@@ -179,10 +180,10 @@ func TestSC004_SingleFunctionPerformance(t *testing.T) {
 func TestSC005_PackageAnalysisPerformance(t *testing.T) {
 	// SC-005: Package analysis < 5s for packages with up to 50
 	// exported functions. Each package should complete well within
-	// the threshold independently. Threshold raised to 10s to
+	// the threshold independently. Threshold raised to 15s to
 	// accommodate BuildSerially (issue #33) + race detector + CI
-	// contention.
-	const maxDuration = 10 * time.Second
+	// contention on GitHub Actions ubuntu-latest runners.
+	const maxDuration = 15 * time.Second
 
 	pkgNames := []string{"returns", "sentinel", "mutation", "p1effects", "p2effects"}
 	opts := analysis.Options{IncludeUnexported: true}

--- a/internal/crap/analyze.go
+++ b/internal/crap/analyze.go
@@ -134,6 +134,15 @@ func Analyze(patterns []string, moduleDir string, opts Options) (*Report, error)
 	// Step 5: Join complexity with coverage and compute CRAP.
 	scores := computeScores(complexityStats, coverMap, opts)
 
+	// Step 5b: Relativize file paths for portable JSON output.
+	// computeScores uses absolute paths for coverage lookups, but the
+	// final report should contain paths relative to the module root.
+	for i := range scores {
+		if rel, err := filepath.Rel(moduleDir, scores[i].File); err == nil {
+			scores[i].File = rel
+		}
+	}
+
 	// Step 6: Build summary.
 	summary := buildSummary(scores, opts)
 

--- a/internal/crap/crap_test.go
+++ b/internal/crap/crap_test.go
@@ -1494,3 +1494,39 @@ func TestWriteText_RemediationBreakdown(t *testing.T) {
 		t.Errorf("expected '[decompose]' label on worst offender, got:\n%s", out)
 	}
 }
+
+func TestAnalyze_RelativizesFilePaths(t *testing.T) {
+	modRoot := moduleRoot(t)
+
+	// Build a minimal coverage profile so Analyze can run.
+	profileContent := "mode: set\n" +
+		"github.com/unbound-force/gaze/internal/crap/crap.go:152.55,156.2 2 1\n"
+
+	profileFile := filepath.Join(t.TempDir(), "cover.out")
+	if err := os.WriteFile(profileFile, []byte(profileContent), 0o644); err != nil {
+		t.Fatalf("writing cover profile: %v", err)
+	}
+
+	opts := DefaultOptions()
+	opts.CoverProfile = profileFile
+
+	report, err := Analyze([]string{"./internal/crap"}, modRoot, opts)
+	if err != nil {
+		t.Fatalf("Analyze failed: %v", err)
+	}
+
+	// All Score.File paths must be relative (no leading /).
+	for _, s := range report.Scores {
+		if filepath.IsAbs(s.File) {
+			t.Errorf("Score.File is absolute, want relative: %q (function %s)", s.File, s.Function)
+		}
+	}
+
+	// RecommendedActions (if any) must also have relative paths.
+	for _, a := range report.Summary.RecommendedActions {
+		if filepath.IsAbs(a.File) {
+			t.Errorf("RecommendedAction.File is absolute, want relative: %q (function %s)",
+				a.File, a.Function)
+		}
+	}
+}

--- a/openspec/changes/report-payload-reduction/.openspec.yaml
+++ b/openspec/changes/report-payload-reduction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-19

--- a/openspec/changes/report-payload-reduction/design.md
+++ b/openspec/changes/report-payload-reduction/design.md
@@ -1,0 +1,104 @@
+## Context
+
+The `gaze report --ai=opencode` pipeline assembles a `ReportPayload` from four analysis steps (CRAP, Quality, Classify, Docscan), serializes the entire struct via `json.Marshal`, and pipes it as stdin to the AI adapter subprocess. The payload has grown to ~1.17M tokens (~3-4MB JSON), exceeding the 1M token context window of `claude-sonnet-4-6`.
+
+The pipeline currently has zero payload size awareness — no filtering, truncation, deduplication, or budget enforcement exists between the analysis steps and the adapter.
+
+The `ReportPayload` is a struct of four `json.RawMessage` fields, each containing the pretty-printed JSON from its respective step. The `ReportSummary` struct (tagged `json:"-"`) holds pre-extracted metrics but is never serialized to the adapter. Key size contributors:
+
+| Step | Typical Size | Primary Bloat Source |
+|------|-------------|---------------------|
+| CRAP | 50-80 KB | `worst_crap`/`worst_gaze_crap`/`recommended_actions` duplicate `scores` entries |
+| Quality | 200-500 KB | Full `SideEffect` objects (with nested `Classification.Signals`) embedded in `gaps`, `ambiguous_effects`, `discarded_returns` |
+| Classify | 100-300 KB | Per-signal `source_file`, `excerpt`, `reasoning` fields |
+| Docscan | 500 KB-3+ MB | Full raw text `content` of every `.md` file |
+
+## Goals / Non-Goals
+
+### Goals
+- Reduce the AI adapter payload to fit within 1M tokens (~250KB JSON) with margin for system prompt and response
+- Preserve all information the gaze-reporter agent needs to produce its formatted report (metrics, scores, quality assessments, classification labels)
+- Keep `--format=json` output unchanged — full-fidelity JSON for machine consumers is unaffected
+- Make the reduction testable with deterministic size assertions
+
+### Non-Goals
+- Changing the AI model or adapter — the fix should work with any model's context window
+- Modifying the gaze-reporter agent prompt — it already works with the data it receives
+- Adding pagination or multi-call splitting — a single compact payload is simpler and sufficient
+- Changing the `docscan.DocumentFile` struct — the reduction operates on the serialized payload, not the scanner's data model
+
+## Decisions
+
+### D1: Compact serialization method on ReportPayload
+
+**Decision**: Add a `CompactForAI() ([]byte, error)` method to `ReportPayload` that produces a reduced JSON representation. `runTextPath()` calls `CompactForAI()` instead of `json.Marshal(payload)`.
+
+**Rationale**: This keeps the full `ReportPayload` intact for `--format=json` consumers (Observable Quality — machine-parseable output preserved). The compact method is a one-way projection that cannot accidentally affect the canonical JSON output. It is a pure function on the struct, testable in isolation (Testability).
+
+**Alternative rejected**: Filtering at the step level (modifying `runCRAPStep`, `runQualityStep`, etc.) would couple step logic to the AI adapter's needs, violating the current separation where steps produce full-fidelity data and the runner decides how to deliver it.
+
+### D2: Docscan reduction — paths only
+
+**Decision**: The compact payload replaces the `docscan` field with an array of `{"path": "...", "priority": N}` objects — the `content` field is stripped entirely.
+
+**Rationale**: The gaze-reporter agent has Read tool access and can fetch any file it needs. Embedding full file contents is wasteful and accounts for the single largest payload contribution. The reporter prompt instructs it to read documentation files as needed; it does not expect pre-loaded content in the payload.
+
+### D3: Quality compaction — reference-based gaps
+
+**Decision**: In the compact payload, Quality report `gaps`, `ambiguous_effects`, and `discarded_returns` fields are reduced to arrays of side effect IDs (strings) rather than full embedded `SideEffect` objects. The full side effect data is already available in the Classify step output.
+
+**Rationale**: Each `SideEffect` object with its nested `Classification` and `Signals` array can be 500-2000 bytes. A test-target pair with 5 gaps embeds 2.5-10KB of duplicate data per pair. Replacing with ID references (`"se-a1b2c3d4"`) reduces this to ~80 bytes per pair while preserving the mapping.
+
+### D4: Signal stripping in Classify output
+
+**Decision**: In the compact payload, `Classification.Signals` arrays are omitted entirely. The top-level `Classification.Label`, `Classification.Confidence`, and `Classification.Reasoning` fields are preserved.
+
+**Rationale**: Individual signals (`source`, `weight`, `source_file`, `excerpt`, `reasoning` per signal) are debugging/audit data. The reporter agent uses `Label` and `Confidence` for report formatting — it never references individual signals. This is the second-largest contributor to Classify step size.
+
+### D5: CRAP summary deduplication
+
+**Decision**: In the compact payload, `summary.worst_crap`, `summary.worst_gaze_crap`, and `summary.recommended_actions` are omitted. The full `scores` array is preserved (it already contains all data needed to derive these subsets).
+
+**Rationale**: These three fields duplicate 20-40 entries from the `scores` array. The reporter agent can identify worst offenders from the scores directly. Similarly, `quality_summary.worst_coverage_tests` is omitted from the Quality output.
+
+### D6: Include ReportSummary in compact output
+
+**Decision**: The compact payload includes a top-level `"summary"` field with the `ReportSummary` values (CRAPload, GazeCRAPload, AvgContractCoverage, classification counts, SSA degradation info).
+
+**Rationale**: Currently `ReportSummary` is `json:"-"` and never reaches the adapter. Including it gives the reporter agent immediate access to pre-extracted key metrics without parsing raw step JSON. This is a small addition (~200 bytes) that significantly aids report formatting.
+
+## Risks / Trade-offs
+
+### Risk: Reporter agent output quality degrades
+
+The compact payload omits verbose signal details and raw doc contents. If the reporter agent's prompt evolves to reference these fields, reports may silently lose detail.
+
+**Mitigation**: The reporter prompt is scaffolded and tool-owned — changes go through `gaze init` and are version-tracked. A breaking prompt change would surface during development. Additionally, the reporter has Read tool access to fetch any file or detail it needs on demand.
+
+### Risk: Compact payload size still exceeds limit for very large projects
+
+Projects with thousands of functions could still produce large CRAP `scores` arrays even after deduplication.
+
+**Mitigation**: The `scores` array uses compact JSON (no indentation) and each entry is ~200 bytes. Even 2000 functions would produce ~400KB — well within the 1M token budget. If a project exceeds this, a future enhancement could filter to CRAPload-only functions (Q3+Q4), but this is not needed now.
+
+### Trade-off: Two serialization paths
+
+Adding `CompactForAI()` means `ReportPayload` now has two serialization paths — `json.Marshal` (full) and `CompactForAI()` (compact). Any new fields added to the payload must be considered for both paths.
+
+**Accepted**: The cost is modest — `CompactForAI()` is explicit about what it includes, and new fields default to excluded from the compact path (safe by default). A comment on `ReportPayload` will document the dual-path requirement.
+
+### D7: CompactForAI error handling — fail hard
+
+**Decision**: If `CompactForAI()` returns an error, `runTextPath` fails the command. There is no fallback to `json.Marshal(payload)`.
+
+**Rationale**: The full payload already causes a hard failure (API rejection with "prompt is too long"). Falling back to it would produce the same error with an additional misleading retry. Failing fast on compact errors surfaces bugs in the compaction logic immediately.
+
+## Coverage Strategy
+
+All new code is covered by unit tests with synthetic `ReportPayload` inputs. No integration or e2e tests are required — `CompactForAI()` is a pure data transformation with no I/O, subprocess, or filesystem dependencies.
+
+- **Unit tests**: Each compaction behavior (docscan stripping, quality ID extraction, signal stripping, CRAP deduplication, summary inclusion) has a dedicated test with explicit assertions on the compact JSON output.
+- **Size budget test**: A representative synthetic payload (~200 functions, ~100 test-target pairs, ~30 doc files with defined field sizes) verifies the compact output stays under 300KB.
+- **Full-fidelity preservation test**: A test verifies `json.Marshal(payload)` output is unaffected by the existence of `CompactForAI()`.
+- **Edge case tests**: Empty payloads (all steps nil), mixed success/failure payloads, and zero-length step outputs are tested.
+- **Target**: 100% branch coverage of `CompactForAI()` and all compact type projection logic.

--- a/openspec/changes/report-payload-reduction/proposal.md
+++ b/openspec/changes/report-payload-reduction/proposal.md
@@ -1,0 +1,67 @@
+## Why
+
+The `gaze report --ai=opencode` CI step fails because the combined JSON payload exceeds the AI model's 1M token context window. The payload reached ~1.17M tokens on run [#24633674351](https://github.com/unbound-force/gaze/actions/runs/24633674351), causing two consecutive "prompt is too long" errors from the API and a non-zero exit code that fails the CI job.
+
+The payload grows with every new function, test, and documentation file added to the project. Without intervention, this failure is permanent and worsening — the AI quality report step will never pass again on `main`.
+
+Root causes identified via pipeline analysis:
+
+1. **Docscan embeds full file contents** — every `.md` file's raw text is serialized into the payload, contributing hundreds of KB to several MB depending on spec/doc volume.
+2. **Quality step embeds full SideEffect objects** (with nested Classification and Signals arrays) in `gaps`, `ambiguous_effects`, and `discarded_returns` — duplicating data already present in the Classify step output.
+3. **Summary fields duplicate scores** — `worst_crap`, `worst_gaze_crap`, `recommended_actions`, and `worst_coverage_tests` re-embed full objects already in their parent arrays.
+4. **Classification signals include verbose debugging fields** — `source_file`, `excerpt`, and `reasoning` per signal are useful for human debugging but not for AI report formatting.
+5. **No payload size budget** — the pipeline has zero awareness of output size; there is no cap, filter, or truncation on any step's contribution.
+
+## What Changes
+
+Introduce a payload reduction layer between the four pipeline steps and the AI adapter. The layer filters, deduplicates, and truncates step outputs to produce a compact "AI-ready" payload that preserves all information the reporter agent needs for formatting while staying well within context window limits.
+
+## Capabilities
+
+### New Capabilities
+- `payload budget enforcement`: The pipeline enforces a maximum payload size before sending to the AI adapter. The compact output MUST stay under 300KB, providing ~4x margin below the 1M token context window and leaving ample room for the system prompt and model response.
+- `docscan content exclusion`: Docscan output sent to the AI adapter includes file paths and priority only — full file contents are stripped. The AI reporter already has Read tool access to fetch file contents on demand.
+- `quality data compaction`: Quality reports sent to the AI use side effect IDs referencing the Classify output instead of re-embedding full SideEffect objects with Classification and Signals.
+- `signal stripping`: Classification signals (the per-signal `source_file`, `excerpt`, and `reasoning` fields) are omitted from the AI payload. The top-level `reasoning` summary on each Classification is preserved.
+
+### Modified Capabilities
+- `ReportPayload serialization`: A new `CompactForAI() ([]byte, error)` method on `ReportPayload` produces the reduced payload. The existing `json.Marshal` path for `--format=json` is unchanged — full-fidelity JSON output is preserved for machine consumers.
+- `runTextPath()`: Uses `CompactForAI()` instead of `json.Marshal(payload)` when sending to an AI adapter.
+
+### Removed Capabilities
+- None. Full JSON output (`--format=json`) remains unchanged. Only the AI adapter input path is affected.
+
+## Impact
+
+- **Files modified**: `internal/aireport/payload.go` (new compact method), `internal/aireport/runner.go` (call compact in text path), `internal/aireport/runner_steps.go` (optional: docscan content stripping at source)
+- **CI**: The "Gaze quality report" step will succeed again once the payload fits within the 1M token window
+- **AI report quality**: Minimal impact — the reporter agent receives the same summary metrics, CRAP scores, quality reports, and classification labels. Verbose signal details and raw doc contents were never referenced in the reporter's output format.
+- **JSON output consumers**: Zero impact — `--format=json` continues to emit the full unmodified payload
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+The change preserves all artifact-based communication. The `ReportPayload` struct remains the single interface between pipeline steps and the AI adapter. The compact method is a projection of the same data — no new coupling between steps is introduced.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Gaze remains independently installable and usable without AI adapters (`--format=json` is unaffected). The compaction logic is self-contained within the `aireport` package and introduces no new external dependencies.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Machine-parseable JSON output (`--format=json`) is unchanged. The AI adapter receives a subset of the same data — all metrics, scores, and classifications are preserved. Provenance metadata (versions, locations) is maintained in the compact output.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+`CompactForAI()` is a pure transformation (struct in, bytes out) testable in isolation with synthetic payloads. No external services, subprocess calls, or filesystem access required. Size assertions can enforce the budget invariant in unit tests.

--- a/openspec/changes/report-payload-reduction/specs/payload-compaction.md
+++ b/openspec/changes/report-payload-reduction/specs/payload-compaction.md
@@ -1,0 +1,139 @@
+## ADDED Requirements
+
+### Requirement: CompactForAI method
+
+`ReportPayload` MUST provide a `CompactForAI() ([]byte, error)` method that produces a reduced JSON representation suitable for AI adapter consumption. The compact output MUST be valid JSON and MUST contain the following top-level fields: `summary`, `crap`, `quality`, `classify`, `docscan`, `errors`.
+
+#### Scenario: Compact output is valid JSON
+- **GIVEN** a fully populated `ReportPayload` with all four steps succeeded
+- **WHEN** `CompactForAI()` is called
+- **THEN** the returned bytes MUST be valid JSON that unmarshals without error
+
+#### Scenario: Compact output includes summary
+- **GIVEN** a `ReportPayload` with `Summary.CRAPload=12`, `Summary.GazeCRAPload=3`, `Summary.AvgContractCoverage=45`
+- **WHEN** `CompactForAI()` is called
+- **THEN** the output MUST contain a top-level `"summary"` object with `"crapload": 12`, `"gaze_crapload": 3`, `"avg_contract_coverage": 45`
+
+#### Scenario: Compact output respects step failures
+- **GIVEN** a `ReportPayload` where the Quality step failed (Quality is nil, Errors.Quality is non-nil)
+- **WHEN** `CompactForAI()` is called
+- **THEN** the `"quality"` field MUST be `null` and `"errors"` MUST contain the quality error message
+
+#### Scenario: All steps failed
+- **GIVEN** a `ReportPayload` with all four step fields nil and all four `Errors` fields populated
+- **WHEN** `CompactForAI()` is called
+- **THEN** the output MUST be valid JSON with all step fields as `null` and the `"errors"` object containing all four error messages
+
+#### Scenario: Step succeeds with empty data
+- **GIVEN** a `ReportPayload` where Docscan succeeded but returned an empty array (`[]`)
+- **WHEN** `CompactForAI()` is called
+- **THEN** the `"docscan"` field MUST be `[]` (empty array), not `null`
+
+### Requirement: Docscan content exclusion
+
+The compact payload MUST strip the `content` field from docscan entries. Each docscan entry MUST retain only `path` and `priority` fields.
+
+#### Scenario: Docscan paths without content
+- **GIVEN** a `ReportPayload` with docscan containing 3 documents each with `path`, `content`, and `priority`
+- **WHEN** `CompactForAI()` is called
+- **THEN** the `"docscan"` array MUST contain 3 entries, each with `"path"` and `"priority"` only, and no `"content"` field
+
+#### Scenario: Docscan step failure preserved
+- **GIVEN** a `ReportPayload` where Docscan is nil
+- **WHEN** `CompactForAI()` is called
+- **THEN** the `"docscan"` field MUST be `null`
+
+### Requirement: Quality data compaction
+
+The compact payload MUST replace full `SideEffect` objects in Quality report fields with arrays of side effect ID strings. Specifically:
+
+- `contract_coverage.gaps` (nested under `ContractCoverage`) MUST be replaced with `contract_coverage.gap_ids`
+- `contract_coverage.discarded_returns` (nested under `ContractCoverage`) MUST be replaced with `contract_coverage.discarded_return_ids`
+- `ambiguous_effects` (top-level on `QualityReport`) MUST be replaced with `ambiguous_effect_ids`
+
+The `contract_coverage.gap_hints` and `contract_coverage.discarded_return_hints` fields MUST be preserved as-is. All scalar fields on `ContractCoverage` and `QualityReport` MUST be preserved.
+
+#### Scenario: Quality gaps reduced to IDs
+- **GIVEN** a Quality report with a test-target pair whose `contract_coverage.gaps` contains 3 full `SideEffect` objects with `id` fields `"se-a1b2c3d4"`, `"se-b2c3d4e5"`, `"se-c3d4e5f6"`
+- **WHEN** `CompactForAI()` is called
+- **THEN** the corresponding quality entry's `contract_coverage` MUST contain `"gap_ids": ["se-a1b2c3d4", "se-b2c3d4e5", "se-c3d4e5f6"]` and MUST NOT contain a `"gaps"` field
+
+#### Scenario: Quality discarded returns reduced to IDs
+- **GIVEN** a Quality report with a test-target pair whose `contract_coverage.discarded_returns` contains 2 full `SideEffect` objects with `id` fields `"se-d4e5f6a7"`, `"se-e5f6a7b8"`
+- **WHEN** `CompactForAI()` is called
+- **THEN** the corresponding quality entry's `contract_coverage` MUST contain `"discarded_return_ids": ["se-d4e5f6a7", "se-e5f6a7b8"]` and MUST NOT contain a `"discarded_returns"` field
+
+#### Scenario: Quality ambiguous effects reduced to IDs
+- **GIVEN** a Quality report with a test-target pair whose `ambiguous_effects` contains 2 full `SideEffect` objects with `id` fields `"se-f6a7b8c9"`, `"se-a7b8c9d0"`
+- **WHEN** `CompactForAI()` is called
+- **THEN** the corresponding quality entry MUST contain `"ambiguous_effect_ids": ["se-f6a7b8c9", "se-a7b8c9d0"]` and MUST NOT contain an `"ambiguous_effects"` field
+
+#### Scenario: Quality hints preserved
+- **GIVEN** a Quality report with `contract_coverage.gap_hints: ["assert err != nil", "check return value"]`
+- **WHEN** `CompactForAI()` is called
+- **THEN** the `contract_coverage.gap_hints` field MUST be `["assert err != nil", "check return value"]`
+
+#### Scenario: Cross-reference resilience when Classify fails
+- **GIVEN** a `ReportPayload` where the Classify step failed (Classify is nil) but Quality has gaps with side effect IDs
+- **WHEN** `CompactForAI()` is called
+- **THEN** the quality `gap_ids` MUST still be emitted (the reporter can degrade gracefully without cross-referencing the Classify output)
+
+### Requirement: Signal stripping in Classify output
+
+The compact payload MUST omit `Classification.Signals` arrays from all side effects in the Classify output. `Classification.Label`, `Classification.Confidence`, and `Classification.Reasoning` MUST be preserved.
+
+#### Scenario: Signals omitted, label and reasoning preserved
+- **GIVEN** a Classify result with a side effect whose Classification has `label: "contractual"`, `confidence: 85`, `reasoning: "interface method with documented contract"`, `signals: [{source: "interface", weight: 15, ...}]`
+- **WHEN** `CompactForAI()` is called
+- **THEN** the side effect's classification MUST have `"label": "contractual"`, `"confidence": 85`, `"reasoning": "interface method with documented contract"`, and no `"signals"` field
+
+### Requirement: CRAP summary deduplication
+
+The compact payload MUST omit `summary.worst_crap`, `summary.worst_gaze_crap`, and `summary.recommended_actions` from the CRAP output. The `scores` array and all other summary fields (`total_functions`, `avg_complexity`, `avg_line_coverage`, `avg_crap`, `crapload`, `crap_threshold`, `gaze_crapload`, `gaze_crap_threshold`, `avg_gaze_crap`, `avg_contract_coverage`, `quadrant_counts`, `fix_strategy_counts`) MUST be preserved.
+
+#### Scenario: Worst offender lists omitted
+- **GIVEN** a CRAP report with `summary.worst_crap` containing 5 entries and `scores` containing 150 entries
+- **WHEN** `CompactForAI()` is called
+- **THEN** the CRAP output MUST contain `"scores"` with 150 entries and `"summary"` without `"worst_crap"`, `"worst_gaze_crap"`, or `"recommended_actions"` fields
+
+### Requirement: Quality summary deduplication
+
+The compact payload MUST omit `quality_summary.worst_coverage_tests` from the Quality output. All other summary fields (`total_tests`, `average_contract_coverage`, `total_over_specifications`, `assertion_detection_confidence`, `ssa_degraded`, `ssa_degraded_packages`) MUST be preserved.
+
+#### Scenario: Worst coverage tests omitted
+- **GIVEN** a Quality output with `quality_summary.worst_coverage_tests` containing 5 entries
+- **WHEN** `CompactForAI()` is called
+- **THEN** the `"quality_summary"` MUST NOT contain `"worst_coverage_tests"` and MUST contain `"total_tests"`, `"average_contract_coverage"`, `"ssa_degraded"`
+
+### Requirement: Compact payload size budget
+
+The compact payload MUST produce output under 300KB for projects with up to 500 analyzed functions. The 300KB threshold provides ~4x margin below the 1M token context window (~250KB per 1M tokens at ~4 chars/token), ensuring room for the system prompt and model response. A unit test MUST verify that a representative synthetic payload compacts to under this threshold.
+
+Synthetic fixture parameters for the size budget test: each doc file has 15KB content (stripped in compact), each function has 3-5 side effects, each side effect has 2-4 signals with 100-char excerpts, each test-target pair has 2 gaps and 1 discarded return.
+
+#### Scenario: Size budget met for medium project
+- **GIVEN** a synthetic `ReportPayload` representing 200 functions, 100 test-target pairs, and 30 documentation files with the fixture parameters above
+- **WHEN** `CompactForAI()` is called
+- **THEN** the output size MUST be less than 300KB
+
+## MODIFIED Requirements
+
+### Requirement: AI adapter payload delivery
+
+Previously: `runTextPath()` calls `json.Marshal(payload)` and passes the full result to the AI adapter.
+
+`runTextPath()` MUST call `payload.CompactForAI()` instead of `json.Marshal(payload)` when delivering the payload to the AI adapter. The `--format=json` path (`runJSONPath()`) MUST remain unchanged, continuing to use `json.Encoder` with full-fidelity output.
+
+#### Scenario: Text path uses compact payload
+- **GIVEN** a report run with `--ai=opencode --format=text`
+- **WHEN** the pipeline completes and invokes the AI adapter
+- **THEN** the adapter MUST receive the compact payload (with docscan content stripped, signals omitted, etc.) not the full `json.Marshal` output
+
+#### Scenario: JSON path unchanged
+- **GIVEN** a report run with `--format=json`
+- **WHEN** the pipeline completes
+- **THEN** stdout MUST contain the full pretty-printed JSON with all fields including docscan content, signals, worst offender lists, and full side effect objects
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/report-payload-reduction/tasks.md
+++ b/openspec/changes/report-payload-reduction/tasks.md
@@ -1,0 +1,58 @@
+## 1. Compact payload types and method
+
+- [x] 1.1 Add compact intermediate types to `internal/aireport/payload.go`: `compactPayload`, `compactDocscanEntry`, `compactQualityReport` (with `GapIDs`, `AmbiguousEffectIDs`, `DiscardedReturnIDs` instead of full objects), `compactContractCoverage` (with ID arrays), `compactClassifyResult`, `compactClassification` (without Signals), `compactCRAPReport` (without worst offender lists), `compactSummary` (unexported, mirroring `ReportSummary` with JSON tags).
+- [x] 1.2 Implement `CompactForAI() ([]byte, error)` on `ReportPayload`. Unmarshal each `json.RawMessage` field into the full type, project into the compact type, marshal the compact struct with `json.Marshal` (compact, no indentation). Handle nil fields (step failures) by passing them through as `null`. Handle empty arrays (`[]`) distinctly from nil (`null`). If any unmarshal/marshal fails, return the error directly (no fallback to full payload).
+- [x] 1.3 Add dual-path documentation comment on `ReportPayload` noting that new fields must be considered for both `json.Marshal` (full) and `CompactForAI()` (compact) serialization paths.
+- [x] 1.4 Add test: all steps failed (all four fields nil, all errors populated) produces valid JSON with null step fields and populated errors.
+- [x] 1.5 Add test: step succeeds with empty data (docscan returns `[]`) produces `[]` in compact output, not `null`.
+
+## 2. Docscan content stripping
+
+- [x] 2.1 In `CompactForAI()`, unmarshal the `Docscan` field into `[]docscan.DocumentFile`, project each entry to `compactDocscanEntry{Path, Priority}` (dropping `Content`), marshal back.
+- [x] 2.2 Add test: given a docscan payload with 3 files each having 10KB content, `CompactForAI()` docscan output contains paths and priorities only, no content field present.
+
+## 3. Quality data compaction
+
+- [x] 3.1 In `CompactForAI()`, unmarshal the `Quality` field, replace `ContractCoverage.Gaps []SideEffect` with `ContractCoverage.GapIDs []string` (extracted from each SideEffect's `ID` field). Same for `ContractCoverage.DiscardedReturns` → `ContractCoverage.DiscardedReturnIDs` and `QualityReport.AmbiguousEffects` → `QualityReport.AmbiguousEffectIDs`. Preserve `ContractCoverage.GapHints`, `ContractCoverage.DiscardedReturnHints`, and all scalar fields.
+- [x] 3.2 Omit `quality_summary.worst_coverage_tests` from the compact quality output. Preserve `total_tests`, `average_contract_coverage`, `total_over_specifications`, `assertion_detection_confidence`, `ssa_degraded`, `ssa_degraded_packages`.
+- [x] 3.3 Add test: given a quality payload with 3 gaps each as full SideEffect objects, compact output has `contract_coverage.gap_ids: ["se-a1b2c3d4", ...]` and no `contract_coverage.gaps` field. Verify `contract_coverage.gap_hints` are preserved.
+- [x] 3.4 Add test: given a quality payload with 2 discarded returns, compact output has `contract_coverage.discarded_return_ids` and no `contract_coverage.discarded_returns` field.
+- [x] 3.5 Add test: given a quality payload with 2 ambiguous effects, compact output has `ambiguous_effect_ids` and no `ambiguous_effects` field.
+- [x] 3.6 Add test: Classify step failed (nil) but Quality has gaps with IDs — `gap_ids` are still emitted correctly.
+
+## 4. Classify signal stripping
+
+- [x] 4.1 In `CompactForAI()`, unmarshal the `Classify` field, walk each result's side effects and use compact classification struct without Signals field. Preserve `Label`, `Confidence`, `Reasoning`.
+- [x] 4.2 Add test: given a classify payload with signals and reasoning, compact output has classification with label, confidence, and reasoning but no signals array.
+
+## 5. CRAP summary deduplication
+
+- [x] 5.1 In `CompactForAI()`, unmarshal the `CRAP` field, nil out `Summary.WorstCrap`, `Summary.WorstGazeCrap`, and `Summary.RecommendedActions`. Preserve `Scores` array and all other summary fields.
+- [x] 5.2 Add test: given a CRAP payload with 150 scores and worst offender lists, compact output has 150 scores and summary without worst/recommended fields.
+
+## 6. Wire compact payload into text path
+
+- [x] 6.1 In `runTextPath()` (`internal/aireport/runner.go`), replace `json.Marshal(payload)` with `payload.CompactForAI()`. No changes to `runJSONPath()`. Add stderr diagnostic: `fmt.Fprintf(stderr, "Payload: %d bytes (compact)\n", len(compactBytes))`.
+- [x] 6.2 Add test: `runTextPath` sends compact payload to adapter (verify via fake adapter that receives stdin). Assert: (1) docscan content absent, (2) no `signals` arrays in classify data, (3) no `worst_crap`/`worst_gaze_crap` in CRAP summary, (4) top-level `summary` field present.
+
+## 7. Size budget verification
+
+- [x] 7.1 Add test: construct a synthetic `ReportPayload` representing ~200 functions, ~100 test-target pairs, ~30 doc files with defined fixture parameters (15KB content per doc, 3-5 effects per function, 2-4 signals with 100-char excerpts per effect, 2 gaps per test-target pair). Assert `CompactForAI()` output is under 300KB.
+- [x] 7.2 Add test: construct the same synthetic payload and verify `json.Marshal(payload)` produces the full uncompacted output (docscan content present, signals present, worst offender lists present) — confirming `--format=json` is unaffected.
+
+## 8. Reporter prompt audit
+
+- [x] 8.1 Read `.opencode/agents/gaze-reporter.md` and check for references to fields absent from the compact payload (`signals`, `content` on docscan, `worst_crap`, `worst_gaze_crap`, `recommended_actions`, `worst_coverage_tests`, `gaps` as objects). If references exist, update the prompt to use compact field names or add guidance about using Read tool for detailed data.
+
+## 9. Constitution alignment verification
+
+- [x] 9.1 Verify Testability: confirm all new functions (`CompactForAI`, compact type projections) are tested with synthetic inputs, no subprocess or filesystem dependencies. 100% branch coverage of compact method.
+- [x] 9.2 Verify Composability: confirm no new external dependencies introduced (`go mod tidy` produces no changes).
+
+## 10. CI and integration
+
+- [x] 10.1 Run `go test -race -count=1 -short ./...` — all tests pass.
+- [x] 10.2 Run `golangci-lint run` — no new lint issues.
+- [x] 10.3 Run `go build ./cmd/gaze && ./gaze report ./... --format=json --coverprofile=coverage.out > /dev/null` — verify full JSON output succeeds (smoke test for Observable Quality).
+<!-- spec-review: passed -->
+<!-- code-review: passed -->

--- a/openspec/schemas/unbound-force/schema.yaml
+++ b/openspec/schemas/unbound-force/schema.yaml
@@ -68,3 +68,4 @@ apply:
 # scaffolded by uf vv0.6.1
 # scaffolded by uf vdev
 # scaffolded by uf vdev
+# scaffolded by uf vdev

--- a/openspec/schemas/unbound-force/templates/design.md
+++ b/openspec/schemas/unbound-force/templates/design.md
@@ -20,3 +20,4 @@
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->

--- a/openspec/schemas/unbound-force/templates/proposal.md
+++ b/openspec/schemas/unbound-force/templates/proposal.md
@@ -57,3 +57,4 @@ Are components testable in isolation? -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->

--- a/openspec/schemas/unbound-force/templates/spec.md
+++ b/openspec/schemas/unbound-force/templates/spec.md
@@ -23,3 +23,4 @@
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->

--- a/openspec/schemas/unbound-force/templates/tasks.md
+++ b/openspec/schemas/unbound-force/templates/tasks.md
@@ -9,3 +9,4 @@
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->

--- a/specs/038-platform-scaffold/checklists/requirements.md
+++ b/specs/038-platform-scaffold/checklists/requirements.md
@@ -2,6 +2,7 @@
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-04-30
+**Updated**: 2026-04-30 (post-review-council iteration 1)
 **Feature**: [spec.md](../spec.md)
 
 ## Content Quality
@@ -13,7 +14,7 @@
 
 ## Requirement Completeness
 
-- [x] No [NEEDS CLARIFICATION] markers remain
+- [ ] No [NEEDS CLARIFICATION] markers remain
 - [x] Requirements are testable and unambiguous
 - [x] Success criteria are measurable
 - [x] Success criteria are technology-agnostic (no implementation details)
@@ -21,6 +22,7 @@
 - [x] Edge cases are identified
 - [x] Scope is clearly bounded
 - [x] Dependencies and assumptions identified
+- [x] Documentation impact identified
 
 ## Feature Readiness
 
@@ -35,14 +37,71 @@
   Multi-Platform Scaffold Deployment) for gaze's simpler scaffold
   system (8 embedded files vs 50, no convention packs, no MCP
   configuration, no DivisorOnly mode).
-- Gaze-specific simplifications over the uf spec:
-  - No convention pack to `.mdc` rule translation (gaze has no packs)
-  - No MCP configuration translation (gaze has no MCP scaffolding)
-  - No `--divisor` mode (gaze has no DivisorOnly concept)
-  - No bridge files (`.cursorrules`, `CLAUDE.md`) -- gaze doesn't
-    create these
-- FR-007 references OpenCode-specific frontmatter fields that must
-  be dropped for Cursor; these are observable in the current embedded
-  agent assets (e.g., `gaze-reporter.md` has `tools` restrictions).
-- Out of Scope section explicitly excludes features that are uf-specific
-  rather than gaze-specific.
+- FR-007 references specific frontmatter field names (`mode`,
+  `temperature`, `tools`, etc.) which are input/output contracts
+  necessary for testability, not implementation prescriptions.
+- FR-011 was rewritten to remove the `isToolOwned()` function name
+  reference per review council feedback.
+- Dependencies section updated to note scaffold evolution through
+  specs 012, 016, and 017 since the original spec 005.
+- Documentation Impact section added per Curator review.
+- Website documentation gate requirement added per AGENTS.md.
+- User Story 3 Independent Test softened from "byte-identical" to
+  "functionally identical" per Architect review.
+- US3-AS2 expanded with specific equivalence criteria per Tester review.
+- Acceptance scenarios added for FR-015 (US1-AS5) and FR-018 (US2-AS4)
+  per Tester/Adversary review.
+- Edge case added for `--force` with non-existent platform directory
+  per SRE review.
+- Extensibility assumption (line 329 in original) removed as redundant
+  with FR-016/SC-006 per Architect review.
+- Key Entities "Asset" rewritten to remove `internal/scaffold/assets/`
+  path reference per Adversary review.
+
+## Outstanding HIGH/CRITICAL Findings (Human Decision Required)
+
+The following findings from the review council require human
+judgment. They were NOT auto-fixed:
+
+1. **CRITICAL (Adversary, Tester)**: Missing coverage strategy
+   section. Constitution Principle IV requires coverage strategy
+   in the plan. The spec should signal testing expectations to
+   the planner. Recommendation: Add a coverage strategy note or
+   defer to plan.md with an explicit acknowledgment.
+
+2. **HIGH (Adversary, Tester, SRE, Scribe)**: FR-007 frontmatter
+   transformation contract is incomplete. The `model` field
+   (present in `reviewer-testing.md`) and `agent` field (present
+   in `gaze.md` commands) are not addressed. The `name`
+   derivation rule is unspecified (e.g., `gaze-reporter.md` →
+   `name: gaze-reporter` or `name: Gaze Reporter`?). The drop
+   list may be incomplete. Recommendation: Define a complete
+   field disposition table or specify "preserve only `name` and
+   `description`; drop all other frontmatter fields."
+
+3. **HIGH (Adversary, SRE)**: Cursor format assumptions are
+   unvalidated. No Cursor documentation source is cited. No
+   degradation strategy if Cursor changes its format. The Scribe
+   notes that Cursor may use `.cursor/prompts/` rather than
+   `.cursor/commands/`. Recommendation: Create a `research.md`
+   artifact validating Cursor's directory structure and
+   frontmatter schema before planning.
+
+4. **HIGH (Tester, Adversary)**: FR-016/SC-006 extensibility
+   requirement is not objectively testable. "Verified by code
+   review" is subjective. Recommendation: Either rewrite as a
+   testable requirement (e.g., "a mock platform can be added
+   without modifying existing code") or move to architectural
+   constraints.
+
+5. **HIGH (Tester)**: Missing cross-platform ownership acceptance
+   scenarios. No scenario verifies tool-owned overwrite-on-diff
+   behavior per platform, force flag isolation to selected
+   platforms only, or ownership classification consistency across
+   platforms.
+
+6. **HIGH (SRE)**: Drift detection test
+   (`TestEmbeddedAssetsMatchSource`) not addressed. The spec
+   must define how the existing drift test is preserved for
+   OpenCode and whether a new Cursor-specific validation test
+   is needed.

--- a/specs/038-platform-scaffold/checklists/requirements.md
+++ b/specs/038-platform-scaffold/checklists/requirements.md
@@ -1,0 +1,48 @@
+# Specification Quality Checklist: Multi-Platform Scaffold Deployment
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Adapted from unbound-force/unbound-force PR #144 (Spec 035:
+  Multi-Platform Scaffold Deployment) for gaze's simpler scaffold
+  system (8 embedded files vs 50, no convention packs, no MCP
+  configuration, no DivisorOnly mode).
+- Gaze-specific simplifications over the uf spec:
+  - No convention pack to `.mdc` rule translation (gaze has no packs)
+  - No MCP configuration translation (gaze has no MCP scaffolding)
+  - No `--divisor` mode (gaze has no DivisorOnly concept)
+  - No bridge files (`.cursorrules`, `CLAUDE.md`) -- gaze doesn't
+    create these
+- FR-007 references OpenCode-specific frontmatter fields that must
+  be dropped for Cursor; these are observable in the current embedded
+  agent assets (e.g., `gaze-reporter.md` has `tools` restrictions).
+- Out of Scope section explicitly excludes features that are uf-specific
+  rather than gaze-specific.

--- a/specs/038-platform-scaffold/spec.md
+++ b/specs/038-platform-scaffold/spec.md
@@ -1,0 +1,360 @@
+# Feature Specification: Multi-Platform Scaffold Deployment
+
+**Feature Branch**: `038-platform-scaffold`
+**Created**: 2026-04-30
+**Status**: Draft
+**Input**: User description: "Create an analogous spec from unbound-force/unbound-force PR #144 for gaze to support platforms other than OpenCode"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Cursor-Only Project Scaffolding (Priority: P1)
+
+A developer uses Cursor as their primary AI coding
+assistant and wants gaze's quality agents and commands
+available natively in Cursor. They run `gaze init
+--platform cursor` and receive a `.cursor/` directory
+containing gaze-reporter, gaze-test-generator, and
+reviewer-testing agents, plus commands and reference
+files -- all in Cursor's native formats. The gaze
+tooling works immediately in Cursor without any
+additional configuration.
+
+**Why this priority**: This is the core value
+proposition. Without correct Cursor file generation, the
+feature has no purpose. Users of Cursor currently cannot
+use gaze's quality reporting and test generation agents.
+
+**Independent Test**: Can be fully tested by running
+`gaze init --platform cursor` in an empty directory
+with a `go.mod` file and verifying all generated files
+match Cursor's expected directory structure, frontmatter
+schemas, and file extensions.
+
+**Acceptance Scenarios**:
+
+1. **Given** an empty directory with a `go.mod` file,
+   **When** a user runs `gaze init --platform cursor`,
+   **Then** a `.cursor/` directory is created containing
+   `agents/` and `commands/` subdirectories with
+   correctly formatted files, and no `.opencode/`
+   directory is created.
+
+2. **Given** an empty directory with a `go.mod` file,
+   **When** a user runs `gaze init --platform cursor`,
+   **Then** agent files in `.cursor/agents/` have YAML
+   frontmatter with `name` (derived from filename) and
+   `description` fields, and do not contain OpenCode-
+   specific fields (`mode`, `temperature`, `tools`,
+   `maxSteps`, `disabled`).
+
+3. **Given** an empty directory with a `go.mod` file,
+   **When** a user runs `gaze init --platform cursor`,
+   **Then** reference files are deployed to
+   `.cursor/references/` with no content transformation
+   (they are loaded on demand by agents via file read).
+
+4. **Given** an empty directory with a `go.mod` file,
+   **When** a user runs `gaze init --platform cursor`,
+   **Then** command files are deployed to
+   `.cursor/commands/` as plain Markdown with no content
+   transformation.
+
+---
+
+### User Story 2 - Dual-Platform Project Scaffolding (Priority: P2)
+
+A team uses both OpenCode and Cursor across different
+developers. A lead runs `gaze init --platform opencode
+--platform cursor` and the project receives both
+`.opencode/` and `.cursor/` directories, each containing
+platform-native files derived from the same canonical
+embedded assets. Both tools can use gaze's quality
+reporting in the same project.
+
+**Why this priority**: Multi-platform support is the
+strategic differentiator. Without this, users must
+choose one platform or manually copy and adapt agent
+files for their second tool.
+
+**Independent Test**: Can be tested by running
+`gaze init --platform opencode --platform cursor` in an
+empty directory and verifying both `.opencode/` and
+`.cursor/` directories are created with correct,
+platform-appropriate content.
+
+**Acceptance Scenarios**:
+
+1. **Given** an empty directory with a `go.mod` file,
+   **When** a user runs `gaze init --platform opencode
+   --platform cursor`, **Then** both `.opencode/` and
+   `.cursor/` directories are created, each containing
+   agents, commands, and reference files.
+
+2. **Given** a project with an existing `.opencode/`
+   directory from a previous `gaze init`, **When** a
+   user runs `gaze init --platform cursor`, **Then** a
+   `.cursor/` directory is created alongside the
+   existing `.opencode/` directory, and no files within
+   the existing `.opencode/` directory are modified,
+   created, or deleted.
+
+3. **Given** a dual-platform project, **When** a user
+   runs `gaze init --platform opencode --platform
+   cursor` again, **Then** tool-owned files in both
+   directories are updated if content has changed, and
+   user-owned files in both directories are preserved.
+
+---
+
+### User Story 3 - Backward-Compatible Default Behavior (Priority: P1)
+
+An existing gaze user runs `gaze init` without any
+`--platform` flag. The behavior is identical to today:
+files are deployed to `.opencode/` exactly as before.
+No `.cursor/` directory is created. No existing
+workflows are broken.
+
+**Why this priority**: Breaking backward compatibility
+for existing users would be a regression. This must be
+guaranteed alongside the new platform support.
+
+**Independent Test**: Can be tested by running
+`gaze init` (no `--platform` flag) and verifying the
+output is byte-identical to the current behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** an empty directory with a `go.mod` file,
+   **When** a user runs `gaze init` with no `--platform`
+   flag, **Then** files are deployed to `.opencode/`
+   exactly as they are today, and no `.cursor/`
+   directory is created.
+
+2. **Given** an empty directory with a `go.mod` file,
+   **When** a user runs `gaze init --platform opencode`,
+   **Then** the result is identical to running
+   `gaze init` with no `--platform` flag.
+
+---
+
+### User Story 4 - Force Overwrite Across Platforms (Priority: P3)
+
+A developer wants to reset all gaze scaffold files to
+the latest embedded versions, including files they have
+customized. They run `gaze init --platform cursor
+--force` and all Cursor files are overwritten, including
+user-owned agents like `gaze-reporter.md`.
+
+**Why this priority**: `--force` is an existing escape
+hatch. Extending it to new platforms is a parity feature
+that ensures consistent behavior.
+
+**Independent Test**: Can be tested by running
+`gaze init --platform cursor`, modifying a user-owned
+agent file, then running `gaze init --platform cursor
+--force` and verifying the modification is overwritten.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with a customized
+   `.cursor/agents/gaze-reporter.md`, **When** a user
+   runs `gaze init --platform cursor --force`, **Then**
+   the customized file is overwritten with the latest
+   embedded version.
+
+2. **Given** a dual-platform project, **When** a user
+   runs `gaze init --platform opencode --platform cursor
+   --force`, **Then** `--force` applies to both
+   platforms -- user-owned files in both `.opencode/`
+   and `.cursor/` are overwritten.
+
+---
+
+### Edge Cases
+
+- What happens when `--platform` is given an unknown
+  value (e.g., `--platform vim`)? System rejects with
+  a clear error listing valid platforms.
+- What happens when `--platform` is specified multiple
+  times with the same value (e.g., `--platform cursor
+  --platform cursor`)? Deduplicated silently; files
+  deployed once.
+- What happens when a `.cursor/agents/` file exists
+  with content the user has customized? User-owned
+  files are never overwritten (same ownership model as
+  `.opencode/`).
+- What happens when `--platform cursor --force` is
+  specified? All Cursor files are overwritten, including
+  user-owned agents.
+- What happens when `--platform opencode --platform
+  cursor --force` is specified? `--force` applies to
+  all selected platforms -- both `.opencode/` and
+  `.cursor/` user-owned files are overwritten.
+- What happens when `gaze init --platform cursor` is
+  run in a directory with no `go.mod`? Same warning
+  as today ("no go.mod found") but initialization
+  proceeds.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST accept a `--platform` flag on
+  `gaze init` that takes one or more platform names as a
+  repeatable string value.
+- **FR-002**: System MUST support two platform values:
+  `opencode` (current behavior) and `cursor` (new).
+- **FR-003**: System MUST default to `--platform
+  opencode` when no `--platform` flag is specified,
+  preserving 100% backward compatibility.
+- **FR-004**: System MUST reject unknown platform values
+  with an error message listing valid platforms.
+- **FR-005**: System MUST deduplicate repeated platform
+  values silently.
+- **FR-006**: System MUST deploy embedded assets to
+  all selected platforms in a single initialization
+  operation, processing each asset for every applicable
+  platform.
+- **FR-007**: System MUST transform OpenCode agent
+  frontmatter to Cursor format by: adding `name`
+  (derived from filename stem), preserving
+  `description`, and dropping OpenCode-specific fields
+  (`mode`, `temperature`, `tools`, `maxSteps`,
+  `disabled`).
+- **FR-008**: System MUST deploy command files to
+  `.cursor/commands/` as plain Markdown with no content
+  transformation beyond the version marker insertion.
+- **FR-009**: System MUST deploy reference files to
+  `.cursor/references/` with no content transformation
+  beyond the version marker insertion.
+- **FR-010**: System MUST apply the same file ownership
+  model to Cursor files: tool-owned files are auto-
+  updated on re-init, user-owned files are never
+  overwritten unless `--force` is specified.
+- **FR-011**: System MUST classify Cursor files using
+  the same ownership rules as OpenCode files: the
+  existing `isToolOwned()` logic determines ownership
+  regardless of target platform.
+- **FR-012**: System MUST insert the standard version
+  marker (`<!-- scaffolded by gaze vX.Y.Z -->`) into
+  all files regardless of target platform.
+- **FR-013**: System MUST deploy files to the correct
+  platform-specific root directory: `.opencode/` for
+  OpenCode, `.cursor/` for Cursor.
+- **FR-014**: System MUST support the `--force` flag for
+  all platforms, overwriting user-owned files when
+  specified.
+- **FR-015**: System MUST display the selected
+  platform(s) in the scaffold summary output so users
+  can confirm which platforms were deployed to.
+- **FR-016**: System MUST be architecturally extensible
+  so that adding a new platform target requires no
+  modification to the scaffold engine's core asset-
+  walking logic. Each platform's path mapping and
+  content transformation MUST be encapsulated
+  independently.
+- **FR-017**: When multiple platforms are selected,
+  the system MUST NOT modify files belonging to a
+  platform that was not selected. Running
+  `gaze init --platform cursor` on a project with an
+  existing `.opencode/` directory MUST leave the
+  `.opencode/` files untouched.
+- **FR-018**: System MUST report per-platform results
+  in the scaffold summary, showing created, skipped,
+  updated, and overwritten counts for each selected
+  platform.
+
+### Key Entities
+
+- **Platform**: An abstraction representing a target AI
+  coding tool. Each platform knows how to map an asset's
+  relative path to a platform-specific output directory
+  and how to transform content (e.g., frontmatter
+  adaptation).
+- **Asset**: An embedded file from
+  `internal/scaffold/assets/` that is deployed to one
+  or more platform target directories.
+- **File Ownership**: A classification (tool-owned or
+  user-owned) that determines whether a file is auto-
+  updated on re-init or preserved for user
+  customization. Ownership is determined by the asset's
+  relative path, independent of the target platform.
+
+## Out of Scope
+
+- Claude Code native `.claude/` directory deployment
+  (not applicable; gaze does not manage Claude Code
+  configuration)
+- Copilot, Windsurf, or other platform support (future
+  work via the platform extensibility mechanism)
+- MCP configuration translation (gaze does not scaffold
+  MCP server configuration; this is an `uf init`
+  concern)
+- Convention pack or `.mdc` rule translation (gaze does
+  not scaffold convention packs; this is an `uf init`
+  concern)
+- Runtime platform auto-detection (detecting which AI
+  tool is currently running)
+- Bidirectional sync between platform configurations
+- Migration tooling for converting existing platform
+  configurations between formats
+- `--divisor` mode (gaze does not have a DivisorOnly
+  mode)
+
+## Dependencies
+
+- **Spec 005** (gaze-opencode-integration): Defines
+  `gaze init` subcommand and the `internal/scaffold`
+  package that this spec extends.
+- **Spec 016** (agent-context-reduction): Defines the
+  tool-owned `references/` directory pattern and the
+  `isToolOwned()` function that this spec preserves.
+
+### Research References
+
+- unbound-force/unbound-force PR #144 (Spec 035:
+  Multi-platform scaffold deployment) informed the
+  design. Adapted for gaze's simpler scaffold (8 files
+  vs 50, no convention packs, no MCP config).
+
+## Assumptions
+
+- Cursor supports `.cursor/agents/` with Markdown files
+  containing YAML frontmatter with `name` and
+  `description` fields.
+- Cursor supports `.cursor/commands/` with plain
+  Markdown command files.
+- The `--platform` flag follows established CLI
+  conventions for repeatable string slices.
+- Future platforms can be added by implementing the
+  platform abstraction without modifying the scaffold
+  engine's core asset-walking logic.
+- The `references/` directory pattern (externalized
+  context loaded on demand by agents) works the same
+  way in Cursor as in OpenCode (agents read files via
+  a file-read tool).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can scaffold a Cursor-native gaze
+  project with a single command (`gaze init --platform
+  cursor`) and have all agent files contain valid
+  Cursor-format frontmatter.
+- **SC-002**: Users can scaffold a dual-platform gaze
+  project (`gaze init --platform opencode --platform
+  cursor`) and use gaze's quality agents in both tools
+  within the same repository without conflicts.
+- **SC-003**: Running `gaze init --platform cursor`
+  twice on the same project updates tool-owned files
+  without overwriting user-customized agents.
+- **SC-004**: All existing `gaze init` behavior is
+  preserved when no `--platform` flag is specified
+  (100% backward compatibility).
+- **SC-005**: The scaffold summary output clearly
+  identifies which platform(s) files were deployed to.
+- **SC-006**: Adding a new platform target requires
+  no changes to the scaffold engine's core asset-
+  walking logic (verified by code review of the
+  platform extensibility design).

--- a/specs/038-platform-scaffold/spec.md
+++ b/specs/038-platform-scaffold/spec.md
@@ -1,8 +1,8 @@
 # Feature Specification: Multi-Platform Scaffold Deployment
 
-**Feature Branch**: `038-platform-scaffold`
-**Created**: 2026-04-30
-**Status**: Draft
+**Feature Branch**: `038-platform-scaffold`  
+**Created**: 2026-04-30  
+**Status**: Draft  
 **Input**: User description: "Create an analogous spec from unbound-force/unbound-force PR #144 for gaze to support platforms other than OpenCode"
 
 ## User Scenarios & Testing *(mandatory)*
@@ -59,6 +59,12 @@ schemas, and file extensions.
    `.cursor/commands/` as plain Markdown with no content
    transformation.
 
+5. **Given** an empty directory with a `go.mod` file,
+   **When** a user runs `gaze init --platform cursor`,
+   **Then** the scaffold summary output includes the
+   platform name "cursor" confirming which platform was
+   deployed to.
+
 ---
 
 ### User Story 2 - Dual-Platform Project Scaffolding (Priority: P2)
@@ -104,6 +110,13 @@ platform-appropriate content.
    directories are updated if content has changed, and
    user-owned files in both directories are preserved.
 
+4. **Given** an empty directory with a `go.mod` file,
+   **When** a user runs `gaze init --platform opencode
+   --platform cursor`, **Then** the scaffold summary
+   output shows per-platform results with created,
+   skipped, updated, and overwritten counts for each
+   platform.
+
 ---
 
 ### User Story 3 - Backward-Compatible Default Behavior (Priority: P1)
@@ -120,7 +133,7 @@ guaranteed alongside the new platform support.
 
 **Independent Test**: Can be tested by running
 `gaze init` (no `--platform` flag) and verifying the
-output is byte-identical to the current behavior.
+output is functionally identical to the current behavior.
 
 **Acceptance Scenarios**:
 
@@ -132,8 +145,11 @@ output is byte-identical to the current behavior.
 
 2. **Given** an empty directory with a `go.mod` file,
    **When** a user runs `gaze init --platform opencode`,
-   **Then** the result is identical to running
-   `gaze init` with no `--platform` flag.
+   **Then** the files deployed to `.opencode/` are
+   functionally identical to those produced by
+   `gaze init` with no `--platform` flag, with the same
+   Created/Skipped/Updated/Overwritten results, and no
+   `.cursor/` directory is created.
 
 ---
 
@@ -194,6 +210,10 @@ agent file, then running `gaze init --platform cursor
   run in a directory with no `go.mod`? Same warning
   as today ("no go.mod found") but initialization
   proceeds.
+- What happens when `--platform cursor --force` is
+  run but no `.cursor/` directory exists yet? Same as
+  a fresh init -- all files are created. `--force` is
+  a no-op for non-existent files.
 
 ## Requirements *(mandatory)*
 
@@ -221,6 +241,11 @@ agent file, then running `gaze init --platform cursor
   `description`, and dropping OpenCode-specific fields
   (`mode`, `temperature`, `tools`, `maxSteps`,
   `disabled`).
+  [NEEDS CLARIFICATION: The `model` field present in
+  some agents and the `agent` field present in some
+  commands are not addressed -- should these be dropped
+  for Cursor, preserved, or transformed? See HIGH
+  finding #1 in review council advisories.]
 - **FR-008**: System MUST deploy command files to
   `.cursor/commands/` as plain Markdown with no content
   transformation beyond the version marker insertion.
@@ -233,8 +258,8 @@ agent file, then running `gaze init --platform cursor
   overwritten unless `--force` is specified.
 - **FR-011**: System MUST classify Cursor files using
   the same ownership rules as OpenCode files: the
-  existing `isToolOwned()` logic determines ownership
-  regardless of target platform.
+  existing ownership classification logic determines
+  ownership regardless of target platform.
 - **FR-012**: System MUST insert the standard version
   marker (`<!-- scaffolded by gaze vX.Y.Z -->`) into
   all files regardless of target platform.
@@ -271,9 +296,9 @@ agent file, then running `gaze init --platform cursor
   relative path to a platform-specific output directory
   and how to transform content (e.g., frontmatter
   adaptation).
-- **Asset**: An embedded file from
-  `internal/scaffold/assets/` that is deployed to one
-  or more platform target directories.
+- **Asset**: An embedded file from the scaffold's
+  embedded asset store that is deployed to one or more
+  platform target directories.
 - **File Ownership**: A classification (tool-owned or
   user-owned) that determines whether a file is auto-
   updated on re-init or preserved for user
@@ -301,14 +326,38 @@ agent file, then running `gaze init --platform cursor
 - `--divisor` mode (gaze does not have a DivisorOnly
   mode)
 
+## Documentation Impact
+
+The following documentation MUST be updated when this
+feature is implemented:
+
+- **README.md** — Update `gaze init` command description
+  and OpenCode Integration section to mention Cursor
+  and multi-platform support.
+- **AGENTS.md** — Update Architecture scaffold
+  description, Active Technologies, and Recent Changes
+  sections.
+- **GoDoc comments** — New exported types (platform
+  abstraction) and modified function signatures.
+
+A website documentation issue MUST be filed in
+`unbound-force/website` per the Website Documentation
+Gate before the implementing PR is merged, covering:
+- Gaze project page update for Cursor support
+- `gaze init` workflow description update for
+  `--platform` flag
+
 ## Dependencies
 
 - **Spec 005** (gaze-opencode-integration): Defines
-  `gaze init` subcommand and the `internal/scaffold`
-  package that this spec extends.
+  the original `gaze init` subcommand and the scaffold
+  package architecture. Note: the scaffold has evolved
+  through specs 012 (consolidation), 016 (context
+  reduction), and 017 (testing persona) since spec 005.
 - **Spec 016** (agent-context-reduction): Defines the
   tool-owned `references/` directory pattern and the
-  `isToolOwned()` function that this spec preserves.
+  file ownership classification logic that this spec
+  preserves.
 
 ### Research References
 
@@ -326,9 +375,6 @@ agent file, then running `gaze init --platform cursor
   Markdown command files.
 - The `--platform` flag follows established CLI
   conventions for repeatable string slices.
-- Future platforms can be added by implementing the
-  platform abstraction without modifying the scaffold
-  engine's core asset-walking logic.
 - The `references/` directory pattern (externalized
   context loaded on demand by agents) works the same
   way in Cursor as in OpenCode (agents read files via


### PR DESCRIPTION
## Summary

- Add Spec 038: Multi-platform scaffold deployment for `gaze init` with `--platform` flag
- Supports `opencode` (default, current behavior) and `cursor` (new) as selectable targets
- Multiple `--platform` flags combine additively for dual-platform projects

## Design Context

Analogous to [unbound-force/unbound-force#144](https://github.com/unbound-force/unbound-force/pull/144) (Spec 035), adapted for gaze's simpler scaffold system (8 embedded files vs ~50, no convention packs, no MCP config, no DivisorOnly mode).

## Scope

| Stories | Priority | Description |
|---------|----------|-------------|
| US1     | P1       | Cursor-only scaffolding |
| US2     | P2       | Dual-platform co-deploy |
| US3     | P1       | Backward-compatible default |
| US4     | P3       | Force overwrite across platforms |

18 functional requirements, 6 success criteria. Spec only -- no implementation code.

## Review Council (Iteration 1)

9 Divisor agents reviewed. 14 LOW/MEDIUM findings auto-fixed. 6 HIGH/CRITICAL advisories documented in `checklists/requirements.md` for human decision:

1. **CRITICAL**: Missing coverage strategy signal (Constitution IV)
2. **HIGH**: FR-007 frontmatter transformation incomplete (`model`, `agent` fields, `name` derivation)
3. **HIGH**: Cursor format assumptions unvalidated (no documentation source)
4. **HIGH**: FR-016/SC-006 extensibility not objectively testable
5. **HIGH**: Missing cross-platform ownership acceptance scenarios
6. **HIGH**: Drift detection test (`TestEmbeddedAssetsMatchSource`) not addressed

Council verdict: **APPROVE WITH ADVISORIES** — ready for `/speckit.clarify` to resolve outstanding items.