### PR TITLE
fix: resolve coverage from module root when invoked from subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ fake_opencode
 .uf/replicator/*.db-shm
 .uf/replicator/*.db-wal
 .uf/replicator/*.lock
+.uf/replicator/*.log
 .uf/muti-mind/artifacts/
 .uf/mx-f/data/
 # Legacy tool directories (renamed to .uf/ in Spec 025)

--- a/.uf/dewey/learnings/038-crap-subdir-coverage-20260622T103805-gustavo-miranda.md
+++ b/.uf/dewey/learnings/038-crap-subdir-coverage-20260622T103805-gustavo-miranda.md
@@ -1,0 +1,10 @@
+---
+tag: 038-crap-subdir-coverage
+author: gustavo-miranda
+category: gotcha
+created_at: 2026-06-22T10:38:05Z
+identity: 038-crap-subdir-coverage-20260622T103805-gustavo-miranda
+tier: draft
+---
+
+During spec review of the 038-crap-subdir-coverage feature, the review found a call site that the original issue analysis missed: runDocscan at cmd/gaze/main.go:767 also uses os.Getwd() as a proxy for the module root. The lesson is that when an issue reports N affected call sites, always grep for ALL os.Getwd() calls in the codebase and evaluate each one — the actual count is typically higher than what the issue author identified. In this case the issue found 5 sites, jflowers' review council found 5, but a thorough codebase scan found 10 total (9 needing fixes, 1 correct as-is in scaffold.go). The spec review process caught the gap before implementation.

--- a/.uf/dewey/learnings/module-root-resolution-20260622T103755-gustavo-miranda.md
+++ b/.uf/dewey/learnings/module-root-resolution-20260622T103755-gustavo-miranda.md
@@ -1,0 +1,10 @@
+---
+tag: module-root-resolution
+author: gustavo-miranda
+category: pattern
+created_at: 2026-06-22T10:37:55Z
+identity: module-root-resolution-20260622T103755-gustavo-miranda
+tier: draft
+---
+
+When fixing os.Getwd()-as-module-root bugs in Go CLI tools, the comprehensive approach is to extract a shared FindModuleRoot(startDir) function to a loader/utility package that walks up the directory tree looking for go.mod. The key insight is that the bug scope is always larger than initially reported — in gaze, what appeared as a single gaze-crap bug actually affected 9 call sites across 4 files (cmd/gaze/main.go, internal/crap/contract.go, internal/crap/coverage.go, internal/aireport/runner_steps.go). The pattern is to push os.Getwd() calls to the CLI entry points and thread moduleDir as a parameter through all internal functions. Functions like loadGazeConfigBestEffort that called os.Getwd() internally should instead accept moduleDir as a parameter (the cmd/gaze/main.go version already had this correct pattern). Defense-in-depth diagnostics (per-entry stderr warnings plus error on 0/N resolution) catch edge cases beyond the walk-up fix like corrupted profiles or wrong modules.

--- a/.uf/replicator/replicator.log
+++ b/.uf/replicator/replicator.log
@@ -1,1 +1,1 @@
-2026/06/16 17:13:18 INFO tool call tool=forge_worktree_list duration=23.771208ms success=true
+2026/06/22 11:01:54 INFO tool call tool=forge_worktree_list duration=3.770027ms success=true

--- a/.uf/replicator/replicator.log
+++ b/.uf/replicator/replicator.log
@@ -1,1 +1,0 @@
-2026/06/22 11:01:54 INFO tool call tool=forge_worktree_list duration=3.770027ms success=true

--- a/cmd/gaze/main.go
+++ b/cmd/gaze/main.go
@@ -149,7 +149,11 @@ func loadConfig(path string, contractualThresh, incidentalThresh int) (*config.G
 		if err != nil {
 			return config.DefaultConfig(), nil
 		}
-		path = filepath.Join(cwd, ".gaze.yaml")
+		configDir := cwd
+		if moduleRoot, findErr := loader.FindModuleRoot(cwd); findErr == nil {
+			configDir = moduleRoot
+		}
+		path = filepath.Join(configDir, ".gaze.yaml")
 	}
 	cfg, err := config.Load(path)
 	if err != nil {
@@ -293,7 +297,15 @@ func runClassify(
 		logger.Debug("could not determine working directory for module load", "err", err)
 		cwd = ""
 	}
-	modResult, modErr := loader.LoadModule(cwd)
+	moduleRoot := cwd
+	if cwd != "" {
+		if root, findErr := loader.FindModuleRoot(cwd); findErr == nil {
+			moduleRoot = root
+		} else {
+			logger.Warn("could not find module root; classification signals may be degraded", "err", findErr)
+		}
+	}
+	modResult, modErr := loader.LoadModule(moduleRoot)
 	var modPkgs []*packages.Package
 	if modErr != nil {
 		// Non-fatal: module loading failure means caller analysis
@@ -723,9 +735,13 @@ If no coverage profile is provided, runs 'go test -coverprofile'
 automatically.`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			moduleDir, err := os.Getwd()
+			cwd, err := os.Getwd()
 			if err != nil {
 				return fmt.Errorf("getting working directory: %w", err)
+			}
+			moduleDir, err := loader.FindModuleRoot(cwd)
+			if err != nil {
+				return fmt.Errorf("finding module root: %w", err)
 			}
 			opts := crap.DefaultOptions()
 			opts.CoverProfile = coverProfile
@@ -788,9 +804,13 @@ func runDocscan(p docscanParams) error {
 
 	// Determine the repo root: walk up from the package directory
 	// to find the go.mod file, defaulting to cwd.
-	repoRoot, err := os.Getwd()
+	cwd, err := os.Getwd()
 	if err != nil {
-		repoRoot = "."
+		cwd = "."
+	}
+	repoRoot := cwd
+	if root, findErr := loader.FindModuleRoot(cwd); findErr == nil {
+		repoRoot = root
 	}
 
 	// Resolve PackageDir from the import path if it corresponds
@@ -1185,27 +1205,6 @@ Requires the target package to have existing test files.`,
 	return cmd
 }
 
-// findModuleRoot walks up from the current working directory to find
-// the nearest directory containing a go.mod file (the module root).
-// This ensures self-check always analyzes the full module, even when
-// invoked from a subdirectory.
-func findModuleRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("getting working directory: %w", err)
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", fmt.Errorf("no go.mod found in %q or any parent directory", dir)
-		}
-		dir = parent
-	}
-}
-
 // selfCheckParams holds the parsed flags for the self-check command.
 type selfCheckParams struct {
 	format          string
@@ -1240,7 +1239,13 @@ func runSelfCheck(p selfCheckParams) error {
 
 	findRoot := p.moduleRootFunc
 	if findRoot == nil {
-		findRoot = findModuleRoot
+		findRoot = func() (string, error) {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return "", fmt.Errorf("getting working directory: %w", err)
+			}
+			return loader.FindModuleRoot(cwd)
+		}
 	}
 	moduleDir, err := findRoot()
 	if err != nil {
@@ -1372,6 +1377,10 @@ func runReport(p reportParams) error {
 	if err != nil {
 		cwd = "."
 	}
+	moduleDir, findErr := loader.FindModuleRoot(cwd)
+	if findErr != nil {
+		return fmt.Errorf("finding module root: %w", findErr)
+	}
 
 	timeout := p.aiTimeout
 	if timeout <= 0 {
@@ -1401,7 +1410,7 @@ func runReport(p reportParams) error {
 		// Load system prompt only in text mode (FR-015): in json mode the
 		// prompt file is never needed and a permission error must not block output.
 		var promptErr error
-		systemPrompt, promptErr = aireport.LoadPrompt(cwd)
+		systemPrompt, promptErr = aireport.LoadPrompt(moduleDir)
 		if promptErr != nil {
 			return fmt.Errorf("loading system prompt: %w", promptErr)
 		}
@@ -1411,7 +1420,7 @@ func runReport(p reportParams) error {
 
 	opts := aireport.RunnerOptions{
 		Patterns:        p.patterns,
-		ModuleDir:       cwd,
+		ModuleDir:       moduleDir,
 		Adapter:         adapter,
 		AdapterCfg:      adapterCfg,
 		SystemPrompt:    systemPrompt,

--- a/cmd/gaze/main_test.go
+++ b/cmd/gaze/main_test.go
@@ -579,6 +579,9 @@ func TestLoadConfig_ContractualThresholdOverride(t *testing.T) {
 // TestLoadConfig_IncidentalThresholdOverride verifies that a positive
 // incidental threshold value is applied to the config.
 func TestLoadConfig_IncidentalThresholdOverride(t *testing.T) {
+	// Chdir to a temp dir without go.mod so FindModuleRoot falls back
+	// to DefaultConfig, isolating the test from the project's .gaze.yaml.
+	t.Chdir(t.TempDir())
 	cfg, err := loadConfig("", -1, 30)
 	if err != nil {
 		t.Fatalf("loadConfig error: %v", err)
@@ -614,6 +617,9 @@ func TestLoadConfig_BothThresholdsOverride(t *testing.T) {
 // TestLoadConfig_NoOverride verifies that -1 sentinel leaves
 // thresholds at their config/default values.
 func TestLoadConfig_NoOverride(t *testing.T) {
+	// Chdir to a temp dir without go.mod so FindModuleRoot falls back
+	// to DefaultConfig, isolating the test from the project's .gaze.yaml.
+	t.Chdir(t.TempDir())
 	cfg, err := loadConfig("", -1, -1)
 	if err != nil {
 		t.Fatalf("loadConfig error: %v", err)

--- a/internal/aireport/runner_steps.go
+++ b/internal/aireport/runner_steps.go
@@ -91,7 +91,7 @@ func runQualityStep(patterns []string, moduleDir string, stderr io.Writer) (*qua
 		return nil, fmt.Errorf("no packages matched patterns %v", patterns)
 	}
 
-	gazeConfig := loadGazeConfigBestEffort()
+	gazeConfig := loadGazeConfigBestEffort(moduleDir)
 
 	// Hoist LoadModule out of the per-package loop — O(1) instead of O(n).
 	modPkgs := resolveModulePackages(moduleDir)
@@ -196,7 +196,7 @@ func runClassifyStep(patterns []string, moduleDir string) (*classifyStepResult, 
 	// Hoist LoadModule out of the per-package loop — O(1) instead of O(n).
 	modPkgs := resolveModulePackages(moduleDir)
 
-	gazeConfig := loadGazeConfigBestEffort()
+	gazeConfig := loadGazeConfigBestEffort(moduleDir)
 	var allResults []taxonomy.AnalysisResult
 
 	for _, pkgPath := range pkgPaths {
@@ -230,7 +230,7 @@ func runClassifyStep(patterns []string, moduleDir string) (*classifyStepResult, 
 
 // runDocscanStep runs the documentation scanner and returns the JSON output.
 func runDocscanStep(moduleDir string) (json.RawMessage, error) {
-	cfg := loadGazeConfigBestEffort()
+	cfg := loadGazeConfigBestEffort(moduleDir)
 	scanOpts := docscan.ScanOptions{Config: cfg}
 
 	docs, err := docscan.Scan(moduleDir, scanOpts)
@@ -294,11 +294,15 @@ func runClassifyResults(
 // degrade gracefully.
 func resolveModulePackages(moduleDir string) []*packages.Package {
 	if moduleDir == "" {
-		var err error
-		moduleDir, err = os.Getwd()
+		cwd, err := os.Getwd()
 		if err != nil {
 			return nil
 		}
+		root, findErr := loader.FindModuleRoot(cwd)
+		if findErr != nil {
+			return nil
+		}
+		moduleDir = root
 	}
 	modResult, err := loader.LoadModule(moduleDir)
 	if err != nil {
@@ -307,14 +311,10 @@ func resolveModulePackages(moduleDir string) []*packages.Package {
 	return modResult.Packages
 }
 
-// loadGazeConfigBestEffort loads the GazeConfig from cwd, falling back to
-// the default config on any error.
-func loadGazeConfigBestEffort() *config.GazeConfig {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return config.DefaultConfig()
-	}
-	cfgPath := filepath.Join(cwd, ".gaze.yaml")
+// loadGazeConfigBestEffort loads the GazeConfig from the module root,
+// falling back to the default config on any error.
+func loadGazeConfigBestEffort(moduleDir string) *config.GazeConfig {
+	cfgPath := filepath.Join(moduleDir, ".gaze.yaml")
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
 		return config.DefaultConfig()

--- a/internal/aireport/runner_steps_test.go
+++ b/internal/aireport/runner_steps_test.go
@@ -49,7 +49,7 @@ func TestResolvePackagePaths_EmptyPatterns(t *testing.T) {
 // TestLoadGazeConfigBestEffort_AlwaysNonNil verifies that the function always
 // returns a non-nil config, even in a directory with no .gaze.yaml.
 func TestLoadGazeConfigBestEffort_AlwaysNonNil(t *testing.T) {
-	cfg := loadGazeConfigBestEffort()
+	cfg := loadGazeConfigBestEffort(".")
 	if cfg == nil {
 		t.Error("expected non-nil GazeConfig from loadGazeConfigBestEffort")
 	}

--- a/internal/crap/contract.go
+++ b/internal/crap/contract.go
@@ -6,7 +6,6 @@ package crap
 import (
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -50,7 +49,7 @@ func BuildContractCoverageFunc(
 	}
 
 	// Load config once for all packages.
-	gazeConfig := loadGazeConfigBestEffort()
+	gazeConfig := loadGazeConfigBestEffort(moduleDir)
 
 	// Build coverage map: "shortPkg:qualifiedName" -> coverage info.
 	coverageMap := make(map[string]ContractCoverageInfo)
@@ -79,7 +78,7 @@ func BuildContractCoverageFunc(
 			}
 		}
 
-		reports, degradedPkg := analyzePackageCoverage(pkgPath, gazeConfig, stderr, aiMapperFn...)
+		reports, degradedPkg := analyzePackageCoverage(pkgPath, moduleDir, gazeConfig, stderr, aiMapperFn...)
 		if degradedPkg != "" {
 			degradedPkgs = append(degradedPkgs, degradedPkg)
 		}
@@ -189,6 +188,7 @@ func resolvePackagePaths(patterns []string, moduleDir string) ([]string, error) 
 // mapping when non-nil. It is passed through to quality.Options.AIMapperFunc.
 func analyzePackageCoverage(
 	pkgPath string,
+	moduleDir string,
 	gazeConfig *config.GazeConfig,
 	stderr io.Writer,
 	aiMapperFn ...quality.AIMapperFunc,
@@ -207,7 +207,7 @@ func analyzePackageCoverage(
 	}
 
 	// Step 2: Classify (Spec 002).
-	classified := classifyResults(results, pkgPath, gazeConfig)
+	classified := classifyResults(results, pkgPath, moduleDir, gazeConfig)
 	if classified == nil {
 		return nil, ""
 	}
@@ -242,6 +242,7 @@ func analyzePackageCoverage(
 func classifyResults(
 	results []taxonomy.AnalysisResult,
 	pkgPath string,
+	moduleDir string,
 	cfg *config.GazeConfig,
 ) []taxonomy.AnalysisResult {
 	// Load the target package for AST access.
@@ -251,11 +252,7 @@ func classifyResults(
 	}
 
 	// Load the module for caller/interface analysis.
-	cwd, err := os.Getwd()
-	if err != nil {
-		cwd = ""
-	}
-	modResult, modErr := loader.LoadModule(cwd)
+	modResult, modErr := loader.LoadModule(moduleDir)
 	var modPkgs []*packages.Package
 	if modErr == nil {
 		modPkgs = modResult.Packages
@@ -321,17 +318,13 @@ func loadTestPackage(pkgPath string) (*packages.Package, error) {
 	return nil, fmt.Errorf("no test files found for %q", pkgPath)
 }
 
-// loadGazeConfigBestEffort loads the GazeConfig from cwd, falling
-// back to the default config on any error.
+// loadGazeConfigBestEffort loads the GazeConfig from the module root,
+// falling back to the default config on any error.
 //
 // NOTE: keep in sync with internal/aireport/runner_steps.go:loadGazeConfigBestEffort.
 // Consolidation deferred — see specs/022-report-gazecrap-pipeline/tasks.md.
-func loadGazeConfigBestEffort() *config.GazeConfig {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return config.DefaultConfig()
-	}
-	cfgPath := filepath.Join(cwd, ".gaze.yaml")
+func loadGazeConfigBestEffort(moduleDir string) *config.GazeConfig {
+	cfgPath := filepath.Join(moduleDir, ".gaze.yaml")
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
 		return config.DefaultConfig()

--- a/internal/crap/contract_test.go
+++ b/internal/crap/contract_test.go
@@ -122,6 +122,7 @@ func TestAnalyzePackageCoverage_ValidPackage(t *testing.T) {
 	var stderr bytes.Buffer
 	reports, _ := analyzePackageCoverage(
 		"github.com/unbound-force/gaze/internal/quality/testdata/src/welltested",
+		".",
 		gazeConfig,
 		&stderr,
 	)
@@ -138,6 +139,7 @@ func TestAnalyzePackageCoverage_InvalidPackage(t *testing.T) {
 	var stderr bytes.Buffer
 	reports, _ := analyzePackageCoverage(
 		"github.com/nonexistent/does/not/exist",
+		".",
 		gazeConfig,
 		&stderr,
 	)

--- a/internal/crap/coverage.go
+++ b/internal/crap/coverage.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	"golang.org/x/tools/cover"
+
+	"github.com/unbound-force/gaze/internal/loader"
 )
 
 // FuncCoverage holds the coverage percentage for a single function.
@@ -54,17 +56,28 @@ func ParseCoverProfile(profilePath string, moduleDir string, stderr io.Writer) (
 	}
 
 	if moduleDir == "" {
-		moduleDir, _ = os.Getwd()
+		cwd, _ := os.Getwd()
+		if cwd != "" {
+			if root, err := loader.FindModuleRoot(cwd); err == nil {
+				moduleDir = root
+			}
+		}
 	}
 
 	var results []FuncCoverage
+	var totalEntries, resolvedEntries int
 
 	for _, profile := range profiles {
+		totalEntries++
 		// Resolve the import path to a filesystem path.
 		filePath := resolveFilePath(profile.FileName, moduleDir)
 		if filePath == "" {
+			if stderr != nil {
+				_, _ = fmt.Fprintf(stderr, "warning: skipping profile entry %q: could not resolve to file on disk\n", profile.FileName)
+			}
 			continue
 		}
+		resolvedEntries++
 
 		// Find all functions in this source file.
 		funcs, err := findFunctions(filePath)
@@ -92,6 +105,10 @@ func ParseCoverProfile(profilePath string, moduleDir string, stderr io.Writer) (
 				Percentage:   pct,
 			})
 		}
+	}
+
+	if totalEntries > 0 && resolvedEntries == 0 {
+		return nil, fmt.Errorf("all %d coverage profile entries failed to resolve — check that the profile matches the current module", totalEntries)
 	}
 
 	return results, nil

--- a/internal/crap/crap_test.go
+++ b/internal/crap/crap_test.go
@@ -1559,3 +1559,110 @@ func TestAnalyze_RelativizesFilePaths(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// ParseCoverProfile diagnostic tests (T018-T020)
+// ---------------------------------------------------------------------------
+
+func TestParseCoverProfile_AllUnresolved(t *testing.T) {
+	// Create a temp dir with a valid go.mod so FindModuleRoot succeeds,
+	// but profile entries reference a non-existent module.
+	dir := t.TempDir()
+	gomod := filepath.Join(dir, "go.mod")
+	if err := os.WriteFile(gomod, []byte("module example.com/test\n\ngo 1.24\n"), 0o644); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
+	}
+
+	profileContent := "mode: set\nnonexistent.com/pkg/file.go:1.1,5.2 1 1\n"
+	profilePath := filepath.Join(dir, "cover.out")
+	if err := os.WriteFile(profilePath, []byte(profileContent), 0o644); err != nil {
+		t.Fatalf("writing cover profile: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, err := ParseCoverProfile(profilePath, dir, &buf)
+	if err == nil {
+		t.Fatal("expected error when all profile entries fail to resolve, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to resolve") {
+		t.Errorf("error should mention 'failed to resolve', got: %v", err)
+	}
+}
+
+func TestParseCoverProfile_PartialUnresolved(t *testing.T) {
+	// Create a temp dir with a valid go.mod and one .go file that matches
+	// one profile entry, while a second entry is unresolvable.
+	dir := t.TempDir()
+	gomod := filepath.Join(dir, "go.mod")
+	if err := os.WriteFile(gomod, []byte("module example.com/test\n\ngo 1.24\n"), 0o644); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
+	}
+
+	// Create a Go source file that the first profile entry resolves to.
+	goFile := filepath.Join(dir, "main.go")
+	goSrc := "package main\n\nfunc main() {\n\tprintln(\"hello\")\n}\n"
+	if err := os.WriteFile(goFile, []byte(goSrc), 0o644); err != nil {
+		t.Fatalf("writing main.go: %v", err)
+	}
+
+	profileContent := "mode: set\n" +
+		"example.com/test/main.go:3.13,5.2 1 1\n" +
+		"nonexistent.com/other/file.go:1.1,5.2 1 1\n"
+	profilePath := filepath.Join(dir, "cover.out")
+	if err := os.WriteFile(profilePath, []byte(profileContent), 0o644); err != nil {
+		t.Fatalf("writing cover profile: %v", err)
+	}
+
+	var buf bytes.Buffer
+	results, err := ParseCoverProfile(profilePath, dir, &buf)
+	if err != nil {
+		t.Fatalf("expected no error for partial resolution, got: %v", err)
+	}
+	if len(results) == 0 {
+		t.Error("expected at least one resolved function coverage result")
+	}
+
+	// Stderr should contain a warning about the unresolved entry.
+	stderrOutput := buf.String()
+	if !strings.Contains(stderrOutput, "warning") {
+		t.Errorf("expected warning in stderr, got: %q", stderrOutput)
+	}
+	if !strings.Contains(stderrOutput, "nonexistent.com/other/file.go") {
+		t.Errorf("expected unresolved entry name in stderr, got: %q", stderrOutput)
+	}
+}
+
+func TestParseCoverProfile_WarningContent(t *testing.T) {
+	// Verify the warning message format includes the profile entry filename.
+	dir := t.TempDir()
+	gomod := filepath.Join(dir, "go.mod")
+	if err := os.WriteFile(gomod, []byte("module example.com/test\n\ngo 1.24\n"), 0o644); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
+	}
+
+	// Create a Go source file for the resolvable entry.
+	goFile := filepath.Join(dir, "main.go")
+	goSrc := "package main\n\nfunc main() {\n\tprintln(\"hello\")\n}\n"
+	if err := os.WriteFile(goFile, []byte(goSrc), 0o644); err != nil {
+		t.Fatalf("writing main.go: %v", err)
+	}
+
+	profileContent := "mode: set\n" +
+		"example.com/test/main.go:3.13,5.2 1 1\n" +
+		"bogus.io/missing/handler.go:10.1,20.2 3 0\n"
+	profilePath := filepath.Join(dir, "cover.out")
+	if err := os.WriteFile(profilePath, []byte(profileContent), 0o644); err != nil {
+		t.Fatalf("writing cover profile: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, err := ParseCoverProfile(profilePath, dir, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stderrOutput := buf.String()
+	if !strings.Contains(stderrOutput, "bogus.io/missing/handler.go") {
+		t.Errorf("warning should contain the profile entry filename 'bogus.io/missing/handler.go', got: %q", stderrOutput)
+	}
+}

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -5,6 +5,8 @@ package loader
 import (
 	"fmt"
 	"go/token"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/tools/go/packages"
@@ -120,4 +122,22 @@ func LoadModule(dir string) (*ModuleResult, error) {
 		Packages: valid,
 		Fset:     fset,
 	}, nil
+}
+
+// FindModuleRoot walks up from startDir to find the nearest directory
+// containing a go.mod file (the module root). Returns the directory
+// path or an error if no go.mod is found in startDir or any parent
+// directory up to the filesystem root.
+func FindModuleRoot(startDir string) (string, error) {
+	dir := startDir
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no go.mod found in %q or any parent directory", startDir)
+		}
+		dir = parent
+	}
 }

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -3,6 +3,7 @@ package loader_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/unbound-force/gaze/internal/loader"
@@ -147,5 +148,89 @@ func TestLoadModule_ExcludesBrokenPackages(t *testing.T) {
 	}
 	if !foundValid {
 		t.Error("expected valid package 'example.com/testmod/valid' in result")
+	}
+}
+
+func TestFindModuleRoot_AtRoot(t *testing.T) {
+	dir := t.TempDir()
+	goMod := filepath.Join(dir, "go.mod")
+	if err := os.WriteFile(goMod, []byte("module example.com/test\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
+	}
+
+	got, err := loader.FindModuleRoot(dir)
+	if err != nil {
+		t.Fatalf("FindModuleRoot(%q) returned error: %v", dir, err)
+	}
+	if got != dir {
+		t.Errorf("FindModuleRoot(%q) = %q, want %q", dir, got, dir)
+	}
+}
+
+func TestFindModuleRoot_FromSubdirectory(t *testing.T) {
+	root := t.TempDir()
+	goMod := filepath.Join(root, "go.mod")
+	if err := os.WriteFile(goMod, []byte("module example.com/test\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
+	}
+
+	deepDir := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(deepDir, 0o755); err != nil {
+		t.Fatalf("creating subdirectories: %v", err)
+	}
+
+	got, err := loader.FindModuleRoot(deepDir)
+	if err != nil {
+		t.Fatalf("FindModuleRoot(%q) returned error: %v", deepDir, err)
+	}
+	if got != root {
+		t.Errorf("FindModuleRoot(%q) = %q, want %q", deepDir, got, root)
+	}
+}
+
+func TestFindModuleRoot_NoGoMod(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := loader.FindModuleRoot(dir)
+	if err == nil {
+		t.Fatal("FindModuleRoot() expected error for directory without go.mod, got nil")
+	}
+	if !strings.Contains(err.Error(), "go.mod") {
+		t.Errorf("error message should contain 'go.mod', got: %v", err)
+	}
+}
+
+func TestFindModuleRoot_NestedModules(t *testing.T) {
+	root := t.TempDir()
+
+	// Write go.mod at root level.
+	rootGoMod := filepath.Join(root, "go.mod")
+	if err := os.WriteFile(rootGoMod, []byte("module example.com/root\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("writing root go.mod: %v", err)
+	}
+
+	// Write go.mod in sub/ (nested module).
+	subDir := filepath.Join(root, "sub")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("creating sub dir: %v", err)
+	}
+	subGoMod := filepath.Join(subDir, "go.mod")
+	if err := os.WriteFile(subGoMod, []byte("module example.com/root/sub\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("writing sub go.mod: %v", err)
+	}
+
+	// Create sub/deep/ directory (no go.mod here).
+	deepDir := filepath.Join(subDir, "deep")
+	if err := os.MkdirAll(deepDir, 0o755); err != nil {
+		t.Fatalf("creating deep dir: %v", err)
+	}
+
+	// FindModuleRoot from sub/deep should find sub/ (nearest ancestor), not root.
+	got, err := loader.FindModuleRoot(deepDir)
+	if err != nil {
+		t.Fatalf("FindModuleRoot(%q) returned error: %v", deepDir, err)
+	}
+	if got != subDir {
+		t.Errorf("FindModuleRoot(%q) = %q, want %q (nearest ancestor with go.mod)", deepDir, got, subDir)
 	}
 }

--- a/specs/038-crap-subdir-coverage/checklists/requirements.md
+++ b/specs/038-crap-subdir-coverage/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Fix Zero Coverage When Running from Subdirectory
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. The spec is well-defined due to the detailed upstream bug report (issue #113) with exact reproduction steps and the comprehensive review council analysis from jflowers identifying the full scope of affected call sites.
+- The spec references specific file locations (e.g., `cmd/gaze/main.go:703`) in the Upstream Analysis section only — these document the bug diagnosis, not implementation decisions. The Requirements and Success Criteria sections remain technology-agnostic.
+- FR-010 mentions "extracted to a shared, testable location" — this describes the behavioral requirement (shared and testable) without prescribing specific package placement.
+- FR-011 lists specific call sites — these are part of the bug scope analysis, not implementation instructions. The requirement is "all internal call sites using cwd as module root must be updated."
+- FR-012 references a specific test name — this is part of the bug documentation (the test codifies incorrect behavior). The requirement is that the test contract must be corrected.

--- a/specs/038-crap-subdir-coverage/data-model.md
+++ b/specs/038-crap-subdir-coverage/data-model.md
@@ -1,0 +1,79 @@
+# Data Model: Fix Zero Coverage When Running from Subdirectory
+
+**Feature**: 038-crap-subdir-coverage
+**Date**: 2026-06-22
+
+## Overview
+
+This feature introduces no new data types or entities. It refactors the module root discovery pattern from an implicit assumption (cwd = module root) to an explicit function call (`loader.FindModuleRoot`). The change affects function signatures and data flow, not data structures.
+
+## Function Signature Changes
+
+### New Function
+
+```
+FindModuleRoot(startDir string) (string, error)
+```
+
+- **Package**: `internal/loader`
+- **Input**: `startDir` — the directory to start walking up from (typically `os.Getwd()` result)
+- **Output**: Absolute path to the nearest ancestor directory containing `go.mod`, or error if none found
+- **Error cases**: No `go.mod` found in `startDir` or any ancestor up to filesystem root
+
+### Modified Signatures
+
+#### `classifyResults` (internal/crap/contract.go)
+
+**Before**: `func classifyResults(results []taxonomy.AnalysisResult, pkgPath string, cfg *config.GazeConfig) []taxonomy.AnalysisResult`
+
+**After**: `func classifyResults(results []taxonomy.AnalysisResult, pkgPath string, moduleDir string, cfg *config.GazeConfig) []taxonomy.AnalysisResult`
+
+Added `moduleDir` parameter to replace internal `os.Getwd()` call.
+
+#### `loadGazeConfigBestEffort` (internal/crap/contract.go)
+
+**Before**: `func loadGazeConfigBestEffort() *config.GazeConfig`
+
+**After**: `func loadGazeConfigBestEffort(moduleDir string) *config.GazeConfig`
+
+Adopts the same signature as the `cmd/gaze/main.go` version.
+
+#### `loadGazeConfigBestEffort` (internal/aireport/runner_steps.go)
+
+**Before**: `func loadGazeConfigBestEffort() *config.GazeConfig`
+
+**After**: `func loadGazeConfigBestEffort(moduleDir string) *config.GazeConfig`
+
+Same change as above. The `NOTE: keep in sync` comment should be preserved or the two copies consolidated.
+
+### Data Flow Changes
+
+#### `gaze crap` command flow
+
+```
+Before:  os.Getwd() → moduleDir → crap.Analyze / BuildContractCoverageFunc
+After:   os.Getwd() → loader.FindModuleRoot(cwd) → moduleDir → crap.Analyze / BuildContractCoverageFunc
+```
+
+#### `gaze report` command flow
+
+```
+Before:  os.Getwd() → cwd → RunnerOptions.ModuleDir → pipeline steps
+After:   os.Getwd() → loader.FindModuleRoot(cwd) → moduleDir → RunnerOptions.ModuleDir → pipeline steps
+```
+
+#### `ParseCoverProfile` diagnostics (new)
+
+```
+Before:  resolveFilePath returns "" → silently skipped
+After:   resolveFilePath returns "" → warning to stderr + counter tracked
+         After loop: if resolved == 0 && total > 0 → return error
+```
+
+## Unchanged Entities
+
+- `crap.Report`, `crap.Score`, `crap.Summary` — no field changes
+- `taxonomy.AnalysisResult`, `taxonomy.PackageSummary` — no field changes
+- `aireport.RunnerOptions` — `ModuleDir` field already exists, just receives correct value
+- `aireport.ReportSummary` — no field changes
+- `config.GazeConfig` — no field changes

--- a/specs/038-crap-subdir-coverage/plan.md
+++ b/specs/038-crap-subdir-coverage/plan.md
@@ -1,0 +1,195 @@
+# Implementation Plan: Fix Zero Coverage When Running from Subdirectory
+
+**Branch**: `038-crap-subdir-coverage` | **Date**: 2026-06-22 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/038-crap-subdir-coverage/spec.md`
+
+## Summary
+
+`gaze crap` and `gaze report` assume the current working directory is the Go module root when resolving coverage profile paths, loading configuration, and loading module packages. When invoked from a subdirectory, `go.mod` is not found, causing all coverage to be silently dropped (0% everywhere, inflated CRAP scores, exit 0). The fix extracts a shared `loader.FindModuleRoot(startDir)` function that walks up to find the nearest `go.mod`, replaces 9 `os.Getwd()` call sites with the correct module root, and adds stderr diagnostics for unresolved coverage profile entries.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+ (per `go.mod` directive)
+**Primary Dependencies**: `golang.org/x/tools/go/packages` (existing), standard library (`os`, `path/filepath`)
+**Storage**: N/A — no persistence changes
+**Testing**: Standard library `testing` package, `-race -count=1`
+**Target Platform**: Linux/macOS (cross-platform, no platform-specific code)
+**Project Type**: Single CLI binary with layered internal packages
+**Performance Goals**: `FindModuleRoot` must complete in <1ms (filesystem stat walk)
+**Constraints**: No new external dependencies; no breaking API changes
+**Scale/Scope**: 9 call sites across 4 files, 1 new function, ~50 lines of new code + ~100 lines of tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Research Gate (Phase 0)
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| **I. Accuracy** | PASS | This fix directly restores accuracy — eliminates false 0% coverage reports. Regression tests will verify correct coverage from subdirectories. |
+| **II. Minimal Assumptions** | PASS | Removes the undocumented assumption that cwd = module root. The tool will now work from any directory within a module without user action. |
+| **III. Actionable Output** | PASS | Adds stderr diagnostics for unresolved profile entries and error for 0/N resolution. Metrics become comparable across runs regardless of cwd. |
+| **IV. Testability** | PASS | `FindModuleRoot(startDir)` is pure (no internal `os.Getwd()`), testable with temp directories. Coverage strategy specified below. |
+
+### Post-Design Gate (Phase 1)
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| **I. Accuracy** | PASS | `FindModuleRoot` walks up to the correct `go.mod`, ensuring `resolveFilePath` receives the right module path. Defense-in-depth: 0/N error catches any remaining resolution failure. |
+| **II. Minimal Assumptions** | PASS | The only assumption is that `go.mod` exists somewhere in an ancestor directory — this is the Go module system's own requirement. When it doesn't exist, a clear error is returned. |
+| **III. Actionable Output** | PASS | Stderr warnings identify specific unresolved profile entries. The 0/N error message suggests checking that the profile matches the current module. |
+| **IV. Testability** | PASS | All new code is testable in isolation. `FindModuleRoot` takes `startDir` parameter. `ParseCoverProfile` already accepts `stderr io.Writer` for test capture. Coverage strategy: unit tests for `FindModuleRoot` (all branches), unit tests for `ParseCoverProfile` diagnostics, integration test for subdirectory invocation. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/038-crap-subdir-coverage/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output — research decisions
+├── data-model.md        # Phase 1 output — signature changes
+├── quickstart.md        # Phase 1 output — verification guide
+├── checklists/
+│   └── requirements.md  # Specification quality checklist
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+internal/
+  loader/
+    loader.go            # ADD FindModuleRoot(startDir) function
+    loader_test.go       # ADD FindModuleRoot unit tests
+  crap/
+    coverage.go          # MODIFY ParseCoverProfile — add diagnostics
+    contract.go          # MODIFY classifyResults, loadGazeConfigBestEffort — add moduleDir param
+    crap_test.go         # MODIFY TestResolveFilePath_NoGoMod, ADD diagnostic tests
+  aireport/
+    runner_steps.go      # MODIFY resolveModulePackages, loadGazeConfigBestEffort — use moduleDir
+cmd/
+  gaze/
+    main.go              # MODIFY newCrapCmd, runReport, runClassify, loadConfig — use FindModuleRoot
+                         # DELETE findModuleRoot (replaced by loader.FindModuleRoot)
+```
+
+**Structure Decision**: No new packages or directories. All changes fit within existing package boundaries. `FindModuleRoot` is added to `internal/loader` (its natural home alongside `Load` and `LoadModule`).
+
+## Design Decisions
+
+### D1: Function Placement
+
+`FindModuleRoot(startDir string) (string, error)` lives in `internal/loader/loader.go`. See [research.md](research.md) R2 for rationale and alternatives considered.
+
+### D2: Signature Change Strategy
+
+Internal functions that called `os.Getwd()` as a module root proxy gain a `moduleDir string` parameter. The `os.Getwd() → FindModuleRoot(cwd)` resolution happens once at the CLI entry point (command RunE closures), and the result flows down through the call chain. This is the "push cwd resolution to the edge" pattern — internal packages never call `os.Getwd()` for module root resolution.
+
+### D3: Diagnostic Strategy
+
+Two levels of diagnostics in `ParseCoverProfile`:
+1. **Per-entry warning** (stderr): `warning: skipping profile entry %q: could not resolve to file on disk`
+2. **Aggregate error** (return value): When 0/N entries resolve, return `fmt.Errorf("all %d coverage profile entries failed to resolve — check that the profile matches the current module", totalEntries)`
+
+### D4: Error vs Warning Threshold
+
+0/N resolved = error (hard stop). 1+/N resolved = warnings only (partial results may still be useful — e.g., some packages were removed since the profile was generated). This matches the existing `findFunctions` pattern in `ParseCoverProfile` where individual file parse errors are warnings, not fatal.
+
+### D5: `loadGazeConfigBestEffort` Consolidation
+
+The three copies are reduced to two with matching signatures. Full consolidation into a single shared function would require moving it to a shared package (e.g., `internal/config`) or making it a method — deferred to avoid scope creep. The immediate fix is ensuring both internal copies accept `moduleDir` as a parameter instead of calling `os.Getwd()`.
+
+## Implementation Phases
+
+### Phase 1: Core Function + Unit Tests
+
+**Files**: `internal/loader/loader.go`, `internal/loader/loader_test.go`
+
+1. Add `FindModuleRoot(startDir string) (string, error)` to `internal/loader/loader.go`
+   - Walk up from `startDir`, checking for `go.mod` at each level
+   - Stop at filesystem root (`filepath.Dir(dir) == dir`)
+   - Return error: `no go.mod found in %q or any parent directory`
+2. Add unit tests in `internal/loader/loader_test.go`:
+   - `TestFindModuleRoot_AtRoot` — `go.mod` in starting directory
+   - `TestFindModuleRoot_FromSubdirectory` — walks up 1-3 levels
+   - `TestFindModuleRoot_NoGoMod` — returns error
+   - `TestFindModuleRoot_NestedModules` — finds nearest (not deepest)
+
+**FR coverage**: FR-001, FR-005, FR-006, FR-010
+
+### Phase 2: ParseCoverProfile Diagnostics
+
+**Files**: `internal/crap/coverage.go`, `internal/crap/crap_test.go`
+
+1. Add warning when `resolveFilePath` returns `""` in `ParseCoverProfile`
+2. Add 0/N resolution error after the profile loop
+3. Replace `os.Getwd()` fallback in `ParseCoverProfile` with `FindModuleRoot`
+4. Update `TestResolveFilePath_NoGoMod` — verify it still tests the correct contract
+5. Add `TestParseCoverProfile_AllUnresolved` — 0/N returns error
+6. Add `TestParseCoverProfile_PartialUnresolved` — warns but succeeds
+7. Add `TestParseCoverProfile_WarningOutput` — verify stderr content
+
+**FR coverage**: FR-008, FR-009, FR-012
+
+### Phase 3: Internal Package Call Site Updates
+
+**Files**: `internal/crap/contract.go`, `internal/aireport/runner_steps.go`
+
+1. `classifyResults` — add `moduleDir string` parameter, pass to `loader.LoadModule(moduleDir)` instead of `os.Getwd()`
+2. `loadGazeConfigBestEffort` in `contract.go` — add `moduleDir string` parameter
+3. `loadGazeConfigBestEffort` in `runner_steps.go` — add `moduleDir string` parameter
+4. `resolveModulePackages` in `runner_steps.go` — replace `os.Getwd()` fallback with `loader.FindModuleRoot`
+5. Update all callers of these modified functions to pass `moduleDir`
+6. Verify `BuildContractCoverageFunc` already receives `moduleDir` and threads it correctly
+
+**FR coverage**: FR-007, FR-011
+
+### Phase 4: CLI Entry Point Updates
+
+**Files**: `cmd/gaze/main.go`
+
+1. `newCrapCmd` RunE (line 703) — replace `os.Getwd()` with `loader.FindModuleRoot(cwd)`
+2. `runReport` (line 1329) — replace `os.Getwd()` with `loader.FindModuleRoot(cwd)`
+3. `runClassify` (line 291) — replace `os.Getwd()` with `loader.FindModuleRoot(cwd)`
+4. `loadConfig` (line 148) — replace `os.Getwd()` with `loader.FindModuleRoot(cwd)`
+5. Delete `findModuleRoot()` (line 1168) — replaced by `loader.FindModuleRoot`
+6. Update `runSelfCheck` to use `loader.FindModuleRoot` via `selfCheckParams.moduleRootFunc`
+
+**FR coverage**: FR-002, FR-003, FR-004
+
+### Phase 5: Integration Tests + Regression Verification
+
+1. Run `go test -race -count=1 -short ./...` — verify all existing tests pass
+2. Run `go build ./cmd/gaze` — verify build succeeds
+3. Run `golangci-lint run` — verify no lint issues
+4. Manual verification: `gaze crap ./...` from module root (regression check)
+
+**FR coverage**: FR-005, SC-004
+
+## Coverage Strategy
+
+| Component | Test Type | Coverage Target |
+|-----------|-----------|----------------|
+| `loader.FindModuleRoot` | Unit (temp dirs) | 100% branch — all 4 paths (at root, walk up, no module, nested) |
+| `ParseCoverProfile` diagnostics | Unit (synthetic profiles) | 100% — 0/N error, partial warn, all resolved |
+| `classifyResults` moduleDir param | Existing tests + param update | Existing coverage maintained |
+| `loadGazeConfigBestEffort` param | Existing tests + param update | Existing coverage maintained |
+| CLI entry points | Integration (existing e2e) | Covered by existing `TestRunSelfCheck` and unit tests |
+| Subdirectory invocation | Integration | New: verify SC-001 (subdirectory = same results as root) |
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Signature changes break callers | Low | Medium | All callers are internal; compiler catches missing args |
+| `FindModuleRoot` walk hits symlink loops | Very Low | Low | `filepath.Dir` handles symlinks; Go's `os.Stat` follows them |
+| 0/N error is too aggressive | Low | Medium | Only triggers when ALL entries fail; partial resolution still succeeds with warnings |
+| Nested module edge case | Low | Low | `FindModuleRoot` returns nearest, which is correct for the user's cwd context |
+| Performance regression from walk | Very Low | Very Low | Walk is <1ms even at 50 levels; happens once per command invocation |
+
+## Complexity Tracking
+
+No constitution violations requiring justification. All principles pass in both pre-research and post-design gates.

--- a/specs/038-crap-subdir-coverage/quickstart.md
+++ b/specs/038-crap-subdir-coverage/quickstart.md
@@ -1,0 +1,47 @@
+# Quickstart: Fix Zero Coverage When Running from Subdirectory
+
+**Feature**: 038-crap-subdir-coverage
+**Date**: 2026-06-22
+
+## What This Fixes
+
+Running `gaze crap` or `gaze report` from a subdirectory of a Go module silently drops all coverage data. Every function shows 0% coverage and CRAP scores are maximally inflated — with no warning and exit code 0.
+
+## After This Fix
+
+```bash
+# Both commands produce the same correct output:
+cd <module-root> && gaze crap ./...    # works (always worked)
+cd <module-root>/sub && gaze crap ./...  # now also works correctly
+
+# Clear error when outside any Go module:
+cd /tmp && gaze crap ./...
+# Error: no go.mod found in "/tmp" or any parent directory
+```
+
+## Key Changes
+
+1. **Module root auto-discovery**: `gaze crap` and `gaze report` walk up from the current directory to find the nearest `go.mod`, instead of assuming cwd is the module root.
+
+2. **Diagnostic warnings**: When coverage profile entries cannot be resolved to files on disk, warnings appear on stderr. When zero entries resolve, the tool returns an error.
+
+3. **Config resolution**: `.gaze.yaml` and `.gaze/baseline.json` are resolved from the discovered module root, not from cwd.
+
+## Verification
+
+```bash
+# From module root (baseline — should be unchanged):
+gaze crap ./...
+
+# From a subdirectory (was broken, now fixed):
+cd internal/crap && gaze crap ./...
+
+# Compare: coverage values should match for the same functions
+```
+
+## Implementation Scope
+
+- New shared function `loader.FindModuleRoot(startDir)` in `internal/loader/`
+- Updated 9 call sites across `cmd/gaze/main.go`, `internal/crap/contract.go`, `internal/aireport/runner_steps.go`, and `internal/crap/coverage.go`
+- Added stderr diagnostics for unresolved coverage profile entries
+- No new CLI flags, no new output fields, no breaking changes

--- a/specs/038-crap-subdir-coverage/research.md
+++ b/specs/038-crap-subdir-coverage/research.md
@@ -1,0 +1,110 @@
+# Research: Fix Zero Coverage When Running from Subdirectory
+
+**Feature**: 038-crap-subdir-coverage
+**Date**: 2026-06-22
+
+## R1: Module Root Discovery Approach
+
+**Decision**: Walk up from the current working directory to find the nearest `go.mod` file.
+
+**Rationale**: This approach is already proven in the codebase (`findModuleRoot` in `cmd/gaze/main.go:1168`, test helper in `internal/loader/loader_test.go:36`). It is deterministic, runs in 5-50us, and requires only `os.Stat` calls — no subprocess execution.
+
+**Alternatives considered**:
+- `go/packages` with `packages.NeedModule`: Spawns a `go list` subprocess, adds 100-500ms latency per call. Overkill for finding a file that can be located with a simple directory walk. Rejected unanimously by review council.
+- `go list -m -json`: Same subprocess overhead, plus requires parsing JSON output. No benefit over walking.
+- `go env GOMOD`: Single subprocess call, lighter than `go/packages`, but still orders of magnitude slower than a filesystem walk. Also cannot distinguish "no go.mod" from "go.mod exists but env is not set."
+
+## R2: Where to Place the Shared Function
+
+**Decision**: Add `FindModuleRoot(startDir string) (string, error)` to `internal/loader/loader.go`.
+
+**Rationale**:
+- `internal/loader` already wraps `go/packages` and owns `LoadModule(dir string)` — the primary consumer of the module root directory.
+- The function has zero external dependencies (only `os` and `path/filepath`).
+- A test-only version already exists in `internal/loader/loader_test.go:36-53` with identical logic.
+- The production version in `cmd/gaze/main.go:1168` (`findModuleRoot`) can be replaced with a call to `loader.FindModuleRoot(cwd)`.
+
+**Alternatives considered**:
+- New package `internal/modroot`: Too much ceremony for a single function. Creates an unnecessary package boundary.
+- Keep in `cmd/gaze/main.go`: Already there, but forces `internal/crap/contract.go` and `internal/aireport/runner_steps.go` to either duplicate the logic or import the `cmd` package (which is architecturally wrong — internal packages cannot import cmd packages).
+- `internal/crap/coverage.go`: Too narrow — the function is needed by packages beyond `crap`.
+
+## R3: Complete Inventory of Affected Call Sites
+
+**Decision**: 10 call sites use `os.Getwd()` as a proxy for the module root. 9 must be fixed; 1 (`scaffold.go`) is correct as-is.
+
+| # | File:Line | Function | Impact | Fix Strategy |
+|---|-----------|----------|--------|-------------|
+| 1 | `cmd/gaze/main.go:703` | `newCrapCmd` RunE | PRIMARY BUG — moduleDir = cwd | Replace with `loader.FindModuleRoot(cwd)` |
+| 2 | `cmd/gaze/main.go:1329` | `runReport` | Same bug — ModuleDir = cwd | Replace with `loader.FindModuleRoot(cwd)` |
+| 3 | `cmd/gaze/main.go:291` | `runClassify` | Classification degrades silently | Replace with `loader.FindModuleRoot(cwd)` |
+| 4 | `cmd/gaze/main.go:148` | `loadConfig` | Config not found, silent fallback | Replace with `loader.FindModuleRoot(cwd)` |
+| 5 | `internal/crap/contract.go:254` | `classifyResults` | Module loading from cwd | Add `moduleDir` parameter |
+| 6 | `internal/crap/contract.go:330` | `loadGazeConfigBestEffort` | Config not found from subdirectory | Add `moduleDir` parameter (like `cmd/gaze/main.go:628`) |
+| 7 | `internal/aireport/runner_steps.go:298` | `resolveModulePackages` | Fallback to cwd when empty | Replace fallback with `loader.FindModuleRoot` |
+| 8 | `internal/aireport/runner_steps.go:313` | `loadGazeConfigBestEffort` | Duplicate of #6 | Add `moduleDir` parameter (consolidate with #6) |
+| 9 | `internal/crap/coverage.go:57` | `ParseCoverProfile` | Fallback to cwd when empty | Replace fallback with `loader.FindModuleRoot` |
+| 10 | `internal/scaffold/scaffold.go:159` | `applyDefaults` | NOT A BUG — cwd is correct target | No change needed |
+
+## R4: `loadGazeConfigBestEffort` Duplication
+
+**Decision**: Consolidate the three versions by adopting the `cmd/gaze/main.go:628` signature pattern (takes `moduleDir` as parameter) for all call sites.
+
+**Current state**:
+- `cmd/gaze/main.go:628`: `func loadGazeConfigBestEffort(moduleDir string) *config.GazeConfig` — correct pattern, takes dir as param
+- `internal/crap/contract.go:329`: `func loadGazeConfigBestEffort() *config.GazeConfig` — calls `os.Getwd()` internally
+- `internal/aireport/runner_steps.go:312`: `func loadGazeConfigBestEffort() *config.GazeConfig` — calls `os.Getwd()` internally
+
+Both internal copies have `NOTE: keep in sync` comments acknowledging the duplication (deferred from spec 022).
+
+**Rationale**: The `cmd/gaze/main.go` version is the only correct pattern — it accepts the module directory as a parameter, making it testable and immune to cwd issues. The internal copies must adopt the same parameter. Full consolidation into a single shared function is desirable but may require a shared package location; at minimum, both copies must accept `moduleDir` as a parameter.
+
+## R5: Silent Failure Defense-in-Depth
+
+**Decision**: Add two levels of diagnostics to `ParseCoverProfile`:
+1. Per-entry warning when `resolveFilePath` returns `""` (to stderr, respecting the existing nil-check pattern)
+2. Error return when 0/N profile entries resolve successfully
+
+**Rationale**: Even with the module root walk-up fix, other scenarios can trigger silent 0% coverage: corrupted profile, stale profile from a different module, wrong working directory outside any module. The 0/N case is almost certainly a configuration error, not "legitimately zero coverage." Existing callers already pass `stderr` to `ParseCoverProfile` for other warnings.
+
+**Design**:
+- Track `totalEntries` and `resolvedEntries` counters in the `ParseCoverProfile` loop.
+- When `resolveFilePath` returns `""`, write `warning: skipping profile entry %q: could not resolve to file on disk` to stderr (only if stderr is non-nil).
+- After the loop, if `totalEntries > 0 && resolvedEntries == 0`, return an error: `all %d coverage profile entries failed to resolve — check that the profile matches the current module`.
+
+## R6: Existing Test Update
+
+**Decision**: Update `TestResolveFilePath_NoGoMod` to test the correct contract: "outside any module" should return `""`, while "subdirectory of a module" should resolve correctly via module root walk-up.
+
+**Current test** (`internal/crap/crap_test.go:752-758`):
+```go
+func TestResolveFilePath_NoGoMod(t *testing.T) {
+    dir := t.TempDir()
+    got := resolveFilePath("example.com/test/foo.go", dir)
+    if got != "" {
+        t.Errorf("expected empty string without go.mod, got %q", got)
+    }
+}
+```
+
+This test creates a temp directory with no `go.mod` and asserts that `resolveFilePath` returns `""`. This correctly tests the "outside any module" case. However, `resolveFilePath` currently does not walk up — it only reads `go.mod` from the given `moduleDir`. After the fix, `resolveFilePath` will receive the module root (found by `FindModuleRoot`), so this test still makes sense: a directory with no `go.mod` and no ancestors with `go.mod` should return `""`.
+
+The new tests needed are:
+1. `TestFindModuleRoot_FromSubdirectory` — walks up and finds `go.mod`
+2. `TestFindModuleRoot_NoGoMod` — returns error when no `go.mod` in any ancestor
+3. `TestFindModuleRoot_AtRoot` — finds `go.mod` in the starting directory (no walk)
+4. `TestParseCoverProfile_AllUnresolved` — returns error when 0/N entries resolve
+5. `TestParseCoverProfile_PartialUnresolved` — warns but succeeds when some resolve
+
+## R7: Coverage Strategy
+
+**Decision**: Unit tests for the new `FindModuleRoot` function and the `ParseCoverProfile` diagnostics. Integration test for the end-to-end subdirectory invocation path.
+
+| Layer | What | Target |
+|-------|------|--------|
+| Unit | `loader.FindModuleRoot` — walk up, at root, no module, nested modules | 100% branch coverage |
+| Unit | `ParseCoverProfile` — 0/N error, partial warnings, all resolved | All three paths |
+| Unit | Updated `TestResolveFilePath_NoGoMod` — contract boundary | Existing test updated |
+| Integration | `gaze crap ./...` from subdirectory vs root — same results | SC-001 |
+| Integration | `gaze report ./... --format=json` from subdirectory | SC-002 |
+| Integration | `gaze crap ./...` from outside any module | SC-003 |

--- a/specs/038-crap-subdir-coverage/spec.md
+++ b/specs/038-crap-subdir-coverage/spec.md
@@ -1,0 +1,191 @@
+# Feature Specification: Fix Zero Coverage When Running from Subdirectory
+
+**Feature Branch**: `038-crap-subdir-coverage`
+**Created**: 2026-06-22
+**Status**: Draft
+**Input**: User description: "based on issue 113 of the original repository where the fork was created from"
+**Upstream Issue**: unbound-force/gaze#113
+
+## Upstream Analysis
+
+### Bug Report (issue author)
+
+`gaze crap` resolves the import-path-relative filenames in a coverage profile to
+on-disk files by reading `go.mod` from `moduleDir`, where `moduleDir` is the
+current working directory. When `crap` is invoked from a **subdirectory** of the
+module (which has no `go.mod`), `readModulePath` returns `""`, `resolveFilePath`
+returns `""` for every profile entry, and all coverage is dropped. Every function
+reads 0% and CRAP is maximally inflated — with a normal-looking report and exit 0.
+
+**Reproduction:**
+
+```
+$ cd <module-root> && gaze crap ./... | grep -E 'G|COVERAGE'
+│CRAP│COMPLEXITY│COVERAGE│FUNCTION│FILE      │
+│2.1 │2         │66.7%   │G       │sub/s.go:4│      # correct
+
+$ cd sub && gaze crap ./... | grep -E 'G|COVERAGE'
+│CRAP│COMPLEXITY│COVERAGE│FUNCTION│FILE  │
+│6.0 │2         │0.0%    │G       │s.go:4│          # coverage silently dropped
+```
+
+### Review Council Analysis (jflowers)
+
+**Verdict: Valid bug, CRITICAL severity.** Five review council agents (Adversary, Architect, Guard, SRE, Testing) converged on five problems with the original suggested fix:
+
+#### 1. Scope is underestimated (~4x)
+
+The issue frames this as a `gaze crap` bug. It also affects `gaze report` and several internal call sites that use `os.Getwd()` where they should use the module root:
+
+| Location | Impact |
+|----------|--------|
+| `cmd/gaze/main.go:703` (crap command) | **PRIMARY BUG** — moduleDir from os.Getwd() |
+| `cmd/gaze/main.go:1329` (report command) | **Same bug** — cwd used as ModuleDir |
+| `internal/crap/contract.go:254` (classifyResults) | Classification degraded — module loading from cwd |
+| `internal/crap/contract.go:330` (loadGazeConfigBestEffort) | Config not found from subdirectory |
+| `internal/aireport/runner_steps.go:298,313` | Module loading + config — fallback to os.Getwd() |
+
+#### 2. The silence problem is not addressed
+
+The walk-upward fix corrects the *wrong numbers* but does not fix the *silence*. The entire failure chain is silent:
+
+- `readModulePath` returns `""` — no warning
+- `resolveFilePath` returns `""` — no warning
+- `ParseCoverProfile` silently skips unresolved entries (`continue` at line 65-66)
+- `Analyze` returns a report with 0% coverage and `nil` error
+- Exit code 0
+
+Defense-in-depth is needed: warn when `resolveFilePath` fails for individual entries, and error when *all* profile entries fail to resolve (0/N resolved is almost certainly a configuration error, not "no coverage").
+
+#### 3. The `go/packages` alternative should be rejected
+
+Walk-upward is 5-50us vs `go/packages` at 100-500ms (subprocess spawn). The walk already exists as `findModuleRoot` and is proven by `self-check`.
+
+#### 4. `findModuleRoot` should be refactored for testability
+
+The current `findModuleRoot()` calls `os.Getwd()` internally, making it untestable without `os.Chdir` (process-global, race-unsafe). It should be split into `findModuleRootFrom(startDir)` + a thin wrapper.
+
+#### 5. Existing test codifies the bug as correct
+
+`TestResolveFilePath_NoGoMod` (`crap_test.go:752-758`) asserts the buggy behavior is expected — it verifies `resolveFilePath` returns `""` when `go.mod` is absent. This test must be updated to distinguish "subdirectory of a module" from "outside any module."
+
+#### Constitutional Violations
+
+| Principle | Violation |
+|-----------|-----------|
+| **Accuracy** | Reports 0% coverage when actual coverage may be 80%+ |
+| **Minimal Assumptions** | Assumes CWD is module root — undocumented, unenforced, silently ignored when wrong |
+| **Actionable Output** | Guides user toward writing tests that already exist; metrics not comparable across runs |
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Accurate Coverage from Any Directory (Priority: P1)
+
+A developer working in a Go module runs `gaze crap` from a subdirectory (e.g., `cd pkg/server && gaze crap ./...`) and expects the same CRAP scores and coverage percentages as running from the module root. Today, running from a subdirectory silently drops all coverage data, inflating CRAP scores to their maximum values with no warning — producing confidently wrong output.
+
+**Why this priority**: This is the core bug. Users get incorrect, misleading output with no indication that anything is wrong. It violates three of four constitutional principles simultaneously.
+
+**Independent Test**: Can be fully tested by running `gaze crap ./...` from both the module root and a subdirectory, verifying that coverage percentages and CRAP scores match for the same functions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Go module with tests providing 66.7% coverage on function `G`, **When** the user runs `gaze crap ./...` from a subdirectory within that module, **Then** the reported coverage for `G` is 66.7% (same as from the root).
+2. **Given** a Go module with a `go.mod` at the root, **When** the user runs `gaze crap ./...` from any nested subdirectory at any depth, **Then** the tool locates the module root automatically and resolves all coverage profile paths correctly.
+3. **Given** a Go module with tests, **When** `gaze crap` is run from the module root, **Then** the behavior is identical to the current behavior (no regression).
+
+---
+
+### User Story 2 - Accurate Report Output from Any Directory (Priority: P2)
+
+A developer or CI pipeline runs `gaze report` from a subdirectory and expects the same quality analysis results as running from the module root. The report pipeline shares the same coverage resolution path as `gaze crap`, so the same bug applies.
+
+**Why this priority**: `gaze report` is the primary CI integration point. Silent data loss in CI produces misleading quality gates that either pass when they should fail or produce inflated CRAPload numbers.
+
+**Independent Test**: Can be tested by running `gaze report ./... --format=json` from both the module root and a subdirectory, verifying the CRAP scores and coverage values in the JSON payload match.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Go module with tests, **When** the user runs `gaze report ./... --format=json` from a subdirectory, **Then** the CRAP scores and coverage percentages in the report match those produced from the module root.
+2. **Given** a CI pipeline that changes to a subdirectory before running `gaze report`, **When** the report executes, **Then** threshold checks (`--max-crapload`, `--max-gaze-crapload`, `--min-contract-coverage`) evaluate against correct coverage data.
+
+---
+
+### User Story 3 - Silent Failure Prevention (Priority: P2)
+
+When coverage profile path resolution fails — whether due to missing `go.mod`, corrupted profile, or wrong module — the tool provides diagnostic feedback instead of silently producing zero-coverage results.
+
+**Why this priority**: Even after fixing the walk-up, other scenarios can trigger silent 0% coverage. Defense-in-depth prevents future silent failures from any cause.
+
+**Independent Test**: Can be tested by providing a coverage profile with entries that cannot be resolved and verifying that warnings appear on stderr and/or an error is returned when all entries fail.
+
+**Acceptance Scenarios**:
+
+1. **Given** a coverage profile where some entries cannot be resolved to files on disk, **When** the tool processes the profile, **Then** a warning is written to stderr for each unresolved entry.
+2. **Given** a coverage profile where zero out of N entries resolve successfully, **When** the tool processes the profile, **Then** an error is returned (not a silent zero-coverage report).
+
+---
+
+### User Story 4 - Clear Error When No Module Root Found (Priority: P3)
+
+A user runs `gaze crap` from a directory that is not inside any Go module (no `go.mod` exists in any ancestor directory). Instead of silently producing zero-coverage results, the tool should produce a clear error message.
+
+**Why this priority**: Edge case, but the current behavior (silent 0% with exit 0) is the worst possible outcome.
+
+**Independent Test**: Can be tested by running `gaze crap ./...` from a directory with no `go.mod` in any ancestor and verifying that a descriptive error is returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** a directory with no `go.mod` in the current directory or any ancestor, **When** the user runs `gaze crap ./...`, **Then** the tool exits with a non-zero exit code and an error message indicating that no Go module root was found.
+
+---
+
+### Edge Cases
+
+- What happens when the module root is at the filesystem root (`/`)?
+- What happens when `go.mod` exists in the current directory (no walk-up needed)? This must continue to work identically to current behavior.
+- What happens when there are nested `go.mod` files (a module within a module)? The nearest ancestor `go.mod` should be used.
+- What happens when `go.mod` is unreadable (permission denied)? The tool should return a clear error rather than silently proceeding with zero coverage.
+- What happens when multiple coverage profiles reference different modules? Only the enclosing module's profile entries should resolve.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The tool MUST locate the nearest ancestor directory containing a `go.mod` file when resolving the module root, rather than assuming the current working directory is the module root.
+- **FR-002**: When running `gaze crap` from any subdirectory within a Go module, the tool MUST produce the same coverage percentages and CRAP scores as when running from the module root.
+- **FR-003**: When running `gaze report` from any subdirectory within a Go module, the tool MUST produce the same coverage data, CRAP scores, and threshold evaluations as when running from the module root.
+- **FR-004**: When no `go.mod` file is found in the current directory or any ancestor directory (up to the filesystem root), the tool MUST exit with a non-zero exit code and a descriptive error message.
+- **FR-005**: When `go.mod` exists in the current working directory (the common case today), the tool MUST behave identically to its current behavior — no regression.
+- **FR-006**: The tool MUST use the nearest ancestor `go.mod` when nested modules exist.
+- **FR-007**: Configuration files (`.gaze.yaml`, `.gaze/baseline.json`) MUST be resolved relative to the discovered module root, not relative to the current working directory.
+- **FR-008**: When individual coverage profile entries fail to resolve to files on disk, a warning MUST be written to stderr identifying the unresolved entry.
+- **FR-009**: When zero out of N coverage profile entries resolve successfully, the tool MUST return an error rather than producing a silent zero-coverage report.
+- **FR-010**: The module-root-finding function MUST be extracted to a shared, testable location and accept a starting directory parameter for testability.
+- **FR-011**: All internal call sites that use `os.Getwd()` as a proxy for the module root MUST be updated to use the shared module-root-finding function. This includes `internal/crap/contract.go` (classifyResults, loadGazeConfigBestEffort) and `internal/aireport/runner_steps.go` (resolveModulePackages, loadGazeConfigBestEffort).
+- **FR-012**: The existing `TestResolveFilePath_NoGoMod` test MUST be updated to reflect the corrected contract boundary (distinguishing "subdirectory of a module" from "outside any module").
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Running `gaze crap ./...` from any subdirectory within a Go module produces identical coverage percentages (within floating-point rounding) to running from the module root.
+- **SC-002**: Running `gaze report ./... --format=json` from a subdirectory produces identical CRAP and coverage values to running from the module root.
+- **SC-003**: Running `gaze crap ./...` from a directory with no ancestor `go.mod` produces a non-zero exit code and an error message containing "go.mod" or "module root".
+- **SC-004**: All existing tests pass (with `TestResolveFilePath_NoGoMod` updated), confirming no regression in the module-root invocation path.
+- **SC-005**: When a coverage profile has entries that cannot be resolved, at least one warning appears on stderr.
+- **SC-006**: When zero profile entries resolve, the tool exits with a non-zero exit code.
+
+## Dependencies & Assumptions
+
+### Dependencies
+
+- **Spec 009 (crapload-reduction)**: Decomposed `buildContractCoverageFunc` into `resolvePackagePaths`/`analyzePackageCoverage` — the coverage resolution path affected by this bug.
+- **Spec 022 (report-gazecrap-pipeline)**: Wired `BuildContractCoverageFunc` into the report pipeline — `gaze report` shares the same `moduleDir` resolution bug.
+- **Spec 020 (report-coverprofile)**: Added `--coverprofile` flag threading through `RunnerOptions.CoverProfile` — the `ModuleDir` in `RunnerOptions` is set from `os.Getwd()`.
+
+### Assumptions
+
+- The `findModuleRoot` function already exists in `cmd/gaze/main.go` (used by `self-check`) and will be extracted to a shared location.
+- Go modules are the only supported project structure (no GOPATH-mode projects).
+- The nearest ancestor `go.mod` is always the correct module root for the user's intended analysis scope.
+- The walk-upward approach is used (not `go/packages`), per review council consensus: 5-50us vs 100-500ms, already proven by `self-check`.

--- a/specs/038-crap-subdir-coverage/tasks.md
+++ b/specs/038-crap-subdir-coverage/tasks.md
@@ -1,0 +1,204 @@
+# Tasks: Fix Zero Coverage When Running from Subdirectory
+
+**Input**: Design documents from `/specs/038-crap-subdir-coverage/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Tests**: Tests are included — the spec requires verifiable regression coverage and the plan specifies a coverage strategy (R7).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Foundational (Blocking Prerequisites)
+
+**Purpose**: Extract the shared `FindModuleRoot` function that ALL user stories depend on. No user story work can begin until this phase is complete.
+
+- [x] T001 Add `FindModuleRoot(startDir string) (string, error)` to `internal/loader/loader.go` — walk up from `startDir` checking for `go.mod` at each level, stop at filesystem root (`filepath.Dir(dir) == dir`), return error `no go.mod found in %q or any parent directory` when not found. Add `os` and `path/filepath` imports. (FR-001, FR-006, FR-010)
+- [x] T002 Add `TestFindModuleRoot_AtRoot` in `internal/loader/loader_test.go` — create temp dir with `go.mod`, call `FindModuleRoot(dir)`, assert returns that dir. (FR-005)
+- [x] T003 [P] Add `TestFindModuleRoot_FromSubdirectory` in `internal/loader/loader_test.go` — create temp dir with `go.mod` at root, create nested subdirectory 2-3 levels deep, call `FindModuleRoot(deepDir)`, assert returns root dir. (FR-001)
+- [x] T004 [P] Add `TestFindModuleRoot_NoGoMod` in `internal/loader/loader_test.go` — create temp dir with NO `go.mod`, call `FindModuleRoot(dir)`, assert returns error containing "go.mod". (FR-004)
+- [x] T005 [P] Add `TestFindModuleRoot_NestedModules` in `internal/loader/loader_test.go` — create temp dir with `go.mod` at root AND in a subdirectory, call `FindModuleRoot(subdir)`, assert returns the subdirectory (nearest ancestor). (FR-006)
+
+**Checkpoint**: `go test -race -count=1 ./internal/loader/...` passes with all `FindModuleRoot` tests green.
+
+---
+
+## Phase 2: User Story 1 - Accurate Coverage from Any Directory (Priority: P1) MVP
+
+**Goal**: `gaze crap ./...` from any subdirectory produces identical coverage/CRAP scores as from the module root.
+
+**Independent Test**: Run `gaze crap ./...` from the module root and a subdirectory; coverage percentages and CRAP scores match for the same functions.
+
+### Implementation for User Story 1
+
+- [x] T006 [US1] In `cmd/gaze/main.go`, `newCrapCmd` RunE closure (line ~703): replace `moduleDir, err := os.Getwd()` with `cwd, err := os.Getwd()` followed by `moduleDir, err := loader.FindModuleRoot(cwd)`, returning the error with context `finding module root: %w`. Add `loader` import if not present. (FR-002, FR-004)
+- [x] T007 [US1] In `cmd/gaze/main.go`, `runClassify` function (line ~291): replace `cwd, err := os.Getwd()` with `cwd, err := os.Getwd()` followed by `moduleRoot, err := loader.FindModuleRoot(cwd)`, pass `moduleRoot` to `loader.LoadModule` instead of `cwd`. On `FindModuleRoot` error, log warning and set `moduleRoot = ""` (non-fatal for classification). (FR-011)
+- [x] T008 [US1] In `cmd/gaze/main.go`, `loadConfig` function (line ~148): when `path == ""`, replace `cwd, err := os.Getwd()` with `cwd, err := os.Getwd()` followed by `moduleRoot, findErr := loader.FindModuleRoot(cwd)`, use `moduleRoot` for config path. On `FindModuleRoot` error, fall back to `config.DefaultConfig()` (existing behavior for config-not-found). (FR-007)
+- [x] T009 [US1] In `cmd/gaze/main.go`, delete `findModuleRoot()` function (line ~1168-1183) — replaced by `loader.FindModuleRoot`. Update `runSelfCheck`: change `selfCheckParams.moduleRootFunc` type from `func() (string, error)` to accept a wrapper that calls `loader.FindModuleRoot(cwd)`. Ensure `runSelfCheck` still works by getting `cwd` via `os.Getwd()` and passing to `loader.FindModuleRoot`. (FR-010)
+- [x] T009a [US1] In `cmd/gaze/main.go`, `runDocscan` function (line ~767): replace `repoRoot, err := os.Getwd()` with `cwd, err := os.Getwd()` followed by `repoRoot, findErr := loader.FindModuleRoot(cwd)`, falling back to `cwd` on error (docscan is non-critical). This ensures doc scanning also resolves from the module root when invoked from a subdirectory. (FR-011)
+- [x] T010 [US1] In `internal/crap/contract.go`, `classifyResults` function (line ~242): add `moduleDir string` parameter after `pkgPath string`, replace `cwd, err := os.Getwd()` and `loader.LoadModule(cwd)` with `loader.LoadModule(moduleDir)`. Remove `os` import if no longer needed. Update signature in GoDoc comment. (FR-011)
+- [x] T011 [US1] In `internal/crap/contract.go`, `loadGazeConfigBestEffort` function (line ~329): add `moduleDir string` parameter, replace body with `cfgPath := filepath.Join(moduleDir, ".gaze.yaml")` (matching the `cmd/gaze/main.go:628` pattern). Remove `os` import if no longer needed. Preserve `NOTE: keep in sync` comment. (FR-007, FR-011)
+- [x] T012 [US1] In `internal/crap/contract.go`, update all callers of the modified functions: `BuildContractCoverageFunc` (line ~53) calls `loadGazeConfigBestEffort()` — change to `loadGazeConfigBestEffort(moduleDir)` using the `moduleDir` parameter it already receives. `analyzePackageCoverage` (line ~210) calls `classifyResults(results, pkgPath, gazeConfig)` — change to `classifyResults(results, pkgPath, moduleDir, gazeConfig)`, threading `moduleDir` from `BuildContractCoverageFunc` through `analyzePackageCoverage`. Add `moduleDir string` parameter to `analyzePackageCoverage` if not already present. (FR-011)
+- [x] T013 [US1] In `internal/crap/coverage.go`, `ParseCoverProfile` function (line ~56-57): replace `os.Getwd()` fallback with `loader.FindModuleRoot`. When `moduleDir == ""`, call `moduleDir, _ = os.Getwd()` then `moduleDir, findErr := loader.FindModuleRoot(moduleDir)` — on error, set `moduleDir = ""` (will trigger 0/N diagnostics in US3). Add `loader` import. (FR-001)
+
+**Checkpoint**: `go build ./cmd/gaze && go test -race -count=1 -short ./...` passes. `gaze crap ./...` from module root works as before (SC-004).
+
+---
+
+## Phase 3: User Story 2 - Accurate Report Output from Any Directory (Priority: P2)
+
+**Goal**: `gaze report ./... --format=json` from any subdirectory produces identical results as from the module root.
+
+**Independent Test**: Run `gaze report ./... --format=json` from the module root and a subdirectory; CRAP scores and coverage values match.
+
+### Implementation for User Story 2
+
+- [x] T014 [US2] In `cmd/gaze/main.go`, `runReport` function (line ~1329): replace `cwd, err := os.Getwd()` with `cwd, err := os.Getwd()` followed by `moduleDir, findErr := loader.FindModuleRoot(cwd)`, return error with context if `FindModuleRoot` fails. Use `moduleDir` for `aireport.LoadPrompt(moduleDir)` and `RunnerOptions.ModuleDir: moduleDir`. (FR-003, FR-004)
+- [x] T015 [US2] In `internal/aireport/runner_steps.go`, `loadGazeConfigBestEffort` function (line ~312): add `moduleDir string` parameter, replace body with `cfgPath := filepath.Join(moduleDir, ".gaze.yaml")` pattern. Remove `os` import if no longer needed. Preserve `NOTE: keep in sync` comment or add one referencing the `contract.go` copy. (FR-007, FR-011)
+- [x] T016 [US2] In `internal/aireport/runner_steps.go`, `resolveModulePackages` function (line ~295): replace `os.Getwd()` fallback (lines 297-301) with `loader.FindModuleRoot`. When `moduleDir == ""`, call `cwd, err := os.Getwd()` then `moduleDir, _ = loader.FindModuleRoot(cwd)` — on error, return nil (existing graceful degradation pattern). Add `loader` import if not present. (FR-011)
+- [x] T017 [US2] In `internal/aireport/runner_steps.go`, update all callers of `loadGazeConfigBestEffort()` to pass `moduleDir`. Search for calls within `runner_steps.go` and pass the `moduleDir` parameter that flows through from `RunnerOptions.ModuleDir`. (FR-011)
+
+**Checkpoint**: `go build ./cmd/gaze && go test -race -count=1 -short ./...` passes. Both `gaze crap` and `gaze report` build and run correctly from module root (SC-004).
+
+---
+
+## Phase 4: User Story 3 - Silent Failure Prevention (Priority: P2)
+
+**Goal**: Unresolved coverage profile entries produce stderr warnings; 0/N resolution produces an error instead of silent zero coverage.
+
+**Independent Test**: Provide a coverage profile with unresolvable entries; verify warnings on stderr and error when all entries fail.
+
+### Tests for User Story 3
+
+- [x] T018 [P] [US3] Add `TestParseCoverProfile_AllUnresolved` in `internal/crap/crap_test.go` — create a coverage profile with entries that cannot be resolved (e.g., `nonexistent.com/pkg/file.go`), create a temp dir with a valid `go.mod`, call `ParseCoverProfile(profilePath, dir, &stderr)`, assert returns error containing "failed to resolve". (FR-009, SC-006)
+- [x] T019 [P] [US3] Add `TestParseCoverProfile_PartialUnresolved` in `internal/crap/crap_test.go` — create a coverage profile with one resolvable and one unresolvable entry, call `ParseCoverProfile`, assert returns nil error (success) AND stderr contains a warning for the unresolvable entry. (FR-008, SC-005)
+- [x] T020 [P] [US3] Add `TestParseCoverProfile_WarningContent` in `internal/crap/crap_test.go` — verify the stderr warning message contains the unresolvable profile entry name for diagnostic clarity. (FR-008)
+
+### Implementation for User Story 3
+
+- [x] T021 [US3] In `internal/crap/coverage.go`, `ParseCoverProfile` function: add `totalEntries` and `resolvedEntries` counters. Increment `totalEntries` for each profile entry. Increment `resolvedEntries` when `resolveFilePath` returns a non-empty string. (FR-008, FR-009)
+- [x] T022 [US3] In `internal/crap/coverage.go`, `ParseCoverProfile` function: when `resolveFilePath` returns `""`, write warning to stderr: `fmt.Fprintf(stderr, "warning: skipping profile entry %q: could not resolve to file on disk\n", profile.FileName)` — only if stderr is non-nil (matching existing nil-check pattern at line ~72). (FR-008)
+- [x] T023 [US3] In `internal/crap/coverage.go`, `ParseCoverProfile` function: after the profile loop, add check: if `totalEntries > 0 && resolvedEntries == 0`, return `nil, fmt.Errorf("all %d coverage profile entries failed to resolve — check that the profile matches the current module", totalEntries)`. (FR-009)
+- [x] T024 [US3] Verify `TestResolveFilePath_NoGoMod` in `internal/crap/crap_test.go` (line ~752) still passes — the test creates a temp dir with no `go.mod` and asserts `resolveFilePath` returns `""`, which remains correct since `resolveFilePath` itself does not walk up (callers provide the module root). Add a GoDoc comment clarifying this tests the "outside any module" contract boundary. (FR-012)
+
+**Checkpoint**: `go test -race -count=1 -short ./internal/crap/...` passes with all diagnostic tests green (SC-005, SC-006).
+
+---
+
+## Phase 5: User Story 4 - Clear Error When No Module Root Found (Priority: P3)
+
+**Goal**: Running `gaze crap` from outside any Go module produces a clear error with non-zero exit code.
+
+**Independent Test**: Run from a directory with no ancestor `go.mod`; verify non-zero exit and descriptive error message.
+
+### Implementation for User Story 4
+
+- [x] T025 [US4] Verify that `FindModuleRoot` error propagation is correct in T006 (`newCrapCmd` RunE) and T014 (`runReport`): when `FindModuleRoot` returns error, the error should propagate to Cobra which prints it and exits non-zero. No additional code needed if T006/T014 return the error correctly — this task validates the error path end-to-end. (FR-004, SC-003)
+- [x] T026 [US4] Add `TestNewCrapCmd_NoModuleRoot` in `cmd/gaze/main_test.go` (or verify via existing test infrastructure): confirm that when `FindModuleRoot` returns an error, `newCrapCmd` RunE returns a non-nil error containing "go.mod" or "module root". This may require a test helper that temporarily changes the working directory to a temp dir without `go.mod`, or uses the existing `moduleRootFunc` injection pattern from `selfCheckParams`. (FR-004, SC-003)
+
+**Checkpoint**: Error path verified — non-zero exit code and descriptive message (SC-003).
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Regression verification, lint checks, and documentation validation
+
+- [x] T027 Run `go build ./cmd/gaze` — verify build succeeds with all changes
+- [x] T028 Run `go test -race -count=1 -short ./...` — verify ALL existing tests pass (SC-004)
+- [x] T029 Run `golangci-lint run` — verify no lint issues introduced
+- [x] T030 Verify no unused imports remain after removing `os.Getwd()` calls from internal packages (`internal/crap/contract.go`, `internal/aireport/runner_steps.go`)
+- [x] T031 Review GoDoc comments on all modified functions — ensure parameter documentation matches new signatures
+- [x] T032 Run quickstart.md validation: execute `gaze crap ./...` from module root (baseline), then from `internal/crap/` subdirectory — verify identical coverage values for overlapping functions
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 1)**: No dependencies — can start immediately. BLOCKS all user stories.
+- **User Story 1 (Phase 2)**: Depends on Phase 1 (`FindModuleRoot` must exist before CLI can use it)
+- **User Story 2 (Phase 3)**: Depends on Phase 1. Can run in parallel with US1 (different files: `runner_steps.go` vs `contract.go`/`main.go`)
+- **User Story 3 (Phase 4)**: Depends on Phase 1 (`ParseCoverProfile` uses `FindModuleRoot` fallback). Tests can start immediately (T018-T020 are independent)
+- **User Story 4 (Phase 5)**: Depends on Phase 2 (T006 must be complete for error path to exist)
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Phase 1 only. Core bug fix — MVP scope.
+- **US2 (P2)**: Depends on Phase 1 only. Can run in parallel with US1 (different files).
+- **US3 (P2)**: Depends on Phase 1 only. Can run in parallel with US1 and US2 (different code path in `coverage.go`).
+- **US4 (P3)**: Depends on US1 (T006 establishes the error propagation path).
+
+### Within Each User Story
+
+- Signature changes before caller updates (within US1: T010-T011 before T012)
+- CLI entry points after internal package changes (T006-T009 depend on T010-T013 being compilable)
+
+### Parallel Opportunities
+
+- **Phase 1**: T003, T004, T005 can run in parallel (independent test cases)
+- **Phase 2 + Phase 3**: US1 and US2 can run in parallel after Phase 1 (different files)
+- **Phase 4**: T018, T019, T020 can run in parallel (independent test files)
+- **Cross-story**: US1, US2, US3 can all start after Phase 1 if three developers are available
+
+---
+
+## Parallel Example: After Phase 1 Completes
+
+```text
+# Developer A: User Story 1 (gaze crap fix)
+Task: T006 — newCrapCmd RunE in cmd/gaze/main.go
+Task: T010 — classifyResults in internal/crap/contract.go
+Task: T011 — loadGazeConfigBestEffort in internal/crap/contract.go
+
+# Developer B: User Story 2 (gaze report fix)
+Task: T014 — runReport in cmd/gaze/main.go
+Task: T015 — loadGazeConfigBestEffort in internal/aireport/runner_steps.go
+Task: T016 — resolveModulePackages in internal/aireport/runner_steps.go
+
+# Developer C: User Story 3 (diagnostics)
+Task: T018 — TestParseCoverProfile_AllUnresolved in internal/crap/crap_test.go
+Task: T021 — Add counters in internal/crap/coverage.go
+Task: T022 — Add warnings in internal/crap/coverage.go
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Foundational (`FindModuleRoot` + tests)
+2. Complete Phase 2: User Story 1 (crap command fix)
+3. **STOP and VALIDATE**: `gaze crap ./...` from subdirectory produces correct results
+4. This alone fixes the primary reported bug (issue #113)
+
+### Incremental Delivery
+
+1. Phase 1 → Foundation ready
+2. Phase 2 (US1) → `gaze crap` fixed → Validate SC-001 (MVP)
+3. Phase 3 (US2) → `gaze report` fixed → Validate SC-002
+4. Phase 4 (US3) → Silent failure prevention → Validate SC-005, SC-006
+5. Phase 5 (US4) → Error path → Validate SC-003
+6. Phase 6 → Polish → Full CI validation (SC-004)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- US1 and US2 both modify `cmd/gaze/main.go` — if done sequentially, US2 builds on US1's changes; if done in parallel, coordinate on `main.go` changes
+- T009 (delete `findModuleRoot`) should be done AFTER T006 verifies the replacement works
+- The `NOTE: keep in sync` comments on `loadGazeConfigBestEffort` copies should be preserved until full consolidation (deferred from spec 022)
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes the critical bug where `gaze crap` and `gaze report` silently drop all
coverage data when invoked from a subdirectory of a Go module
(unbound-force/gaze#113).

### Changes

- **New shared function**: `loader.FindModuleRoot(startDir)` walks up from any
  directory to find the nearest `go.mod` — extracted to `internal/loader/`
- **9 call sites fixed**: All `os.Getwd()`-as-module-root patterns in
  `cmd/gaze/main.go`, `internal/crap/contract.go`, `internal/crap/coverage.go`,
  and `internal/aireport/runner_steps.go`
- **Silent failure prevention**: stderr warnings for unresolved coverage profile
  entries, hard error when 0/N entries resolve
- **Clear error path**: Running outside any Go module now produces a descriptive
  error with non-zero exit code

### Verification

```bash
# From module root (baseline):
gaze crap ./... --format=json  # functions: 324, crapload: 37

# From subdirectory (was broken, now fixed):
cd internal/crap && gaze crap ./... --format=json  # same: 324, 37

# Outside any module (new error):
cd /tmp && gaze crap ./...  # exit 1: "no go.mod found"
```

### Test Results

- `go build ./...` — clean
- `go test -race -count=1 -short ./...` — all 12 packages pass
- `go vet ./...` — clean
- 4 new `FindModuleRoot` tests + 3 new `ParseCoverProfile` diagnostic tests