### PR TITLE
fix: order-agnostic cask checksum patching after macOS signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,13 +169,35 @@ jobs:
           go-version-file: go.mod
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29  # v7.0.0
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7.2.2
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: 'v2.14.1'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload generated cask as release artifact
+        run: |
+          gh release upload "$RELEASE_TAG" \
+            dist/homebrew/Casks/gaze.rb \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push unsigned cask to tap (no signing secrets)
+        if: ${{ needs.preflight.outputs.has_signing_secrets == 'false' }}
+        run: |
+          git clone "https://x-access-token:${HOMEBREW_TAP_GITHUB_TOKEN}@github.com/unbound-force/homebrew-tap.git" tap
+          cp dist/homebrew/Casks/gaze.rb tap/Casks/gaze.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/gaze.rb
+          git diff --cached --quiet && { echo "No cask changes needed"; exit 0; }
+          git commit -m "Update gaze cask to ${RELEASE_TAG} (unsigned)"
+          git push
+        env:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
   sign-macos:
@@ -293,40 +315,86 @@ jobs:
           echo "darwin_arm64 SHA256: $ARM64_SHA"
           echo "darwin_amd64 SHA256: $AMD64_SHA"
 
-          # Clone the Homebrew tap
-          git clone "https://x-access-token:${HOMEBREW_TAP_GITHUB_TOKEN}@github.com/unbound-force/homebrew-tap.git" tap
-          cd tap
+          # Download the GoReleaser-generated cask from release assets
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern "gaze.rb" --dir ./cask-staging
+          CASK_FILE="./cask-staging/gaze.rb"
 
-          CASK_FILE="Casks/gaze.rb"
           if [ ! -f "$CASK_FILE" ]; then
-            echo "::error::Cask file not found: $CASK_FILE"
+            echo "::error::Cask file not found in release assets: gaze.rb"
             exit 1
           fi
 
