### PR TITLE
fix: validate classification thresholds in config.Load

### DIFF
--- a/cmd/gaze/main_test.go
+++ b/cmd/gaze/main_test.go
@@ -649,9 +649,11 @@ func TestLoadConfig_YAMLInvertedThresholdsRejected(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for inverted YAML thresholds, got nil")
 	}
-	// Error should reference the config file path, not CLI flags.
-	if !strings.Contains(err.Error(), "config file") {
-		t.Errorf("error should mention 'config file', got: %s", err)
+	// Error now comes from config.Load (threshold validation) rather
+	// than loadConfig's own coherence check, so it uses YAML field
+	// paths instead of "config file" source attribution.
+	if !strings.Contains(err.Error(), "classification.thresholds.contractual") {
+		t.Errorf("error should mention 'classification.thresholds.contractual', got: %s", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,6 +135,23 @@ func Load(path string) (*GazeConfig, error) {
 			cfg.Baseline.NewFunctionThreshold)
 	}
 
+	// Validate classification thresholds.
+	ct := cfg.Classification.Thresholds.Contractual
+	it := cfg.Classification.Thresholds.Incidental
+	if ct < 1 || ct > 99 {
+		return nil, fmt.Errorf(
+			"classification.thresholds.contractual must be in [1, 99], got %d", ct)
+	}
+	if it < 1 || it > 99 {
+		return nil, fmt.Errorf(
+			"classification.thresholds.incidental must be in [1, 99], got %d", it)
+	}
+	if ct <= it {
+		return nil, fmt.Errorf(
+			"classification.thresholds.contractual (%d) must be greater than incidental (%d)",
+			ct, it)
+	}
+
 	// Parse timeout string if provided.
 	if cfg.Classification.DocScan.TimeoutStr != "" {
 		d, err := time.ParseDuration(cfg.Classification.DocScan.TimeoutStr)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -199,3 +199,131 @@ func TestBaselineConfig_InvalidThreshold(t *testing.T) {
 		t.Errorf("error = %q, want to contain %q", err, want)
 	}
 }
+
+func TestLoad_ContractualOutOfRange(t *testing.T) {
+	_, err := Load(filepath.Join("testdata", "out-of-range-contractual.yaml"))
+	if err == nil {
+		t.Fatal("expected error for contractual=500, got nil")
+	}
+
+	want := "classification.thresholds.contractual must be in [1, 99], got 500"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want to contain %q", err, want)
+	}
+}
+
+func TestLoad_IncidentalOutOfRange(t *testing.T) {
+	_, err := Load(filepath.Join("testdata", "out-of-range-incidental.yaml"))
+	if err == nil {
+		t.Fatal("expected error for incidental=200, got nil")
+	}
+
+	want := "classification.thresholds.incidental must be in [1, 99], got 200"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want to contain %q", err, want)
+	}
+}
+
+func TestLoad_ZeroContractual(t *testing.T) {
+	_, err := Load(filepath.Join("testdata", "zero-contractual.yaml"))
+	if err == nil {
+		t.Fatal("expected error for contractual=0, got nil")
+	}
+
+	want := "classification.thresholds.contractual must be in [1, 99], got 0"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want to contain %q", err, want)
+	}
+}
+
+func TestLoad_NegativeIncidental(t *testing.T) {
+	_, err := Load(filepath.Join("testdata", "negative-incidental.yaml"))
+	if err == nil {
+		t.Fatal("expected error for incidental=-10, got nil")
+	}
+
+	want := "classification.thresholds.incidental must be in [1, 99], got -10"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want to contain %q", err, want)
+	}
+}
+
+func TestLoad_InvertedThresholds(t *testing.T) {
+	_, err := Load(filepath.Join("testdata", "inverted-thresholds.yaml"))
+	if err == nil {
+		t.Fatal("expected error for inverted thresholds, got nil")
+	}
+
+	want := "classification.thresholds.contractual (40) must be greater than incidental (60)"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want to contain %q", err, want)
+	}
+}
+
+func TestLoad_EqualThresholds(t *testing.T) {
+	_, err := Load(filepath.Join("testdata", "equal-thresholds.yaml"))
+	if err == nil {
+		t.Fatal("expected error for equal thresholds, got nil")
+	}
+
+	want := "classification.thresholds.contractual (50) must be greater than incidental (50)"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want to contain %q", err, want)
+	}
+}
+
+func TestLoad_BoundaryValid(t *testing.T) {
+	cfg, err := Load(filepath.Join("testdata", "boundary-thresholds.yaml"))
+	if err != nil {
+		t.Fatalf("Load(boundary-thresholds) error: %v", err)
+	}
+
+	if cfg.Classification.Thresholds.Contractual != 99 {
+		t.Errorf("contractual = %d, want 99",
+			cfg.Classification.Thresholds.Contractual)
+	}
+	if cfg.Classification.Thresholds.Incidental != 1 {
+		t.Errorf("incidental = %d, want 1",
+			cfg.Classification.Thresholds.Incidental)
+	}
+}
+
+func TestLoad_AdjacentValid(t *testing.T) {
+	cfg, err := Load(filepath.Join("testdata", "adjacent-thresholds.yaml"))
+	if err != nil {
+		t.Fatalf("Load(adjacent-thresholds) error: %v", err)
+	}
+
+	if cfg.Classification.Thresholds.Contractual != 51 {
+		t.Errorf("contractual = %d, want 51",
+			cfg.Classification.Thresholds.Contractual)
+	}
+	if cfg.Classification.Thresholds.Incidental != 50 {
+		t.Errorf("incidental = %d, want 50",
+			cfg.Classification.Thresholds.Incidental)
+	}
+}
+
+func TestLoad_NegativeContractual(t *testing.T) {
+	_, err := Load(filepath.Join("testdata", "negative-contractual.yaml"))
+	if err == nil {
+		t.Fatal("expected error for contractual=-10, got nil")
+	}
+
+	want := "classification.thresholds.contractual must be in [1, 99], got -10"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want to contain %q", err, want)
+	}
+}
+
+func TestLoad_ZeroIncidental(t *testing.T) {
+	_, err := Load(filepath.Join("testdata", "zero-incidental.yaml"))
+	if err == nil {
+		t.Fatal("expected error for incidental=0, got nil")
+	}
+
+	want := "classification.thresholds.incidental must be in [1, 99], got 0"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want to contain %q", err, want)
+	}
+}

