### PR TITLE
chore: add CI preflight gate to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,140 @@
+# Release
+# =======
+# Release pipeline triggered via workflow_dispatch.
+# Validates pre-flight conditions (semver format, tag
+# uniqueness, CI status, unreleased commits), creates the
+# tag, builds cross-platform binaries via GoReleaser,
+# signs macOS archives with Apple Developer ID, notarizes
+# them, and publishes to the Homebrew tap.
+#
+# Pattern replicated from unbound-force/unbound-force.
+# See: https://github.com/unbound-force/gaze/issues/98
+
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v0.15.0)'
+        required: true
+        type: string
 
-permissions:
-  contents: write
+permissions: {}
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  release:
+  preflight:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    permissions:
+      contents: write
+      checks: read
+    timeout-minutes: 10
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
     outputs:
       has_signing_secrets: ${{ steps.check-secrets.outputs.has_secrets }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag format
+        run: |
+          if ! echo "$RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid tag format: '$RELEASE_TAG'. Must match vMAJOR.MINOR.PATCH (e.g., v0.15.0)."
+            exit 1
+          fi
+          echo "Tag format valid: $RELEASE_TAG"
+
+      - name: Check tag uniqueness
+        run: |
+          if git ls-remote --tags origin | grep -q "refs/tags/${RELEASE_TAG}$"; then
+            echo "::error::Tag '$RELEASE_TAG' already exists. Choose a different version."
+            exit 1
+          fi
+          echo "Tag '$RELEASE_TAG' does not exist yet."
+
+      - name: Verify semver ordering
+        run: |
+          LATEST=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)
+          if [ -z "$LATEST" ]; then
+            echo "No existing tags found. First release."
+            exit 0
+          fi
+          echo "Latest existing tag: $LATEST"
+          # Compare using sort -V: if TAG sorts after LATEST, it is greater
+          HIGHER=$(printf '%s\n%s' "$LATEST" "$RELEASE_TAG" | sort -V | tail -1)
+          if [ "$HIGHER" = "$LATEST" ]; then
+            echo "::error::Tag '$RELEASE_TAG' is not greater than latest release '$LATEST'."
+            exit 1
+          fi
+          echo "Version ordering valid: $RELEASE_TAG > $LATEST"
+
+      # Check names are derived from the name: fields in test.yml
+      # and mega-linter.yml. If those workflow job names change,
+      # update the REQUIRED_CHECKS array below to match.
+      - name: Verify CI passed on HEAD
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          HEAD_SHA=$(git rev-parse HEAD)
+          echo "Checking CI status for commit $HEAD_SHA"
+
+          REQUIRED_CHECKS=(
+            "Unit + Integration Tests (Go 1.24)"
+            "Unit + Integration Tests (Go 1.25)"
+            "MegaLinter"
+          )
+
+          for CHECK_NAME in "${REQUIRED_CHECKS[@]}"; do
+            STATUS=$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/check-runs" \
+              --jq ".check_runs[] | select(.name == \"${CHECK_NAME}\") | .conclusion" \
+              2>/dev/null | head -1)
+            if [ "$STATUS" != "success" ]; then
+              echo "::error::Required check '${CHECK_NAME}' has not passed (status: ${STATUS:-not found}). Push to main and wait for CI before releasing."
+              exit 1
+            fi
+            echo "  ✓ ${CHECK_NAME}: success"
+          done
+
+          echo "All required CI checks passed."
+
+      - name: Verify unreleased commits
+        run: |
+          LATEST=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)
+          if [ -z "$LATEST" ]; then
+            COUNT=$(git rev-list --count HEAD)
+          else
+            COUNT=$(git rev-list --count "${LATEST}..HEAD")
+          fi
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::error::No unreleased commits since ${LATEST:-initial commit}. Nothing to release."
+            exit 1
+          fi
+          echo "$COUNT commit(s) since ${LATEST:-initial commit}."
+
+      - name: Create and push tag
+        run: |
+          # Skip if tag was already created (e.g., re-run after
+          # partial failure or manual tag via GitHub API).
+          if git ls-remote --tags origin | grep -q "refs/tags/${RELEASE_TAG}$"; then
+            echo "Tag $RELEASE_TAG already exists, skipping creation."
+            exit 0
+          fi
+          # Annotated tags require a committer identity on the
+          # CI runner (git tag -a uses GIT_COMMITTER_NAME/EMAIL).
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$RELEASE_TAG" -m "$RELEASE_TAG"
+          git push origin "$RELEASE_TAG"
+          echo "Created and pushed tag: $RELEASE_TAG"
+
       - name: Check signing secrets
         id: check-secrets
         run: |