-          # Update darwin checksums in the cask file
-          # The cask has on_intel (amd64) then on_arm (arm64) blocks under on_macos
-          # Use awk to replace the correct sha256 values based on URL context
-          awk -v amd64="$AMD64_SHA" -v arm64="$ARM64_SHA" '
-            /darwin_amd64/ { found_amd64=1 }
-            /darwin_arm64/ { found_arm64=1 }
-            /sha256/ && found_amd64 {
-              sub(/sha256 "[^"]*"/, "sha256 \"" amd64 "\"")
-              found_amd64=0
+          # Extract original unsigned darwin checksums from the cask using
+          # section-context parsing. This is order-agnostic — it works
+          # regardless of whether sha256 appears before or after url.
+          ORIG_AMD64_SHA=$(awk '
+            /on_macos/ { in_macos=1 }
+            in_macos && /on_intel/ { in_intel=1 }
+            in_intel && /sha256/ {
+              gsub(/.*sha256 "/, "")
+              gsub(/".*/, "")
+              print
+              exit
             }
-            /sha256/ && found_arm64 {
-              sub(/sha256 "[^"]*"/, "sha256 \"" arm64 "\"")
-              found_arm64=0
-            }
-            { print }
-          ' "$CASK_FILE" > "${CASK_FILE}.tmp"
-          mv "${CASK_FILE}.tmp" "$CASK_FILE"
+            in_intel && /end/ { in_intel=0 }
+          ' "$CASK_FILE")
 
-          # Commit and push
+          ORIG_ARM64_SHA=$(awk '
+            /on_macos/ { in_macos=1 }
+            in_macos && /on_arm/ { in_arm=1 }
+            in_arm && /sha256/ {
+              gsub(/.*sha256 "/, "")
+              gsub(/".*/, "")
+              print
+              exit
+            }
+            in_arm && /end/ { in_arm=0 }
+          ' "$CASK_FILE")
+
+          # Validate extraction — both checksums must be found
+          if [ -z "$ORIG_AMD64_SHA" ] || [ -z "$ORIG_ARM64_SHA" ]; then
+            echo "::error::Failed to extract darwin checksums from cask."
+            echo "  darwin_amd64 (on_intel): '${ORIG_AMD64_SHA:-not found}'"
+            echo "  darwin_arm64 (on_arm):   '${ORIG_ARM64_SHA:-not found}'"
+            echo "  The GoReleaser cask template may have changed."
+            exit 1
+          fi
+
+          echo "Original unsigned darwin_amd64: $ORIG_AMD64_SHA"
+          echo "Original unsigned darwin_arm64: $ORIG_ARM64_SHA"
+
+          # Replace unsigned checksums with signed checksums using sed.
+          # Each SHA-256 hash is unique within the file, so direct string
+          # replacement is unambiguous and order-agnostic.
+          sed -i '' "s/$ORIG_AMD64_SHA/$AMD64_SHA/g" "$CASK_FILE"
+          sed -i '' "s/$ORIG_ARM64_SHA/$ARM64_SHA/g" "$CASK_FILE"
+
+          # Post-patch verification: confirm signed checksums are present
+          AMD64_COUNT=$(grep -c "$AMD64_SHA" "$CASK_FILE" || true)
+          ARM64_COUNT=$(grep -c "$ARM64_SHA" "$CASK_FILE" || true)
+
+          if [ "$AMD64_COUNT" -ne 1 ]; then
+            echo "::error::Verification failed: darwin_amd64 signed checksum appears $AMD64_COUNT times (expected 1)"
+            exit 1
+          fi
+          if [ "$ARM64_COUNT" -ne 1 ]; then
+            echo "::error::Verification failed: darwin_arm64 signed checksum appears $ARM64_COUNT times (expected 1)"
+            exit 1
+          fi
+
+          echo "Verification passed: both signed checksums present exactly once"
+
+          # Clone the tap, copy the patched cask, commit, and push
+          git clone "https://x-access-token:${HOMEBREW_TAP_GITHUB_TOKEN}@github.com/unbound-force/homebrew-tap.git" tap
+          cp "$CASK_FILE" tap/Casks/gaze.rb
+
+          cd tap
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "$CASK_FILE"
+          git add Casks/gaze.rb
           git diff --cached --quiet && { echo "No checksum changes needed"; exit 0; }
           git commit -m "Update macOS checksums for gaze v${VERSION} (post-signing)"
           git push
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,6 +58,4 @@ homebrew_casks:
       Test quality analysis via side effect detection for Go
     binaries:
       - gaze
-    skip_upload: auto
-    commit_msg_template: >-
-      Brew cask update for {{ .ProjectName }} version {{ .Tag }}
+    skip_upload: true

--- a/openspec/changes/fix-cask-checksum-patching/.openspec.yaml
+++ b/openspec/changes/fix-cask-checksum-patching/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-11

--- a/openspec/changes/fix-cask-checksum-patching/design.md
+++ b/openspec/changes/fix-cask-checksum-patching/design.md
@@ -1,0 +1,59 @@
+## Context
+
+The `sign-macos` job in `.github/workflows/release.yml` signs darwin binaries, replaces them in the GitHub Release, and then patches the GoReleaser-generated Homebrew cask with the new SHA-256 checksums before pushing to `unbound-force/homebrew-tap`.
+
+The patching uses an `awk` script that sets a flag when it encounters `darwin_amd64` or `darwin_arm64` in a line, then substitutes the next `sha256` line. This works when `url` precedes `sha256` (as in `unbound-force/unbound-force` with GoReleaser v2.14.1) but fails when `sha256` precedes `url` (as gaze's GoReleaser output does with floating `~> v2`). The flag is set on the `url` line but the `sha256` line has already been printed — causing each platform's hash to land on the wrong line.
+
+Additionally, gaze uses `skip_upload: auto` in `.goreleaser.yaml`, which causes GoReleaser to push the cask to the tap with unsigned checksums during the `release` job. The `sign-macos` job then clones the tap and patches the cask in-place. This creates a race window and differs from the `unbound-force/unbound-force` pattern which uses `skip_upload: true` and has the sign-macos job control the entire tap push.
+
+## Goals / Non-Goals
+
+### Goals
+- Fix the cask checksum patching to work regardless of `sha256`/`url` ordering in GoReleaser output
+- Add a verification gate that catches mismatches before pushing to the tap
+- Align the release workflow with the `unbound-force/unbound-force` reference pattern: `skip_upload: true`, upload cask as release asset, download in sign-macos, patch, then push
+- Pin GoReleaser version to prevent future template drift
+- Remediate the current v1.5.0 cask in `homebrew-tap`
+
+### Non-Goals
+- Fixing the same bug in `unbound-force/unbound-force` or other repos (separate issues)
+- Changing the GoReleaser cask template or switching from cask to formula
+- Adding automated testing of the release workflow (would require a separate spec)
+- Adding a preflight job to the release workflow (separate improvement)
+
+## Decisions
+
+### D1: Use `sed` direct-replacement instead of flag-based awk
+
+**Decision**: Replace the `awk` script with a two-step approach: (a) extract the original unsigned darwin checksums from the GoReleaser-generated cask by parsing `on_macos > on_intel` and `on_macos > on_arm` section context, then (b) use `sed` to replace those exact hash strings with the signed values.
+
+**Rationale**: The `awk` flag approach is inherently fragile — it depends on line ordering within sections. Since each SHA-256 hash is unique within the file, direct string replacement is unambiguous and order-agnostic. This matches the approach chosen by the dewey repo's parallel fix.
+
+**Alternatives considered**:
+- Rewrite the `awk` to buffer `sha256` lines and emit them after seeing the next line: more complex, still coupled to template structure.
+- Use GoReleaser's `cask_template` to control the generated layout: works but adds a template file to maintain and doesn't address the signing flow.
+
+### D2: Add post-patch verification step
+
+**Decision**: After patching, verify that the cask file contains the expected signed checksums in the correct platform sections. Fail the job if they are not found.
+
+**Rationale**: Aligns with Observable Quality — the signing pipeline should fail loudly on mismatch rather than silently publishing wrong checksums. This catches both the original bug and any future GoReleaser template changes.
+
+### D3: Change `skip_upload` from `auto` to `true`
+
+**Decision**: Change `.goreleaser.yaml` `homebrew_casks[].skip_upload` from `auto` to `true`. Add a step in the `release` job to upload the generated cask as a release asset. The `sign-macos` job downloads it, patches checksums, and pushes to the tap.
+
+**Rationale**: With `skip_upload: auto`, GoReleaser pushes the cask to the tap with unsigned checksums, creating a race window where `brew install` could fetch wrong hashes. With `skip_upload: true`, the cask only reaches the tap after signing and patching are complete — matching the proven `unbound-force/unbound-force` pattern.
+
+### D4: Pin GoReleaser to a specific version
+
+**Decision**: Update the goreleaser-action SHA to v7.2.2 and pin the binary version to `v2.14.1` (matching `unbound-force/unbound-force`).
+
+**Rationale**: Floating version ranges (`~> v2`) are a reliability risk for reproducible builds. The cask template ordering that caused this bug could change between minor versions. Pinning ensures consistent behavior.
+
+## Risks / Trade-offs
+
+- **Risk**: The `sed` approach assumes each SHA-256 hash appears exactly once in the cask file. GoReleaser-generated casks do not repeat hashes, so this is safe. The verification step (D2) catches any violation.
+- **Risk**: Pinning GoReleaser version means manual updates are needed for new features. This is acceptable — reproducibility is more important than auto-updates for release tooling.
+- **Risk**: Changing `skip_upload` from `auto` to `true` changes the release flow. If the `sign-macos` job is skipped (no signing secrets), the cask will not be pushed to the tap at all. This is actually better than the current behavior (pushing with wrong checksums), but the release job should handle the no-signing case by pushing the unsigned cask directly — matching the unbound-force pattern where the cask still gets published even without signing.
+- **Trade-off**: The `sign-macos` job now owns the tap push instead of GoReleaser. This adds a step but provides a single point of control for the cask's final state.

--- a/openspec/changes/fix-cask-checksum-patching/proposal.md
+++ b/openspec/changes/fix-cask-checksum-patching/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+`brew install unbound-force/tap/gaze` fails on darwin_amd64, darwin_arm64, and linux_amd64 with SHA-256 checksum mismatches. The Homebrew cask at `Casks/gaze.rb` in `unbound-force/homebrew-tap` has checksums shifted by one platform position — each platform gets the SHA from a different platform's artifact.
+
+The root cause is in the `sign-macos` job of `.github/workflows/release.yml`. An `awk` script patches darwin checksums in the GoReleaser-generated cask after code signing. The script sets a flag when it encounters `darwin_amd64` or `darwin_arm64` in a `url` line, then replaces the next `sha256` line. But GoReleaser's `homebrew_casks` template places `sha256` **before** `url` in each platform block — so the flag is set after the `sha256` it should have modified has already been printed, causing each replacement to land on the **next** platform's checksum.
+
+A secondary issue: gaze uses `skip_upload: auto` in `.goreleaser.yaml`, meaning GoReleaser pushes the cask to the tap with unsigned checksums during the `release` job, and `sign-macos` patches it in-place afterward. This creates a race window where someone could install with wrong checksums between the initial push and the patch.
+
+Related issues: [gaze#124](https://github.com/unbound-force/gaze/issues/124), [homebrew-tap#4](https://github.com/unbound-force/homebrew-tap/issues/4). The same class of bug exists in dewey ([dewey#67](https://github.com/unbound-force/dewey/issues/67)) and is latently present in `unbound-force/unbound-force` (which avoids the bug only because its pinned GoReleaser version happens to produce the `url`-first ordering).
+
+## What Changes
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `release.yml sign-macos`: Rewrite the cask checksum patching logic to be order-agnostic, handling both `sha256-before-url` and `url-before-sha256` cask layouts
+- `release.yml sign-macos`: Add a verification step that confirms patched checksums match before pushing to the tap
+- `release.yml release`: Upload GoReleaser-generated cask as a release asset (instead of letting GoReleaser push directly to the tap)
+- `.goreleaser.yaml`: Change `skip_upload` from `auto` to `true` so the sign-macos job controls when the cask reaches the tap
+- `.goreleaser.yaml`: Pin GoReleaser action version to v7.2.2 and binary version to v2.14.1 to prevent future template drift
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Files changed**: `.github/workflows/release.yml`, `.goreleaser.yaml`
+- **Affected systems**: macOS signing job, Homebrew tap publishing
+- **No production code changes**: This is purely a CI workflow fix
+- **Cross-repo note**: The same latent bug exists in `unbound-force/unbound-force` if its GoReleaser version ever changes template ordering. The dewey repo has the same active bug and a parallel fix in progress.
+- **Remediation**: After the fix is merged, `Casks/gaze.rb` in `homebrew-tap` should be manually corrected for v1.5.0 using the signed checksums from `checksums.txt`
+
+## Constitution Alignment
+
+Assessed against the Gaze project constitution (v1.3.0).
+
+### I. Accuracy
+
+**Assessment**: N/A
+
+This change modifies CI workflow scripts. It does not affect side effect detection, classification, or any analysis output.
+
+### II. Minimal Assumptions
+
+**Assessment**: N/A
+
+This change does not alter how Gaze interacts with host projects or their test frameworks.
+
+### III. Actionable Output
+
+**Assessment**: N/A
+
+This change does not affect report output, JSON schemas, or metric computation.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+This change modifies shell scripts in a GitHub Actions workflow. The added verification step serves as a built-in test gate — it confirms correctness before pushing to the tap, catching both the current bug and any future GoReleaser template changes. No Go code is changed, so no unit test changes are needed.

--- a/openspec/changes/fix-cask-checksum-patching/specs/cask-checksum-patching.md
+++ b/openspec/changes/fix-cask-checksum-patching/specs/cask-checksum-patching.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Cask checksum post-patch verification
+
+The `sign-macos` job MUST verify that the patched cask file contains the correct signed checksums before pushing to the Homebrew tap. If verification fails, the job MUST exit with a non-zero status and log which checksums are missing.
+
+#### Scenario: Checksums match after patching
+- **GIVEN** the `sign-macos` job has signed darwin binaries and patched the cask file
+- **WHEN** the verification step runs
+- **THEN** the cask file MUST contain the exact `AMD64_SHA` value within the `on_intel` section and the exact `ARM64_SHA` value within the `on_arm` section, and the step MUST exit 0
+
+#### Scenario: Checksums do not match after patching
+- **GIVEN** the cask patching logic has a bug or GoReleaser changed its template
+- **WHEN** the verification step runs
+- **THEN** the step MUST exit non-zero with an error message identifying which platform's checksum is missing, and the job MUST NOT push to the Homebrew tap
+
+### Requirement: Cask upload as release asset
+
+The `release` job MUST upload the GoReleaser-generated cask file as a GitHub Release asset so that the `sign-macos` job can download, patch, and push it to the tap.
+
+#### Scenario: Cask available for sign-macos job
+- **GIVEN** GoReleaser has generated the cask to `dist/homebrew/Casks/gaze.rb` with `skip_upload: true`
+- **WHEN** the `release` job completes
+- **THEN** the cask file MUST be available as a release asset named `gaze.rb`, downloadable by the `sign-macos` job
+
+#### Scenario: Cask download failure in sign-macos
+- **GIVEN** the cask file was not uploaded as a release asset (e.g., the upload step failed)
+- **WHEN** the `sign-macos` job attempts to download `gaze.rb`
+- **THEN** the job MUST fail with a clear error message and MUST NOT push any cask to the tap
+
+### Requirement: GoReleaser version pinning
+
+The release workflow MUST pin the GoReleaser binary to a specific version rather than using a floating range.
+
+#### Scenario: Reproducible cask generation
+- **GIVEN** a release is triggered by a `v*` tag push
+- **WHEN** GoReleaser runs
+- **THEN** it MUST use the exact pinned version `v2.14.1` (not a range like `~> v2`), ensuring consistent cask template output across releases
+
+## MODIFIED Requirements
+
+### Requirement: Cask checksum patching logic
+
+The `sign-macos` job MUST patch darwin SHA-256 checksums in the GoReleaser-generated cask to match the signed binary checksums. The patching logic MUST be order-agnostic — it MUST produce correct results regardless of whether `sha256` appears before or after `url` in each platform section.
+
+Previously: The `awk` script assumed `url` (containing the platform identifier) appeared before `sha256`, setting a flag on the `url` line and replacing the next `sha256` line. This failed when GoReleaser placed `sha256` before `url`.
+
+#### Scenario: sha256-before-url ordering (current GoReleaser output)
+- **GIVEN** GoReleaser generates a cask where each platform section has `sha256` before `url`
+- **WHEN** the `sign-macos` job patches darwin checksums
+- **THEN** the `on_intel` section within `on_macos` MUST contain the signed `darwin_amd64` checksum, the `on_arm` section within `on_macos` MUST contain the signed `darwin_arm64` checksum, and all `on_linux` sections MUST remain unchanged
+
+#### Scenario: url-before-sha256 ordering (alternative GoReleaser output)
+- **GIVEN** GoReleaser generates a cask where each platform section has `url` before `sha256`
+- **WHEN** the `sign-macos` job patches darwin checksums
+- **THEN** the same correct results MUST be produced as in the sha256-before-url scenario
+
+#### Scenario: Linux checksums are not modified
+- **GIVEN** a GoReleaser-generated cask with both darwin and linux platform sections
+- **WHEN** the `sign-macos` job patches darwin checksums
+- **THEN** all checksum values within `on_linux` sections MUST remain identical to the GoReleaser-generated values
+
+### Requirement: Cask skip_upload configuration
+
+The `.goreleaser.yaml` `homebrew_casks[].skip_upload` field MUST be set to `true` so that GoReleaser generates the cask to `dist/` without pushing to the Homebrew tap. The `sign-macos` job MUST control when the cask reaches the tap.
+
+Previously: `skip_upload` was set to `auto`, causing GoReleaser to push the cask to the tap with unsigned checksums during the `release` job.
+
+#### Scenario: No race window for unsigned checksums
+- **GIVEN** `skip_upload` is set to `true` in `.goreleaser.yaml`
+- **WHEN** the `release` job completes
+- **THEN** GoReleaser MUST NOT have pushed the cask to `unbound-force/homebrew-tap`; the cask MUST only reach the tap after the `sign-macos` job patches it with signed checksums
+
+#### Scenario: Cask published without signing secrets
+- **GIVEN** `skip_upload` is `true` and the `sign-macos` job is skipped (no signing secrets configured)
+- **WHEN** the `release` job completes
+- **THEN** the `release` job MUST push the unsigned cask directly to `unbound-force/homebrew-tap`, preserving the graceful degradation behavior established by spec 015
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/fix-cask-checksum-patching/tasks.md
+++ b/openspec/changes/fix-cask-checksum-patching/tasks.md
@@ -1,0 +1,50 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Update GoReleaser Configuration
+
+- [x] 1.1 [P] In `.goreleaser.yaml`, change `skip_upload` from `auto` to `true` under `homebrew_casks`. Remove `commit_msg_template` (no longer used when GoReleaser doesn't push). Confirm the `version: 2` field is present and correct.
+- [x] 1.2 [P] In `.github/workflows/release.yml`, update the `goreleaser/goreleaser-action` step: change the pinned SHA from `ec59f474b9834571250b370d4735c50f8e2d1e29` (v7.0.0) to the v7.2.2 SHA `5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89`, and change `version: '~> v2'` to `version: 'v2.14.1'`. Verify the SHA against `https://github.com/goreleaser/goreleaser-action/releases/tag/v7.2.2` before applying. Remove `HOMEBREW_TAP_GITHUB_TOKEN` from the GoReleaser step's `env` block (GoReleaser no longer pushes to the tap with `skip_upload: true`).
+
+## 2. Upload Cask and Handle No-Signing Fallback
+
+- [x] 2.1 In `.github/workflows/release.yml`, add a step after the GoReleaser step in the `release` job to upload the generated cask file to the GitHub Release: `gh release upload "${GITHUB_REF_NAME}" dist/homebrew/Casks/gaze.rb --clobber`. Add `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` env var.
+- [x] 2.2 In `.github/workflows/release.yml`, add a conditional step in the `release` job that runs when `has_signing_secrets == 'false'` to push the unsigned cask directly to `unbound-force/homebrew-tap`. This preserves the graceful degradation behavior from spec 015 — releases without signing secrets still publish a Homebrew cask with correct (unsigned) checksums.
+
+## 3. Rewrite Cask Checksum Patching
+
+- [x] 3.1 In `.github/workflows/release.yml`, replace the "Update Homebrew cask checksums" step in the `sign-macos` job with order-agnostic logic: (a) Download the GoReleaser-generated cask from the release assets (instead of cloning the tap). (b) Extract the original unsigned darwin checksums from the cask by parsing `on_macos > on_intel` and `on_macos > on_arm` section context using awk — if extraction fails to find exactly two darwin checksums (one for intel, one for arm), exit non-zero with a descriptive error before attempting any patching. (c) Use `sed` to replace each original hash with the corresponding signed hash (since SHA-256 hashes are unique within the file, direct string replacement is unambiguous). (d) Ensure linux sections are untouched. (e) Clone the tap, copy the patched cask, commit, and push.
+
+## 4. Add Post-Patch Verification
+
+- [x] 4.1 In `.github/workflows/release.yml`, immediately after the patching logic (task 3.1), add a verification block that: (a) Greps the patched cask for `$AMD64_SHA` and confirms it appears exactly once. (b) Greps the patched cask for `$ARM64_SHA` and confirms it appears exactly once. (c) Exits non-zero with a descriptive error if either check fails, preventing the push to `homebrew-tap`. Note: since the `sed` approach replaces specific old hashes with specific new hashes, cross-contamination (swapped checksums) is structurally impossible — flat grep is sufficient for verification.
+
+## 5. Validate Release Workflow
+
+- [x] 5.1 Run `goreleaser check` to validate the updated `.goreleaser.yaml` configuration.
+- [x] 5.2 Run `goreleaser release --snapshot --clean` to verify the cask is generated to `dist/homebrew/Casks/gaze.rb` without being pushed to the tap.
+
+## 6. Remediate Existing Release
+
+- [ ] 6.1 [MANUAL] Push a corrected `Casks/gaze.rb` to `unbound-force/homebrew-tap` for v1.5.0 using the signed checksums from the v1.5.0 `checksums.txt` release artifact. After pushing, verify by running `brew audit --cask unbound-force/tap/gaze` to confirm the checksums match.
+
+## 7. Cross-Repo Follow-Up
+
+- [ ] 7.1 [P] File a GitHub issue on `unbound-force/unbound-force` noting that the same awk patching logic is latently vulnerable to GoReleaser template ordering changes, and recommending the same order-agnostic fix.
+- [ ] 7.2 [P] Close gaze#124 linking to this fix.
+
+## 8. Verify Constitution Alignment
+
+- [ ] 8.1 Confirm Testability (Constitution IV): the verification step (task 4.1) serves as a built-in test gate that catches checksum mismatches before pushing to the tap.
+- [ ] 8.2 Confirm Minimal Assumptions (Constitution II): `brew install unbound-force/tap/gaze` succeeds without requiring users to know about or work around the signing pipeline, after remediation (task 6.1).
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes the Homebrew cask SHA-256 checksum mismatch bug that caused
`brew install unbound-force/tap/gaze` to fail on 3 of 4 platforms
(darwin_amd64, darwin_arm64, linux_amd64).

**Root cause**: The `awk` script in the `sign-macos` CI job assumed
`url` appeared before `sha256` in the GoReleaser-generated cask, but
the `homebrew_casks` template places `sha256` before `url`. This
caused each platform's signed checksum to be written to the next
platform's line.

### Changes

- **Order-agnostic patching**: Replace flag-based awk with
  section-context extraction (awk) + direct string replacement (sed).
  SHA-256 hashes are unique within the file, making sed replacement
  unambiguous regardless of line ordering.
- **Post-patch verification**: Grep for signed checksums and fail the
  job if they are not found, catching future template drift.
- **Eliminate race window**: Change `skip_upload` from `auto` to
  `true` so the cask only reaches the tap after signing and patching.
- **No-signing fallback**: When signing secrets are not configured,
  the release job pushes the unsigned cask directly to the tap,
  preserving graceful degradation (spec 015).
- **Version pinning**: GoReleaser action pinned to v7.2.2, binary to
  v2.14.1, matching the `unbound-force/unbound-force` reference.

### Spec Artifacts

OpenSpec change: `openspec/changes/fix-cask-checksum-patching/`

### Related

- Closes #124
- Related: homebrew-tap#4 (same bug affects dewey)