--- a/internal/config/testdata/adjacent-thresholds.yaml
+++ b/internal/config/testdata/adjacent-thresholds.yaml
@@ -1,0 +1,4 @@
+classification:
+  thresholds:
+    contractual: 51
+    incidental: 50

--- a/internal/config/testdata/boundary-thresholds.yaml
+++ b/internal/config/testdata/boundary-thresholds.yaml
@@ -1,0 +1,4 @@
+classification:
+  thresholds:
+    contractual: 99
+    incidental: 1

--- a/internal/config/testdata/equal-thresholds.yaml
+++ b/internal/config/testdata/equal-thresholds.yaml
@@ -1,0 +1,4 @@
+classification:
+  thresholds:
+    contractual: 50
+    incidental: 50

--- a/internal/config/testdata/inverted-thresholds.yaml
+++ b/internal/config/testdata/inverted-thresholds.yaml
@@ -1,0 +1,4 @@
+classification:
+  thresholds:
+    contractual: 40
+    incidental: 60

--- a/internal/config/testdata/negative-contractual.yaml
+++ b/internal/config/testdata/negative-contractual.yaml
@@ -1,0 +1,4 @@
+classification:
+  thresholds:
+    contractual: -10
+    incidental: 50

--- a/internal/config/testdata/negative-incidental.yaml
+++ b/internal/config/testdata/negative-incidental.yaml
@@ -1,0 +1,4 @@
+classification:
+  thresholds:
+    contractual: 80
+    incidental: -10