@@ -26,10 +146,22 @@ jobs:
         env:
           MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
 
+  release:
+    runs-on: ubuntu-latest
+    needs: preflight
+    permissions:
+      contents: write
+    timeout-minutes: 45
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
+    outputs:
+      has_signing_secrets: ${{ needs.preflight.outputs.has_signing_secrets }}
+    steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag }}
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
@@ -50,38 +182,46 @@ jobs:
     runs-on: macos-latest
     needs: release
     if: ${{ needs.release.outputs.has_signing_secrets == 'true' }}
+    permissions:
+      contents: write
     timeout-minutes: 30
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
     steps:
       - name: Import certificate into Keychain
         run: |
+          set -euo pipefail
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
           KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
 
-          echo -n "$MACOS_SIGN_P12" | base64 --decode -o $RUNNER_TEMP/cert.p12
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security import $RUNNER_TEMP/cert.p12 -P "$MACOS_SIGN_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
+          echo -n "$MACOS_SIGN_P12" | base64 --decode -o "$RUNNER_TEMP/cert.p12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$RUNNER_TEMP/cert.p12" -P "$MACOS_SIGN_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
         env:
           MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
           MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
 
       - name: Prepare notary key
         run: |
-          echo -n "$MACOS_NOTARY_KEY" | base64 --decode -o $RUNNER_TEMP/notary_key.p8
+          set -euo pipefail
+          echo -n "$MACOS_NOTARY_KEY" | base64 --decode -o "$RUNNER_TEMP/notary_key.p8"
         env:
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
 
       - name: Download darwin archives
         run: |
-          gh release download "${GITHUB_REF_NAME}" --repo "$GITHUB_REPOSITORY" --pattern "gaze_*_darwin_*.tar.gz" --dir ./artifacts
+          set -euo pipefail
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern "gaze_*_darwin_*.tar.gz" --dir ./artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sign and notarize
         run: |
+          set -euo pipefail
           mkdir -p ./signed
           for archive in ./artifacts/gaze_*_darwin_*.tar.gz; do
             echo "==> Processing $(basename "$archive")"
@@ -120,11 +260,12 @@ jobs:
 
       - name: Replace release assets and update checksums
         run: |
+          set -euo pipefail
           # Upload signed darwin archives (replaces unsigned)
