### PR TITLE
fix: add mode: subagent to background-worker, coordinator, worker agents

### DIFF
--- a/.opencode/agents/background-worker.md
+++ b/.opencode/agents/background-worker.md
@@ -1,6 +1,7 @@
 ---
 name: background-worker
 description: Runs background tasks without MCP tool access.
+mode: subagent
 ---
 
 # Background Worker

--- a/.opencode/agents/coordinator.md
+++ b/.opencode/agents/coordinator.md
@@ -1,6 +1,7 @@
 ---
 name: coordinator
 description: Orchestrates forge coordination and supervises worker agents.
+mode: subagent
 ---
 
 # Forge Coordinator

--- a/.opencode/agents/worker.md
+++ b/.opencode/agents/worker.md
@@ -1,6 +1,7 @@
 ---
 name: worker
 description: Executes a single subtask with file reservations and progress reporting.
+mode: subagent
 ---
 
 # Forge Worker


### PR DESCRIPTION
Without `mode: subagent`, OpenCode shows these agents as selectable modes in the mode picker alongside build and plan. They are only meant for programmatic invocation via the Task tool. Matches the fix already applied in unbound-force.