--- a/internal/config/testdata/out-of-range-contractual.yaml
+++ b/internal/config/testdata/out-of-range-contractual.yaml
@@ -1,0 +1,4 @@
+classification:
+  thresholds:
+    contractual: 500
+    incidental: 50

--- a/internal/config/testdata/out-of-range-incidental.yaml
+++ b/internal/config/testdata/out-of-range-incidental.yaml
@@ -1,0 +1,4 @@
+classification:
+  thresholds:
+    contractual: 80
+    incidental: 200

--- a/internal/config/testdata/zero-contractual.yaml
+++ b/internal/config/testdata/zero-contractual.yaml
@@ -1,0 +1,4 @@
+classification:
+  thresholds:
+    contractual: 0
+    incidental: 50

--- a/internal/config/testdata/zero-incidental.yaml
+++ b/internal/config/testdata/zero-incidental.yaml
@@ -1,0 +1,4 @@
+classification:
+  thresholds:
+    contractual: 80
+    incidental: 0

--- a/openspec/changes/config-threshold-validation/.openspec.yaml
+++ b/openspec/changes/config-threshold-validation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-19

--- a/openspec/changes/config-threshold-validation/design.md
+++ b/openspec/changes/config-threshold-validation/design.md
@@ -1,0 +1,85 @@
+## Context
+
+`config.Load` (`internal/config/config.go:112-149`) unmarshals `.gaze.yaml` and validates baseline config (epsilon, new_function_threshold) and doc_scan timeout, but performs zero validation on classification thresholds. The `[1, 99]` range check and `contractual > incidental` coherence check live exclusively in the CLI layer's `loadConfig` wrapper (`cmd/gaze/main.go:158-196`).
+
+This creates two gaps:
+1. Config-file values bypass range checking (only flag-sourced values are range-checked).
+2. Non-CLI callers (`loadGazeConfigBestEffort` in `runner_steps.go` and `contract.go`) bypass all threshold validation entirely.
+
+The fix follows the "validate at the boundary" principle: move threshold validation into `config.Load`, the single function through which all config enters the system.
+
+## Goals / Non-Goals
+
+### Goals
+- Validate `contractual` and `incidental` thresholds in `config.Load` so all callers get validated config
+- Enforce `1 <= incidental < contractual <= 99` (the same invariant the CLI path enforces)
+- Return descriptive errors identifying the invalid field, received value, and valid range
+- Add comprehensive test coverage for all validation branches
+
+### Non-Goals
+- Changing the valid range boundaries (these remain `[1, 99]` as established)
+- Modifying CLI flag validation in `loadConfig` (it stays for flag-specific error messages)
+- Adding validation for other config fields beyond classification thresholds (out of scope)
+- Changing the `loadGazeConfigBestEffort` fallback behavior (it already returns `DefaultConfig()` on error)
+
+## Decisions
+
+### D1: Validate in `config.Load`, not in a separate `Validate` method
+
+**Decision**: Add validation directly inside `Load()` after YAML unmarshaling, alongside existing baseline and timeout validation.
+
+**Alternatives considered**:
+- Separate `Validate(*GazeConfig) error` function: More composable, but adds an extra call that callers can forget. The existing pattern (validate-in-Load) is already established for baseline and timeout fields.
+- Validate only in `loadConfig` CLI wrapper: Status quo. Leaves non-CLI paths unprotected.
+
+**Rationale**: Consistency with existing validation pattern in `Load()`. Every caller of `Load` gets validated output without remembering to call a separate function. Aligns with Constitution Principle II (Minimal Assumptions) -- `config.Load` enforces the same constraints already documented in the CLI path, making them explicit at the config boundary.
+
+### D2: Keep CLI `loadConfig` validation intact
+
+**Decision**: Do not remove the range checks or coherence check from `cmd/gaze/main.go:loadConfig`.
+
+**Rationale**: The CLI-layer validation provides better error messages that reference flag names (`--contractual-threshold=500 is invalid`). The `config.Load` errors reference YAML field paths (`classification.thresholds.contractual must be in [1, 99]`). Both are valuable in their respective contexts. The CLI checks also catch invalid states created by merging valid config with invalid flag overrides, which `config.Load` cannot catch (it only sees the file).
+
+### D3: Error message format
+
+**Decision**: Use the pattern `classification.thresholds.<field> must be in [1, 99], got <value>` for range errors and `classification.thresholds.contractual (<value>) must be greater than incidental (<value>)` for coherence errors.
+
+**Rationale**: Matches the existing error format used for baseline validation (`baseline.epsilon must be >= 0, got %g`). Uses YAML field paths so users can locate the problem in their config file.
+
+## Coverage Strategy
+
+Unit tests only. All new validation branches in `config.Load` must achieve 100% branch coverage. The test cases cover: contractual range (above, zero, negative), incidental range (above, zero, negative), coherence (inverted, equal), and valid boundaries (extreme, adjacent) -- covering all 3 validation checks in both pass and fail paths. No integration or e2e tests needed -- `config.Load` is a pure function with file I/O as its only external dependency, tested via isolated YAML fixture files.
+
+## Error Path Change
+
+After this change, for YAML-sourced invalid thresholds, `config.Load` returns the error before `loadConfig`'s own coherence check runs (line 154-156 of `cmd/gaze/main.go`). The error message format changes:
+
+- **Before**: `contractual threshold (50) must be greater than incidental threshold (60); check config file /path/.gaze.yaml` (from `loadConfig`)
+- **After**: `classification.thresholds.contractual (50) must be greater than incidental (60)` (from `config.Load`)
+
+The new format uses YAML field paths and is consistent with other `config.Load` errors. The existing CLI test `TestLoadConfig_YAMLInvertedThresholdsRejected` asserts on `"config file"` in the error and must be updated to match the new format.
+
+The CLI-layer coherence check in `loadConfig` (lines 176-196) still fires when CLI flag overrides create an invalid combination with a valid config file -- that path is unchanged.
+
+## Partial Threshold Specification
+
+When only one threshold is set in `.gaze.yaml` (e.g., `incidental: 85` with no `contractual` key), the YAML unmarshaler writes only the specified field, and the other field retains its default from `DefaultConfig()` (contractual=80, incidental=50). Validation runs on the merged result. This means a partial config like `incidental: 85` will fail coherence (80 <= 85) even though the user only set one field.
+
+This is correct behavior -- the merged config would produce degenerate classification regardless of whether the user explicitly set both values. The error message names the fields and values, making it clear what needs fixing. No special handling for "defaulted" vs. "explicit" values is needed because Go's `int` zero-value (0) and YAML's explicit `0` are indistinguishable after parsing, and 0 is outside `[1, 99]` regardless of intent.
+
+## Risks / Trade-offs
+
+### R1: Breaking change for users with invalid configs (Low risk)
+
+Users who have `.gaze.yaml` files with out-of-range thresholds will get errors where they previously got silent degradation. This is intentional -- the previous behavior was a bug that produced incorrect results. The error messages tell users exactly what to fix.
+
+### R2: Redundant validation in CLI path (Accepted trade-off)
+
+After this change, thresholds from `.gaze.yaml` are validated twice when accessed via CLI commands: once in `config.Load` and again in `loadConfig`. This is acceptable because:
+- The validations are cheap (integer comparisons)
+- They serve different purposes (generic config error vs. flag-specific error)
+- Removing CLI-layer validation would regress error message quality for flag users
+
+### R3: `loadGazeConfigBestEffort` silently swallows validation errors (Existing behavior, unchanged)
+
+When `config.Load` returns an error, `loadGazeConfigBestEffort` falls back to `DefaultConfig()` without surfacing the error to the user. This means an invalid `.gaze.yaml` in the `gaze report` or `gaze crap` path produces default thresholds instead of an error. This is the existing fallback pattern and is acceptable for "best effort" callers, but could be improved in a future change by logging a warning.