-          gh release upload "${GITHUB_REF_NAME}" --repo "$GITHUB_REPOSITORY" ./signed/*.tar.gz --clobber
+          gh release upload "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" ./signed/*.tar.gz --clobber
 
           # Download existing checksums
-          gh release download "${GITHUB_REF_NAME}" --repo "$GITHUB_REPOSITORY" --pattern "checksums.txt" --dir ./
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern "checksums.txt" --dir ./
 
           # Remove darwin lines from checksums (keep linux and other lines)
           grep -v darwin checksums.txt > checksums_updated.txt || true
@@ -136,13 +277,14 @@ jobs:
 
           # Replace checksums file
           mv checksums_updated.txt checksums.txt
-          gh release upload "${GITHUB_REF_NAME}" --repo "$GITHUB_REPOSITORY" checksums.txt --clobber
+          gh release upload "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" checksums.txt --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update Homebrew cask checksums
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
 
           # Compute signed checksums
           ARM64_SHA=$(shasum -a 256 "./signed/gaze_${VERSION}_darwin_arm64.tar.gz" | awk '{print $1}')

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,21 +5,100 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.3.17"
+        "@opencode-ai/plugin": "1.4.10"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.3.17",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.3.17.tgz",
-      "integrity": "sha512-N5lckFtYvEu2R8K1um//MIOTHsJHniF2kHoPIWPCrxKG5Jpismt1ISGzIiU3aKI2ht/9VgcqKPC5oZFLdmpxPw==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.10.tgz",
+      "integrity": "sha512-35Za2LT2oNWnBoonmPjN1Z9PB4+ir2a6GbZ3nIZQQL/96mqzTRkT1FqUkQc3bdMmfT1R1rqOd5aMzkIXMqC7dA==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.3.17",
+        "@opencode-ai/sdk": "1.4.10",
+        "effect": "4.0.0-beta.48",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.1.96",
-        "@opentui/solid": ">=0.1.96"
+        "@opentui/core": ">=0.1.100",
+        "@opentui/solid": ">=0.1.100"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -31,13 +110,19 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.3.17",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.3.17.tgz",
-      "integrity": "sha512-2+MGgu7wynqTBwxezR01VAGhILXlpcHDY/pF7SWB87WOgLt3kD55HjKHNj6PWxyY8n575AZolR95VUC3gtwfmA==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.10.tgz",
+      "integrity": "sha512-Yaddcs/COp0hwiCxgobSZyDUN0nHgkEFL4bG0BQxwd52SGAysOr6A6L0ihfkuhVx0kbi9eXWgZk4ydNOrnur5w==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -53,11 +138,134 @@
         "node": ">= 8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.48",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.48.tgz",
+      "integrity": "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.6.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^6.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^1.11.9",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.10.tgz",
+      "integrity": "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -67,6 +275,22 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -89,6 +313,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/toml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
+      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -102,6 +348,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -436,7 +436,7 @@ Three GitHub Actions workflows:
 
 1. **Test** (`.github/workflows/test.yml`): Build + test with `-race -count=1` on push/PR to `main`.
 2. **MegaLinter** (`.github/workflows/mega-linter.yml`): Runs golangci-lint, revive, markdownlint, yamllint, and gitleaks on push/PR to `main`. Auto-commits lint fixes to PR branches.
-3. **Release** (`.github/workflows/release.yml`): Triggered on `v*` tag push. Runs GoReleaser v2 to build cross-platform binaries (darwin/linux x amd64/arm64), create GitHub Releases, and update the Homebrew cask in `unbound-force/homebrew-tap`.
+3. **Release** (`.github/workflows/release.yml`): Triggered via `workflow_dispatch` with a `tag` input (e.g., `v0.15.0`). A `preflight` job validates tag format, uniqueness, semver ordering, verifies CI checks passed on HEAD via the GitHub Checks API, confirms unreleased commits exist, then creates and pushes the annotated tag. The `release` job runs GoReleaser v2 to build cross-platform binaries (darwin/linux x amd64/arm64), create GitHub Releases, and update the Homebrew cask in `unbound-force/homebrew-tap`. To release: use the GitHub Actions "Run workflow" button or `gh workflow run release.yml -f tag=v1.2.3`.
 
 ## Linting
 

--- a/openspec/changes/release-preflight-gate/.openspec.yaml
+++ b/openspec/changes/release-preflight-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-03

--- a/openspec/changes/release-preflight-gate/design.md
+++ b/openspec/changes/release-preflight-gate/design.md
@@ -1,0 +1,129 @@
+## Context
+
+Gaze's release workflow (`.github/workflows/release.yml`) triggers on
+`v*` tag pushes and immediately runs GoReleaser. There is no
+verification that CI checks passed on the tagged commit. A tag pushed
+from a failing commit produces broken binaries distributed via GitHub
+Releases and Homebrew.
+
+The `unbound-force/unbound-force` repo uses a `workflow_dispatch`
+trigger with a `preflight` job that validates tag format, uniqueness,
+semver ordering, CI status, and unreleased commits before creating
+the tag and building artifacts. This design replicates that pattern
+for gaze.
+
+## Goals / Non-Goals
+
+### Goals
+- Prevent release of binaries from commits that have not passed CI
+- Validate tag format, uniqueness, and semver ordering before release
+- Verify unreleased commits exist to prevent empty releases
+- Align with the org-wide release workflow pattern from
+  `unbound-force/unbound-force`
+- Maintain existing macOS signing and Homebrew cask update behavior
+
+### Non-Goals
+- Adding security scan workflows to gaze (gaze has no security scan
+  CI; the preflight only checks what exists)
+- Changing GoReleaser configuration or build targets
+- Adding SBOM generation or Cosign signing (out of scope for this
+  change; can be added later independently)
+- Changing the macOS signing flow or Homebrew tap structure
+
+## Decisions
+
+### D1: Switch from tag-push to workflow_dispatch trigger
+
+The trigger changes from `on: push: tags: v*` to
+`on: workflow_dispatch` with a `tag` string input. This is the
+pattern used by `unbound-force/unbound-force` and provides two
+key benefits:
+
+1. The workflow can validate preconditions _before_ the tag exists,
+   preventing the "tag pushed from broken commit" problem entirely.
+2. The tag is created by the workflow itself (as an annotated tag)
+   after all preflight checks pass, ensuring the tag always points
+   to a validated commit.
+
+Trade-off: Releases now require using the GitHub Actions UI
+"Run workflow" button or `gh workflow run release.yml -f tag=v1.2.3`
+instead of `git tag v1.2.3 && git push --tags`. This is a minor
+ergonomic change that adds safety.
+
+### D2: Query GitHub Checks API for CI verification
+
+The preflight job queries the GitHub Checks API
+(`repos/{owner}/{repo}/commits/{sha}/check-runs`) to verify that
+specific CI check runs completed successfully on HEAD.
+
+Required checks (all must pass):
+- `Unit + Integration Tests (Go 1.24)` — from test.yml
+- `Unit + Integration Tests (Go 1.25)` — from test.yml
+- `MegaLinter` — from mega-linter.yml
+
+Advisory checks (logged but not blocking):
+- `E2E Tests (Go 1.24)` — from test.yml
+- `E2E Tests (Go 1.25)` — from test.yml
+
+Rationale: The E2E tests run `TestRunSelfCheck` which is a 15-30
+minute self-analysis. While valuable, these are advisory because
+they test gaze's own analysis capabilities rather than build
+correctness. The unit + integration + lint checks cover compilation,
+correctness, and code quality — the minimum bar for a safe release.
+
+Check names are derived from the `name:` fields in the workflow
+files, matching the values that appear in the GitHub Checks API.
+
+### D3: Annotated tag creation by the workflow
+
+After all preflight checks pass, the workflow creates an annotated
+tag (`git tag -a`) and pushes it. This ensures:
+- Tags are only created after validation passes
+- Tags are annotated (not lightweight), which is the GoReleaser
+  default expectation
+- Re-runs after partial failure are idempotent (tag creation is
+  skipped if the tag already exists on the remote)
+
+### D4: Concurrency group with cancel-in-progress: false
+
+A concurrency group `release-${{ github.ref }}` prevents parallel
+release runs. `cancel-in-progress: false` ensures an in-progress
+release is never cancelled by a new dispatch — the new run queues
+instead. This prevents partial releases from being interrupted.
+
+### D5: Tightened permissions
+
+The workflow-level `permissions` block is set to `{}` (no
+permissions). Each job declares only the permissions it needs:
+- `preflight`: `contents: write` (tag creation) + `checks: read`
+  (Checks API queries)
+- `release`: `contents: write` (release creation)
+- `sign-macos`: `contents: write` (asset replacement)
+
+This follows the principle of least privilege.
+
+## Risks / Trade-offs
+
+### R1: Check name drift
+
+If CI workflow job names change (e.g., `Unit + Integration Tests`
+is renamed), the preflight step will fail to find them and block
+the release. Mitigation: the error message includes the check name
+and status, making it clear which check failed or was not found.
+The check names are documented in the workflow file comments.
+
+### R2: CI must have run on HEAD
+
+The preflight verifies CI on HEAD of the branch where
+`workflow_dispatch` is triggered. If a maintainer triggers the
+workflow from a branch where CI has not run (or has not completed),
+the preflight will fail. This is intentional — it forces CI to pass
+before release.
+
+### R3: Ergonomic change for maintainers
+
+Maintainers must use `gh workflow run` or the GitHub UI instead of
+`git push --tags`. This is a deliberate trade-off: slightly more
+friction in exchange for guaranteed CI verification. The
+`unbound-force/unbound-force` repo has used this pattern
+successfully.

--- a/openspec/changes/release-preflight-gate/proposal.md
+++ b/openspec/changes/release-preflight-gate/proposal.md
@@ -1,0 +1,112 @@
+## Why
+
+`release.yml` triggers on any `v*` tag push and runs GoReleaser
+immediately with no CI preflight verification. A tag pushed from a
+commit that never passed tests will produce and distribute broken
+release binaries to GitHub Releases and Homebrew. There is no
+automated check that build, test, or lint CI passed on the tagged
+commit before artifacts are published.
+
+The `unbound-force/unbound-force` repo already solves this with a
+`preflight` job (lines 30-163 of its `release.yml`) that validates
+tag format, uniqueness, semver ordering, CI check status, and
+unreleased commits before creating the tag and proceeding to build.
+Gaze should replicate this pattern for consistency across the org.
+
+Closes https://github.com/unbound-force/gaze/issues/98
+
+## What Changes
+
+Replace the current tag-push-triggered release workflow with a
+`workflow_dispatch`-triggered workflow that includes a `preflight`
+job before GoReleaser runs.
+
+The preflight job:
+1. Validates tag format (strict `vMAJOR.MINOR.PATCH`)
+2. Checks tag uniqueness (not already pushed)
+3. Verifies semver ordering (new tag > latest existing tag)
+4. Queries the GitHub Checks API to verify CI passed on HEAD
+5. Verifies unreleased commits exist since the last tag
+6. Creates and pushes the annotated tag
+7. Checks signing secrets availability
+
+The `release` job becomes dependent on `preflight` via `needs:`.
+The `sign-macos` job remains unchanged in behavior.
+
+## Capabilities
+
+### New Capabilities
+- `preflight-ci-verification`: Queries GitHub Checks API to verify
+  that required CI checks (unit tests, integration tests, E2E tests,
+  MegaLinter) passed on HEAD before building release artifacts.
+- `semver-validation`: Validates tag format, uniqueness, and ordering
+  before tag creation.
+- `unreleased-commit-guard`: Prevents empty releases by verifying at
+  least one commit exists since the last tag.
+- `workflow-dispatch-trigger`: Release is initiated via manual
+  `workflow_dispatch` with a tag input, replacing automatic tag-push
+  trigger.
+
+### Modified Capabilities
+- `release-job`: Now depends on `preflight` job completing
+  successfully. Checks out the tag ref instead of the default ref.
+- `sign-macos`: Receives `has_signing_secrets` from `preflight`
+  outputs (routed through `release` outputs) instead of computing
+  it inline.
+
+### Removed Capabilities
+- `tag-push-trigger`: The `on: push: tags: v*` trigger is removed
+  in favor of `workflow_dispatch`. Tags are created by the workflow
+  itself after preflight validation passes.
+
+## Impact
+
+- **File changed**: `.github/workflows/release.yml` (single file)
+- **No Go code changes**: This is CI-only.
+- **No test changes**: No production code is modified.
+- **Release process change**: Maintainers will use the GitHub Actions
+  "Run workflow" button (or `gh workflow run`) instead of pushing a
+  tag manually. The workflow creates the tag after validation.
+- **Permissions**: Adds `checks: read` permission for the preflight
+  job to query the Checks API.
+- **Concurrency**: Adds a concurrency group to prevent parallel
+  release runs.
+
+## Constitution Alignment
+
+Assessed against the Gaze project constitution (v1.3.0).
+
+### I. Accuracy
+
+**Assessment**: N/A
+
+This change modifies CI workflow configuration only. It does not
+affect side effect detection, assertion mapping, or any analysis
+output. No accuracy impact.
+
+### II. Minimal Assumptions
+
+**Assessment**: PASS
+
+The preflight job queries the GitHub Checks API for specific check
+run names derived from the actual workflow files (`test.yml` and
+`mega-linter.yml`). The check names are explicit and match the
+`name:` fields in those workflows. No assumptions about CI state
+are made beyond what the API reports.
+
+### III. Actionable Output
+
+**Assessment**: N/A
+
+This change does not affect Gaze's analysis output, reports, or
+metrics. CI workflow changes have no bearing on user-facing output
+formats.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+No production code or test code is modified. The workflow itself is
+validated by GitHub Actions execution. The preflight steps produce
+clear pass/fail output with `::error::` annotations for each
+validation failure.

--- a/openspec/changes/release-preflight-gate/specs/release-preflight.md
+++ b/openspec/changes/release-preflight-gate/specs/release-preflight.md
@@ -1,0 +1,191 @@
+## ADDED Requirements
+
+### Requirement: preflight-ci-verification
+
+The release workflow MUST verify that required CI check runs
+completed successfully on the HEAD commit before creating a tag
+or building release artifacts. The workflow MUST query the GitHub
+Checks API for check run conclusions.
+
+Required checks that MUST pass:
+- `Unit + Integration Tests (Go 1.24)`
+- `Unit + Integration Tests (Go 1.25)`
+- `MegaLinter`
+
+If any required check has not passed (conclusion is not `success`),
+the workflow MUST exit with a non-zero status and report which
+check failed via a `::error::` annotation.
+
+#### Scenario: all required CI checks passed
+
+- **GIVEN** the HEAD commit has check runs for
+  `Unit + Integration Tests (Go 1.24)`,
+  `Unit + Integration Tests (Go 1.25)`, and
+  `MegaLinter`, all with conclusion `success`
+- **WHEN** the preflight job runs
+- **THEN** the CI verification step succeeds and the
+  workflow proceeds to tag creation
+
+#### Scenario: a required CI check has not passed
+
+- **GIVEN** the HEAD commit has `Unit + Integration Tests (Go 1.24)`
+  with conclusion `failure`
+- **WHEN** the preflight job runs
+- **THEN** the workflow exits with a non-zero status and emits
+  `::error::Required check 'Unit + Integration Tests (Go 1.24)'
+  has not passed (status: failure)`
+
+#### Scenario: a required CI check has not run
+
+- **GIVEN** the HEAD commit has no check run for `MegaLinter`
+- **WHEN** the preflight job runs
+- **THEN** the workflow exits with a non-zero status and emits
+  `::error::Required check 'MegaLinter' has not passed
+  (status: not found)`
+
+### Requirement: tag-format-validation
+
+The release workflow MUST validate that the tag input matches
+the strict semver format `vMAJOR.MINOR.PATCH` (e.g., `v1.2.3`).
+Pre-release suffixes and build metadata MUST be rejected.
+
+#### Scenario: valid tag format
+
+- **GIVEN** the tag input is `v1.2.3`
+- **WHEN** the preflight job runs
+- **THEN** the format validation step succeeds
+
+#### Scenario: invalid tag format
+
+- **GIVEN** the tag input is `v1.2.3-beta.1`
+- **WHEN** the preflight job runs
+- **THEN** the workflow exits with a non-zero status and emits
+  `::error::Invalid tag format`
+
+### Requirement: tag-uniqueness
+
+The release workflow MUST verify that the tag does not already
+exist on the remote before creating it.
+
+#### Scenario: tag does not exist
+
+- **GIVEN** the tag `v1.2.3` does not exist on the remote
+- **WHEN** the preflight job runs
+- **THEN** the uniqueness check succeeds
+
+#### Scenario: tag already exists
+
+- **GIVEN** the tag `v1.2.3` already exists on the remote
+- **WHEN** the preflight job runs
+- **THEN** the workflow exits with a non-zero status and emits
+  `::error::Tag 'v1.2.3' already exists`
+
+### Requirement: semver-ordering
+
+The release workflow MUST verify that the new tag is strictly
+greater than the latest existing release tag, using semantic
+version ordering.
+
+#### Scenario: new tag is greater than latest
+
+- **GIVEN** the latest existing tag is `v1.1.0` and the input
+  tag is `v1.2.0`
+- **WHEN** the preflight job runs
+- **THEN** the ordering check succeeds
+
+#### Scenario: new tag is not greater than latest
+
+- **GIVEN** the latest existing tag is `v1.2.0` and the input
+  tag is `v1.1.5`
+- **WHEN** the preflight job runs
+- **THEN** the workflow exits with a non-zero status and emits
+  `::error::Tag 'v1.1.5' is not greater than latest release
+  'v1.2.0'`
+
+#### Scenario: first release (no existing tags)
+
+- **GIVEN** no `v*` tags exist in the repository
+- **WHEN** the preflight job runs
+- **THEN** the ordering check succeeds (first release)
+
+### Requirement: unreleased-commits
+
+The release workflow MUST verify that at least one commit exists
+since the last release tag. Empty releases (no new commits) MUST
+be rejected.
+
+#### Scenario: commits exist since last tag
+
+- **GIVEN** 5 commits exist since tag `v1.1.0`
+- **WHEN** the preflight job runs
+- **THEN** the unreleased commits check succeeds
+
+#### Scenario: no commits since last tag
+
+- **GIVEN** HEAD is the same commit as the latest tag `v1.1.0`
+- **WHEN** the preflight job runs
+- **THEN** the workflow exits with a non-zero status and emits
+  `::error::No unreleased commits since v1.1.0`
+
+### Requirement: workflow-dispatch-trigger
+
+The release workflow MUST be triggered via `workflow_dispatch`
+with a required `tag` string input. The `on: push: tags` trigger
+MUST be removed.
+
+#### Scenario: release triggered via workflow dispatch
+
+- **GIVEN** a maintainer runs the workflow with input `tag: v1.2.3`
+- **WHEN** the workflow starts
+- **THEN** the `RELEASE_TAG` environment variable is set to `v1.2.3`
+  and the preflight job begins
+
+### Requirement: tag-creation-by-workflow
+
+After all preflight checks pass, the workflow MUST create an
+annotated tag and push it to the remote. If the tag already exists
+(e.g., workflow re-run after partial failure), the creation step
+MUST be skipped without error.
+
+#### Scenario: tag created after preflight passes
+
+- **GIVEN** all preflight checks have passed and tag `v1.2.3` does
+  not exist on the remote
+- **WHEN** the tag creation step runs
+- **THEN** an annotated tag `v1.2.3` is created and pushed to origin
+
+#### Scenario: tag already exists on re-run
+
+- **GIVEN** all preflight checks have passed but tag `v1.2.3`
+  already exists on the remote (from a prior partial run)
+- **WHEN** the tag creation step runs
+- **THEN** the step succeeds with a skip message and no error
+
+## MODIFIED Requirements
+
+### Requirement: release-job-dependency
+
+The `release` job MUST depend on the `preflight` job via
+`needs: preflight`. The `release` job MUST check out the tag ref
+(`ref: ${{ inputs.tag }}`).
+
+Previously: The `release` job had no dependencies and checked
+out the default ref.
+
+### Requirement: signing-secrets-detection
+
+The signing secrets check MUST be performed in the `preflight`
+job and its output forwarded to the `sign-macos` job via the
+`release` job's outputs.
+
+Previously: The signing secrets check was performed inline in
+the `release` job.
+
+## REMOVED Requirements
+
+### Requirement: tag-push-trigger
+
+The `on: push: tags: v*` trigger is removed. Releases are now
+initiated exclusively via `workflow_dispatch`. This prevents
+release artifacts from being built for tags pushed from commits
+that have not passed CI.

--- a/openspec/changes/release-preflight-gate/tasks.md
+++ b/openspec/changes/release-preflight-gate/tasks.md
@@ -1,0 +1,42 @@
+## 1. Replace trigger and add workflow structure
+
+- [x] 1.1 Change `on:` from `push: tags: v*` to `workflow_dispatch` with required `tag` string input (description: `Release tag (e.g., v0.15.0)`)
+- [x] 1.2 Set workflow-level `permissions: {}` (no default permissions)
+- [x] 1.3 Add concurrency group `release-${{ github.ref }}` with `cancel-in-progress: false`
+- [x] 1.4 Add `RELEASE_TAG: ${{ inputs.tag }}` env to jobs that reference the tag (replace `${GITHUB_REF_NAME}` references in `sign-macos`)
+
+## 2. Add preflight job
+
+- [x] 2.1 Add `preflight` job with `runs-on: ubuntu-latest`, `timeout-minutes: 10`, permissions `contents: write` + `checks: read`
+- [x] 2.2 Add checkout step with `fetch-depth: 0` (needed for tag listing and commit counting)
+- [x] 2.3 Add tag format validation step: regex check for `^v[0-9]+\.[0-9]+\.[0-9]+$`, emit `::error::` on mismatch
+- [x] 2.4 Add tag uniqueness step: `git ls-remote --tags origin` check, emit `::error::` if tag already exists
+- [x] 2.5 Add semver ordering step: compare new tag against latest `v*` tag using `sort -V`, skip if no existing tags (first release)
+- [x] 2.6 Add CI verification step: query GitHub Checks API for required check names (`Unit + Integration Tests (Go 1.24)`, `Unit + Integration Tests (Go 1.25)`, `MegaLinter`), fail if any conclusion is not `success`
+- [x] 2.7 Add unreleased commits step: `git rev-list --count` between latest tag and HEAD, fail if count is 0
+- [x] 2.8 Add tag creation step: `git tag -a` + `git push origin`, with idempotent skip if tag already exists on remote
+- [x] 2.9 Move signing secrets check from `release` job to `preflight` job, expose via `outputs.has_signing_secrets`
+
+## 3. Update release job dependency chain
+
+- [x] 3.1 Add `needs: preflight` to `release` job
+- [x] 3.2 Add `ref: ${{ inputs.tag }}` to the checkout step in `release` job
+- [x] 3.3 Update `release` job `outputs` to forward `has_signing_secrets` from `needs.preflight.outputs.has_signing_secrets`
+- [x] 3.4 Set `release` job permissions to only `contents: write`
+
+## 4. Update sign-macos job references
+
+- [x] 4.1 Replace all `${GITHUB_REF_NAME}` references in `sign-macos` steps with `${{ inputs.tag }}` via the `RELEASE_TAG` env variable
+- [x] 4.2 Verify `sign-macos` conditional reads from `needs.release.outputs.has_signing_secrets`
+
+## 5. Validation
+
+- [x] 5.1 Verify the complete workflow YAML is valid (no syntax errors) by reviewing the final file structure
+- [x] 5.2 Verify all `${{ inputs.tag }}` / `$RELEASE_TAG` references are consistent across all three jobs
+- [x] 5.3 Verify check names in the CI verification step match the `name:` fields in `test.yml` and `mega-linter.yml`
+- [x] 5.4 Verify the action SHAs are pinned (not floating tags) in all steps
+
+## 6. Documentation
+
+- [x] 6.1 Update AGENTS.md "CI/CD" section to document the new release trigger mechanism (workflow_dispatch instead of tag push)
+- [x] 6.2 Add inline comments to the workflow file documenting the preflight pattern and check name source


### PR DESCRIPTION
## Summary

Add a `preflight` job to the release workflow that validates preconditions before building and publishing release artifacts. Replicates the pattern from `unbound-force/unbound-force`'s release workflow.

### Changes

- **Trigger**: `push: tags: v*` → `workflow_dispatch` with `tag` input
- **Preflight job** (8 validation steps):
  - Tag format validation (`vMAJOR.MINOR.PATCH`)
  - Tag uniqueness check
  - Semver ordering verification
  - CI verification via GitHub Checks API (unit tests, integration tests, MegaLinter)
  - Unreleased commits guard
  - Idempotent annotated tag creation
  - Signing secrets detection
- **Permissions**: Tightened to least-privilege per job (`permissions: {}` at workflow level)
- **Concurrency**: Added `release-${{ github.ref }}` group
- **sign-macos**: All `GITHUB_REF_NAME` → `RELEASE_TAG` env, added `set -euo pipefail`
- **AGENTS.md**: Updated CI/CD section to document new release process

### How to Release (new process)

```bash
gh workflow run release.yml -f tag=v1.2.3
```

Or use the GitHub Actions "Run workflow" button.

Closes #98