--- a/openspec/changes/config-threshold-validation/proposal.md
+++ b/openspec/changes/config-threshold-validation/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+`config.Load` (`internal/config/config.go:112-149`) parses `.gaze.yaml` but performs no validation on classification thresholds (`contractual`, `incidental`). Out-of-range values (e.g., 500, -10, 0), negative values, and inverted pairs (`contractual < incidental`) all load without error.
+
+The `[1, 99]` range check and `contractual > incidental` coherence check exist only in the CLI layer's `loadConfig` wrapper (`cmd/gaze/main.go:158-196`). This creates an asymmetry: the same invalid value supplied via a CLI flag is rejected with a clear error, but supplied via the config file it is accepted silently and degrades classification output.
+
+Additionally, non-CLI callers (`loadGazeConfigBestEffort` in `internal/aireport/runner_steps.go` and `internal/crap/contract.go`) bypass `loadConfig` entirely, calling `config.Load` directly with zero threshold validation.
+
+Reported in [#114](https://github.com/unbound-force/gaze/issues/114). Confirmed and reproduced: `contractual: 500` in `.gaze.yaml` causes all effects to be classified as incidental regardless of confidence score.
+
+## What Changes
+
+Move classification threshold validation into `config.Load()` -- the single boundary where config enters the system. This ensures all callers (CLI `loadConfig`, `loadGazeConfigBestEffort`, and any future consumers) receive validated configuration.
+
+## Capabilities
+
+### New Capabilities
+- `config.Load threshold validation`: `config.Load` now validates that `contractual` and `incidental` thresholds are within `[1, 99]` and that `contractual > incidental`. Invalid `.gaze.yaml` files produce descriptive errors instead of silently loading.
+
+### Modified Capabilities
+- `config.Load`: Adds three validation checks after YAML unmarshaling (range check for each threshold, coherence check for the pair).
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- **`internal/config/config.go`**: Add threshold validation to `Load()` (~10 lines).
+- **`internal/config/config_test.go`**: Add test cases for out-of-range, inverted, equal, zero, and boundary-valid thresholds (~6 new tests).
+- **`internal/config/testdata/`**: Add YAML fixture files for new test cases (~6 files).
+- **`cmd/gaze/main.go`**: No production code changes needed. The existing CLI-layer validation in `loadConfig` remains for flag-specific error messages (e.g., mentioning `--contractual-threshold`). The post-merge coherence check also remains because CLI overrides can invalidate a config that was valid on disk.
+- **`cmd/gaze/main_test.go`**: `TestLoadConfig_YAMLInvertedThresholdsRejected` must update its assertion — the error now comes from `config.Load` (field-path format) instead of `loadConfig` (source-attribution format), so the `"config file"` substring check changes to `"classification.thresholds.contractual"`.
+- **`loadGazeConfigBestEffort` callers**: No code changes needed. These already fall back to `DefaultConfig()` on `Load` errors, so invalid configs now trigger safe fallback instead of silently degrading.
+- **No API surface changes**: `Load` signature is unchanged; it just returns errors for previously-accepted invalid inputs.
+
+## Constitution Alignment
+
+Assessed against the Gaze project constitution (v1.3.0).
+
+### I. Accuracy
+
+**Assessment**: PASS
+
+This change directly supports accuracy by preventing degenerate classification thresholds from silently corrupting output. An unreachable `contractual: 500` threshold forces every effect to be classified as incidental regardless of actual confidence, producing systematically inaccurate results. Validating at the config boundary eliminates this failure mode.
+
+### II. Minimal Assumptions
+
+**Assessment**: PASS
+
+The fix enforces the same explicit constraints (`[1, 99]` range, `contractual > incidental`) that already exist in the CLI path. No new assumptions are introduced. Invalid inputs that were silently accepted are now explicitly rejected with descriptive errors, making the system's constraints more transparent to users.
+
+### III. Actionable Output
+
+**Assessment**: PASS
+
+The validation errors are specific and actionable: they name the invalid field, show the value received, and state the valid range. Users get immediate feedback at config load time rather than discovering degraded output after a full analysis run.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+All validation logic is in `config.Load`, which is independently testable with YAML fixture files. No external services or shared state required. Each new validation rule has a corresponding test case with a dedicated fixture file.

--- a/openspec/changes/config-threshold-validation/specs/config-load-validation.md
+++ b/openspec/changes/config-threshold-validation/specs/config-load-validation.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Contractual threshold range validation
+
+`config.Load` MUST reject a `.gaze.yaml` where `classification.thresholds.contractual` is less than 1 or greater than 99. The returned error MUST identify the field name and the invalid value.
+
+#### Scenario: Contractual threshold above upper bound
+- **GIVEN** a `.gaze.yaml` with `classification.thresholds.contractual: 500`
+- **WHEN** `config.Load` is called
+- **THEN** it MUST return an error containing `classification.thresholds.contractual must be in [1, 99], got 500`
+
+#### Scenario: Contractual threshold at zero
+- **GIVEN** a `.gaze.yaml` with `classification.thresholds.contractual: 0`
+- **WHEN** `config.Load` is called
+- **THEN** it MUST return an error containing `classification.thresholds.contractual must be in [1, 99], got 0`
+
+#### Scenario: Contractual threshold negative
+- **GIVEN** a `.gaze.yaml` with `classification.thresholds.contractual: -10`
+- **WHEN** `config.Load` is called
+- **THEN** it MUST return an error containing `classification.thresholds.contractual must be in [1, 99], got -10`
+
+### Requirement: Incidental threshold range validation
+
+`config.Load` MUST reject a `.gaze.yaml` where `classification.thresholds.incidental` is less than 1 or greater than 99. The returned error MUST identify the field name and the invalid value.
+
+#### Scenario: Incidental threshold above upper bound
+- **GIVEN** a `.gaze.yaml` with `classification.thresholds.incidental: 200`
+- **WHEN** `config.Load` is called
+- **THEN** it MUST return an error containing `classification.thresholds.incidental must be in [1, 99], got 200`
+
+#### Scenario: Incidental threshold at zero
+- **GIVEN** a `.gaze.yaml` with `classification.thresholds.incidental: 0`
+- **WHEN** `config.Load` is called
+- **THEN** it MUST return an error containing `classification.thresholds.incidental must be in [1, 99], got 0`
+
+#### Scenario: Incidental threshold negative
+- **GIVEN** a `.gaze.yaml` with `classification.thresholds.incidental: -10`
+- **WHEN** `config.Load` is called
+- **THEN** it MUST return an error containing `classification.thresholds.incidental must be in [1, 99], got -10`
+
+### Requirement: Threshold coherence validation
+
+`config.Load` MUST reject a `.gaze.yaml` where `classification.thresholds.contractual` is less than or equal to `classification.thresholds.incidental`. The returned error MUST include both values.
+
+#### Scenario: Inverted thresholds
+- **GIVEN** a `.gaze.yaml` with `classification.thresholds.contractual: 40` and `classification.thresholds.incidental: 60`
+- **WHEN** `config.Load` is called
+- **THEN** it MUST return an error containing `classification.thresholds.contractual (40) must be greater than incidental (60)`
+
+#### Scenario: Equal thresholds
+- **GIVEN** a `.gaze.yaml` with `classification.thresholds.contractual: 50` and `classification.thresholds.incidental: 50`
+- **WHEN** `config.Load` is called
+- **THEN** it MUST return an error containing `classification.thresholds.contractual (50) must be greater than incidental (50)`
+
+### Requirement: Valid boundary thresholds accepted
+
+`config.Load` MUST accept threshold values at the boundaries of the valid range when coherence is satisfied.
+
+#### Scenario: Maximum contractual with minimum incidental
+- **GIVEN** a `.gaze.yaml` with `classification.thresholds.contractual: 99` and `classification.thresholds.incidental: 1`
+- **WHEN** `config.Load` is called
+- **THEN** it MUST return a valid `*GazeConfig` with no error
+
+#### Scenario: Adjacent valid thresholds
+- **GIVEN** a `.gaze.yaml` with `classification.thresholds.contractual: 51` and `classification.thresholds.incidental: 50`
+- **WHEN** `config.Load` is called
+- **THEN** it MUST return a valid `*GazeConfig` with no error
+
+### Requirement: Validation order
+
+Range validation MUST be performed before coherence validation. If a threshold is out of range, the range error MUST be returned without also checking coherence.
+
+#### Scenario: Out-of-range contractual with valid incidental
+- **GIVEN** a `.gaze.yaml` with `classification.thresholds.contractual: 500` and `classification.thresholds.incidental: 50`
+- **WHEN** `config.Load` is called
+- **THEN** it MUST return the range error for `contractual`, not a coherence error
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/config-threshold-validation/tasks.md
+++ b/openspec/changes/config-threshold-validation/tasks.md
@@ -1,0 +1,47 @@
+## 1. Test Fixtures
+
+- [x] 1.1 Create `internal/config/testdata/out-of-range-contractual.yaml` with `classification.thresholds.contractual: 500` and valid `incidental: 50`
+- [x] 1.2 Create `internal/config/testdata/out-of-range-incidental.yaml` with `classification.thresholds.incidental: 200` and valid `contractual: 80`
+- [x] 1.3 Create `internal/config/testdata/zero-contractual.yaml` with `classification.thresholds.contractual: 0` and valid `incidental: 50`
+- [x] 1.4 Create `internal/config/testdata/negative-incidental.yaml` with `classification.thresholds.incidental: -10` and valid `contractual: 80`
+- [x] 1.5 Create `internal/config/testdata/inverted-thresholds.yaml` with `classification.thresholds.contractual: 40` and `incidental: 60`
+- [x] 1.6 Create `internal/config/testdata/equal-thresholds.yaml` with `classification.thresholds.contractual: 50` and `incidental: 50`
+- [x] 1.7 Create `internal/config/testdata/boundary-thresholds.yaml` with `classification.thresholds.contractual: 99` and `incidental: 1`
+- [x] 1.8 Create `internal/config/testdata/adjacent-thresholds.yaml` with `classification.thresholds.contractual: 51` and `incidental: 50`
+- [x] 1.9 Create `internal/config/testdata/negative-contractual.yaml` with `classification.thresholds.contractual: -10` and valid `incidental: 50`
+- [x] 1.10 Create `internal/config/testdata/zero-incidental.yaml` with `classification.thresholds.incidental: 0` and valid `contractual: 80`
+
+## 2. Validation Logic
+
+- [x] 2.1 Add contractual range check to `config.Load` (`internal/config/config.go`): after baseline validation (line 136), check `cfg.Classification.Thresholds.Contractual` is in `[1, 99]`; return `fmt.Errorf("classification.thresholds.contractual must be in [1, 99], got %d", ct)` if not
+- [x] 2.2 Add incidental range check to `config.Load`: check `cfg.Classification.Thresholds.Incidental` is in `[1, 99]`; return `fmt.Errorf("classification.thresholds.incidental must be in [1, 99], got %d", it)` if not
+- [x] 2.3 Add coherence check to `config.Load`: after both range checks pass, check `contractual > incidental`; return `fmt.Errorf("classification.thresholds.contractual (%d) must be greater than incidental (%d)", ct, it)` if not
+
+## 3. Unit Tests
+
+- [x] 3.1 Add `TestLoad_ContractualOutOfRange` in `internal/config/config_test.go`: load `out-of-range-contractual.yaml`, assert error contains `classification.thresholds.contractual must be in [1, 99], got 500`
+- [x] 3.2 Add `TestLoad_IncidentalOutOfRange`: load `out-of-range-incidental.yaml`, assert error contains `classification.thresholds.incidental must be in [1, 99], got 200`
+- [x] 3.3 Add `TestLoad_ZeroContractual`: load `zero-contractual.yaml`, assert error contains `classification.thresholds.contractual must be in [1, 99], got 0`
+- [x] 3.4 Add `TestLoad_NegativeIncidental`: load `negative-incidental.yaml`, assert error contains `classification.thresholds.incidental must be in [1, 99], got -10`
+- [x] 3.5 Add `TestLoad_InvertedThresholds`: load `inverted-thresholds.yaml`, assert error contains `classification.thresholds.contractual (40) must be greater than incidental (60)`
+- [x] 3.6 Add `TestLoad_EqualThresholds`: load `equal-thresholds.yaml`, assert error contains `classification.thresholds.contractual (50) must be greater than incidental (50)`
+- [x] 3.7 Add `TestLoad_BoundaryValid`: load `boundary-thresholds.yaml`, assert no error, `Contractual == 99`, `Incidental == 1`
+- [x] 3.8 Add `TestLoad_AdjacentValid`: load `adjacent-thresholds.yaml`, assert no error, `Contractual == 51`, `Incidental == 50`
+- [x] 3.9 Add `TestLoad_NegativeContractual`: load `negative-contractual.yaml`, assert error contains `classification.thresholds.contractual must be in [1, 99], got -10`
+- [x] 3.10 Add `TestLoad_ZeroIncidental`: load `zero-incidental.yaml`, assert error contains `classification.thresholds.incidental must be in [1, 99], got 0`
+
+## 4. Verification
+
+- [x] 4.1 Run `go test -race -count=1 ./internal/config/...` and confirm all tests pass
+- [x] 4.2 Run `go test -race -count=1 -short ./...` and confirm no regressions across the full module
+- [x] 4.3 Run `golangci-lint run` and confirm no lint violations
+- [x] 4.4 Update `TestLoadConfig_YAMLInvertedThresholdsRejected` in `cmd/gaze/main_test.go`: after this change, `config.Load` returns the coherence error before `loadConfig`'s own coherence check runs (line 154-156), so the error message format changes from `"config file"` to the `config.Load` format (`classification.thresholds.contractual`). Update the test assertion on line 653 from `strings.Contains(err.Error(), "config file")` to `strings.Contains(err.Error(), "classification.thresholds.contractual")` and verify the test passes
+
+## 5. Constitution Alignment Verification
+
+- [x] 5.1 Verify Principle I (Accuracy): confirm that invalid thresholds are rejected before they can corrupt classification output
+- [x] 5.2 Verify Principle II (Minimal Assumptions): confirm no new assumptions introduced; validation enforces the same constraints already documented in the CLI path
+- [x] 5.3 Verify Principle III (Actionable Output): confirm all error messages name the invalid field, show the received value, and state the valid range
+- [x] 5.4 Verify Principle IV (Testability): confirm all validation branches are covered by dedicated test cases with isolated fixture files
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes #114 — `config.Load` now validates classification thresholds from `.gaze.yaml`, closing the gap where out-of-range or inverted values loaded silently and degraded classification output.

### Problem

`config.Load` parsed `.gaze.yaml` but performed no validation on `classification.thresholds.contractual` and `classification.thresholds.incidental`. The `[1, 99]` range check and `contractual > incidental` coherence check existed only in the CLI layer's `loadConfig` wrapper. Config-file values bypassed range checking entirely, and non-CLI callers (`loadGazeConfigBestEffort`) bypassed all threshold validation.

### Changes

- **`internal/config/config.go`**: Add 3 validation checks to `Load()` after baseline validation — contractual range `[1, 99]`, incidental range `[1, 99]`, coherence `contractual > incidental`
- **`internal/config/config_test.go`**: Add 10 new test functions covering all validation branches (out-of-range, zero, negative, inverted, equal, boundary valid, adjacent valid)
- **`internal/config/testdata/`**: Add 10 YAML fixture files
- **`cmd/gaze/main_test.go`**: Update `TestLoadConfig_YAMLInvertedThresholdsRejected` assertion — error now comes from `config.Load` (YAML field-path format) instead of `loadConfig` (source-attribution format)

### Spec Artifacts

Full OpenSpec artifacts in `openspec/changes/config-threshold-validation/` — proposal, design, delta spec with Given/When/Then scenarios, and implementation tasks.

### Review Council

- Spec review: 5 Divisor agents reviewed, all findings auto-fixed, PASSED
- Code review: 4 Divisor agents reviewed, all APPROVE with zero findings