### PR TITLE
fix: evaluate GazeCRAP in baseline new-function threshold (#164)

### DIFF
--- a/.uf/dewey/learnings/039-baseline-gazecrap-threshold-20260623T175519-jay-flowers.md
+++ b/.uf/dewey/learnings/039-baseline-gazecrap-threshold-20260623T175519-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: 039-baseline-gazecrap-threshold
+author: jay-flowers
+category: pattern
+created_at: 2026-06-23T17:55:19Z
+identity: 039-baseline-gazecrap-threshold-20260623T175519-jay-flowers
+tier: draft
+---
+
+For spec 039-baseline-gazecrap-threshold, the entire pipeline (specify, plan, tasks, review, implement, code review) completed in a single /unleash run with zero findings from either spec review or code review. Key success factor: the design decision (Option 2: separate threshold with default 30, field named new_function_gaze_crap_threshold) was resolved in conversation before speckit.specify, so no NEEDS CLARIFICATION markers existed and no iterations were needed. Pre-resolving design decisions before entering the spec pipeline significantly reduces cycle time. The change was ~50 lines of production code and ~150 lines of test code across 5 production files and 2 test files, plus 2 YAML test fixtures.

--- a/.uf/dewey/learnings/baseline-comparison-20260623T175513-jay-flowers.md
+++ b/.uf/dewey/learnings/baseline-comparison-20260623T175513-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: baseline-comparison
+author: jay-flowers
+category: pattern
+created_at: 2026-06-23T17:55:13Z
+identity: baseline-comparison-20260623T175513-jay-flowers
+tier: draft
+---
+
+When adding a new threshold field to the gaze baseline comparison system (internal/crap/compare.go), the change must be threaded through three types: BaselineConfig (config.go, YAML), CompareOptions (compare.go, in-memory), and ComparisonSummary (crap.go, JSON output). The CLI layer (cmd/gaze/main.go loadAndCompare) wires config to options, and buildComparisonSummary propagates options to summary. This three-type pipeline — config struct, options struct, output struct — is the established pattern for all comparison parameters (epsilon, new_function_threshold). The report layer has three separate sites that evaluate new-function violation status: buildComparisonSummary (counting), WriteComparisonJSON (JSON status assignment), and writeComparisonNewFunctions (text formatting). All three must be updated consistently when adding new violation criteria. The nil-guard pattern for GazeCRAP (s.GazeCRAP != nil && *s.GazeCRAP > threshold) must be used at every evaluation site because GazeCRAP is optional (*float64).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -453,6 +453,7 @@ Formatters: gofmt, goimports.
 ## Active Technologies
 - N/A — Markdown files only (no Go code changes) + None — plain Markdown, no static site generator, no build step (037-project-documentation)
 - Filesystem only — `docs/` directory at repository root (037-project-documentation)
+- Go 1.25+ (per `go.mod` directive) + Standard library only (no new dependencies). Existing: `gopkg.in/yaml.v3` (config), `encoding/json` (report output) (039-baseline-gazecrap-threshold)
 
 - Go 1.24+ (no Go code changes; prompt is markdown) + OpenCode agent runtime (renders markdown prompt), embed.FS (scaffolds prompt copy) (011-output-voice-style)
 - Filesystem only (markdown files) (011-output-voice-style)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,3 +19,10 @@ Divisor agent from .opencode/agents/:
 - divisor-adversary.md — security, error handling
 - divisor-testing.md — test quality, assertions
 - divisor-sre.md — operations, performance
+
+## Active Technologies
+- Go 1.25+ (per `go.mod` directive) + Standard library only (no new dependencies). Existing: `gopkg.in/yaml.v3` (config), `encoding/json` (report output) (039-baseline-gazecrap-threshold)
+- N/A — no persistence changes (039-baseline-gazecrap-threshold)
+
+## Recent Changes
+- 039-baseline-gazecrap-threshold: Added Go 1.25+ (per `go.mod` directive) + Standard library only (no new dependencies). Existing: `gopkg.in/yaml.v3` (config), `encoding/json` (report output)

--- a/cmd/gaze/main.go
+++ b/cmd/gaze/main.go
@@ -632,8 +632,9 @@ func loadAndCompare(
 
 	cfg := loadGazeConfigBestEffort(moduleDir)
 	opts := crap.CompareOptions{
-		Epsilon:              cfg.Baseline.Epsilon,
-		NewFunctionThreshold: cfg.Baseline.NewFunctionThreshold,
+		Epsilon:                      cfg.Baseline.Epsilon,
+		NewFunctionThreshold:         cfg.Baseline.NewFunctionThreshold,
+		NewFunctionGazeCRAPThreshold: cfg.Baseline.NewFunctionGazeCRAPThreshold,
 	}
 	return crap.Compare(baseline, current, opts), nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,13 @@ type BaselineConfig struct {
 	// function (not in the baseline) is classified as a
 	// violation. Must be > 0. Default: 30.
 	NewFunctionThreshold float64 `yaml:"new_function_threshold"`
+
+	// NewFunctionGazeCRAPThreshold is the GazeCRAP score above
+	// which a new function is classified as a violation. Evaluated
+	// independently from NewFunctionThreshold — either metric
+	// exceeding its threshold triggers a violation. Must be > 0.
+	// Default: 30.
+	NewFunctionGazeCRAPThreshold float64 `yaml:"new_function_gaze_crap_threshold"`
 }
 
 // GazeConfig is the top-level configuration loaded from .gaze.yaml.
@@ -80,9 +87,10 @@ type GazeConfig struct {
 func DefaultConfig() *GazeConfig {
 	return &GazeConfig{
 		Baseline: BaselineConfig{
-			File:                 ".gaze/baseline.json",
-			Epsilon:              0.5,
-			NewFunctionThreshold: 30,
+			File:                         ".gaze/baseline.json",
+			Epsilon:                      0.5,
+			NewFunctionThreshold:         30,
+			NewFunctionGazeCRAPThreshold: 30,
 		},
 		Classification: ClassificationConfig{
 			Thresholds: Thresholds{
@@ -133,6 +141,10 @@ func Load(path string) (*GazeConfig, error) {
 	if cfg.Baseline.NewFunctionThreshold <= 0 {
 		return nil, fmt.Errorf("baseline.new_function_threshold must be > 0, got %g",
 			cfg.Baseline.NewFunctionThreshold)
+	}
+	if cfg.Baseline.NewFunctionGazeCRAPThreshold <= 0 {
+		return nil, fmt.Errorf("baseline.new_function_gaze_crap_threshold must be > 0, got %g",
+			cfg.Baseline.NewFunctionGazeCRAPThreshold)
 	}
 
 	// Validate classification thresholds.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -316,6 +316,40 @@ func TestLoad_NegativeContractual(t *testing.T) {
 	}
 }
 
+// --- Issue #164: GazeCRAP new-function threshold tests ---
+
+func TestSC004_ConfigDefault_GazeCRAPThreshold(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Baseline.NewFunctionGazeCRAPThreshold != 30 {
+		t.Errorf("default NewFunctionGazeCRAPThreshold = %g, want 30",
+			cfg.Baseline.NewFunctionGazeCRAPThreshold)
+	}
+}
+
+func TestSC007_ConfigValidation_ZeroGazeCRAPThreshold(t *testing.T) {
+	_, err := Load(filepath.Join("testdata", "invalid-baseline-gaze-threshold-zero.yaml"))
+	if err == nil {
+		t.Fatal("expected error for zero gaze_crap threshold, got nil")
+	}
+
+	want := "baseline.new_function_gaze_crap_threshold must be > 0"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want to contain %q", err, want)
+	}
+}
+
+func TestSC007_ConfigValidation_NegativeGazeCRAPThreshold(t *testing.T) {
+	_, err := Load(filepath.Join("testdata", "invalid-baseline-gaze-threshold-negative.yaml"))
+	if err == nil {
+		t.Fatal("expected error for negative gaze_crap threshold, got nil")
+	}
+
+	want := "baseline.new_function_gaze_crap_threshold must be > 0"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want to contain %q", err, want)
+	}
+}
+
 func TestLoad_ZeroIncidental(t *testing.T) {
 	_, err := Load(filepath.Join("testdata", "zero-incidental.yaml"))
 	if err == nil {

--- a/internal/config/testdata/invalid-baseline-gaze-threshold-negative.yaml
+++ b/internal/config/testdata/invalid-baseline-gaze-threshold-negative.yaml
@@ -1,0 +1,2 @@
+baseline:
+  new_function_gaze_crap_threshold: -5

--- a/internal/config/testdata/invalid-baseline-gaze-threshold-zero.yaml
+++ b/internal/config/testdata/invalid-baseline-gaze-threshold-zero.yaml
@@ -1,0 +1,2 @@
+baseline:
+  new_function_gaze_crap_threshold: 0

--- a/internal/crap/compare.go
+++ b/internal/crap/compare.go
@@ -18,6 +18,13 @@ type CompareOptions struct {
 	// violation. Functions at or below this threshold are
 	// informational "new" entries.
 	NewFunctionThreshold float64
+
+	// NewFunctionGazeCRAPThreshold is the GazeCRAP score above
+	// which a new function is classified as a violation. When
+	// GazeCRAP is available for a new function, it is evaluated
+	// independently from the CRAP threshold — either metric
+	// exceeding its threshold triggers a violation.
+	NewFunctionGazeCRAPThreshold float64
 }
 
 // LoadBaseline deserializes a crap.Report from JSON read from r.
@@ -158,9 +165,10 @@ func classifyDelta(crapDelta float64, gazeCRAPDelta *float64, hasGazeDelta bool,
 // comparison result and determines pass/fail.
 func buildComparisonSummary(result *ComparisonResult, opts CompareOptions) ComparisonSummary {
 	summary := ComparisonSummary{
-		Epsilon:              opts.Epsilon,
-		NewFunctionThreshold: opts.NewFunctionThreshold,
-		RemovedFunctions:     len(result.RemovedFunctions),
+		Epsilon:                      opts.Epsilon,
+		NewFunctionThreshold:         opts.NewFunctionThreshold,
+		NewFunctionGazeCRAPThreshold: opts.NewFunctionGazeCRAPThreshold,
+		RemovedFunctions:             len(result.RemovedFunctions),
 	}
 
 	for _, d := range result.Deltas {
@@ -175,7 +183,9 @@ func buildComparisonSummary(result *ComparisonResult, opts CompareOptions) Compa
 	}
 
 	for _, s := range result.NewFunctions {
-		if s.CRAP > opts.NewFunctionThreshold {
+		crapViolation := s.CRAP > opts.NewFunctionThreshold
+		gazeViolation := s.GazeCRAP != nil && *s.GazeCRAP > opts.NewFunctionGazeCRAPThreshold
+		if crapViolation || gazeViolation {
 			summary.NewViolations++
 		} else {
 			summary.NewFunctions++

--- a/internal/crap/compare_report.go
+++ b/internal/crap/compare_report.go
@@ -116,7 +116,10 @@ func WriteComparisonJSON(w io.Writer, result *ComparisonResult) error {
 	newFuncs := make([]newFunctionJSON, 0, len(result.NewFunctions))
 	for _, nf := range result.NewFunctions {
 		status := StatusNew
-		if nf.CRAP > result.Summary.NewFunctionThreshold {
+		crapViolation := nf.CRAP > result.Summary.NewFunctionThreshold
+		gazeViolation := nf.GazeCRAP != nil &&
+			*nf.GazeCRAP > result.Summary.NewFunctionGazeCRAPThreshold
+		if crapViolation || gazeViolation {
 			status = StatusNewViolation
 		}
 		newFuncs = append(newFuncs, newFunctionJSON{
@@ -183,7 +186,9 @@ func WriteComparisonText(w io.Writer, result *ComparisonResult) error {
 	writeComparisonDeltaTable(w, "Improvements", result.Deltas, StatusImprovement)
 
 	// New functions with violations.
-	writeComparisonNewFunctions(w, result.NewFunctions, result.Summary.NewFunctionThreshold)
+	writeComparisonNewFunctions(w, result.NewFunctions,
+		result.Summary.NewFunctionThreshold,
+		result.Summary.NewFunctionGazeCRAPThreshold)
 
 	// Removed functions.
 	writeComparisonRemovedFunctions(w, result.RemovedFunctions)
@@ -256,9 +261,9 @@ func writeComparisonDeltaTable(w io.Writer, title string, deltas []FunctionDelta
 }
 
 // writeComparisonNewFunctions writes the new functions section.
-// Functions above the threshold are marked as violations.
+// Functions above either threshold are marked as violations.
 // Omitted if there are no new functions.
-func writeComparisonNewFunctions(w io.Writer, newFuncs []Score, threshold float64) {
+func writeComparisonNewFunctions(w io.Writer, newFuncs []Score, crapThreshold, gazeCRAPThreshold float64) {
 	if len(newFuncs) == 0 {
 		return
 	}
@@ -266,7 +271,9 @@ func writeComparisonNewFunctions(w io.Writer, newFuncs []Score, threshold float6
 	// Separate violations from informational new functions.
 	var violations, informational []Score
 	for _, s := range newFuncs {
-		if s.CRAP > threshold {
+		crapViolation := s.CRAP > crapThreshold
+		gazeViolation := s.GazeCRAP != nil && *s.GazeCRAP > gazeCRAPThreshold
+		if crapViolation || gazeViolation {
 			violations = append(violations, s)
 		} else {
 			informational = append(informational, s)
@@ -276,9 +283,14 @@ func writeComparisonNewFunctions(w io.Writer, newFuncs []Score, threshold float6
 	if len(violations) > 0 {
 		_, _ = fmt.Fprintf(w, "\nNew Functions (violations):\n")
 		for _, s := range violations {
-			_, _ = fmt.Fprintf(w, "  %-40s  CRAP: %.1f  [VIOLATION]\n",
-				fmt.Sprintf("%s (%s)", s.Function, shortenPath(s.File)),
-				s.CRAP)
+			label := fmt.Sprintf("%s (%s)", s.Function, shortenPath(s.File))
+			if s.GazeCRAP != nil {
+				_, _ = fmt.Fprintf(w, "  %-40s  CRAP: %.1f  GazeCRAP: %.1f  [VIOLATION]\n",
+					label, s.CRAP, *s.GazeCRAP)
+			} else {
+				_, _ = fmt.Fprintf(w, "  %-40s  CRAP: %.1f  [VIOLATION]\n",
+					label, s.CRAP)
+			}
 		}
 	}
 

--- a/internal/crap/compare_report_test.go
+++ b/internal/crap/compare_report_test.go
@@ -677,3 +677,189 @@ func TestDeltaTable_TwoRowFormat_WidthCompliance(t *testing.T) {
 		}
 	}
 }
+
+// --- Issue #164: GazeCRAP new-function threshold report tests ---
+
+func TestSC006_TextReport_ViolationShowsGazeCRAP(t *testing.T) {
+	// A new-function violation with GazeCRAP available should
+	// display both CRAP and GazeCRAP scores in the text output.
+	result := &ComparisonResult{
+		Report: &Report{
+			Scores: []Score{
+				makeScore("a.go", "Existing", 5.0, nil),
+				makeScore("b.go", "NewFunc", 25.0, float64Ptr(40.0)),
+			},
+			Summary: Summary{
+				TotalFunctions: 2,
+				CRAPThreshold:  15,
+			},
+		},
+		NewFunctions: []Score{
+			makeScore("b.go", "NewFunc", 25.0, float64Ptr(40.0)),
+		},
+		Summary: ComparisonSummary{
+			NewViolations:                1,
+			Passed:                       false,
+			Epsilon:                      0.5,
+			NewFunctionThreshold:         30,
+			NewFunctionGazeCRAPThreshold: 30,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteComparisonText(&buf, result); err != nil {
+		t.Fatalf("WriteComparisonText() error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "CRAP: 25.0") {
+		t.Error("violation output missing CRAP score")
+	}
+	if !strings.Contains(output, "GazeCRAP: 40.0") {
+		t.Error("violation output missing GazeCRAP score")
+	}
+	if !strings.Contains(output, "VIOLATION") {
+		t.Error("violation output missing [VIOLATION] marker")
+	}
+}
+
+func TestSC006_TextReport_ViolationWithoutGazeCRAP(t *testing.T) {
+	// A violation with nil GazeCRAP should show only CRAP, no
+	// GazeCRAP label.
+	result := &ComparisonResult{
+		Report: &Report{
+			Scores: []Score{
+				makeScore("a.go", "Existing", 5.0, nil),
+				makeScore("b.go", "NewFunc", 42.0, nil),
+			},
+			Summary: Summary{
+				TotalFunctions: 2,
+				CRAPThreshold:  15,
+			},
+		},
+		NewFunctions: []Score{
+			makeScore("b.go", "NewFunc", 42.0, nil),
+		},
+		Summary: ComparisonSummary{
+			NewViolations:                1,
+			Passed:                       false,
+			Epsilon:                      0.5,
+			NewFunctionThreshold:         30,
+			NewFunctionGazeCRAPThreshold: 30,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteComparisonText(&buf, result); err != nil {
+		t.Fatalf("WriteComparisonText() error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "CRAP: 42.0") {
+		t.Error("violation output missing CRAP score")
+	}
+	if strings.Contains(output, "GazeCRAP:") {
+		t.Error("violation output should NOT contain GazeCRAP when GazeCRAP is nil")
+	}
+	if !strings.Contains(output, "VIOLATION") {
+		t.Error("violation output missing [VIOLATION] marker")
+	}
+}
+
+func TestSC005_JSONOutput_SummaryIncludesGazeCRAPThreshold(t *testing.T) {
+	// The comparison JSON output must include the
+	// new_function_gaze_crap_threshold field.
+	result := &ComparisonResult{
+		Report: &Report{
+			Scores:  []Score{makeScore("a.go", "Func", 5.0, nil)},
+			Summary: Summary{TotalFunctions: 1, CRAPThreshold: 15},
+		},
+		Deltas: []FunctionDelta{
+			{
+				Baseline:  makeScore("a.go", "Func", 5.0, nil),
+				Current:   makeScore("a.go", "Func", 5.0, nil),
+				CRAPDelta: 0,
+				Status:    StatusUnchanged,
+			},
+		},
+		Summary: ComparisonSummary{
+			Unchanged:                    1,
+			Passed:                       true,
+			Epsilon:                      0.5,
+			NewFunctionThreshold:         30,
+			NewFunctionGazeCRAPThreshold: 40,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteComparisonJSON(&buf, result); err != nil {
+		t.Fatalf("WriteComparisonJSON() error: %v", err)
+	}
+
+	var output map[string]json.RawMessage
+	if err := json.Unmarshal(buf.Bytes(), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	var comparison ComparisonSummary
+	if err := json.Unmarshal(output["comparison"], &comparison); err != nil {
+		t.Fatalf("parsing comparison: %v", err)
+	}
+
+	if comparison.NewFunctionGazeCRAPThreshold != 40 {
+		t.Errorf("comparison.new_function_gaze_crap_threshold = %g, want 40",
+			comparison.NewFunctionGazeCRAPThreshold)
+	}
+}
+
+func TestSC005_JSONOutput_NewFunctionStatusUsesGazeCRAP(t *testing.T) {
+	// A new function with CRAP below threshold but GazeCRAP above
+	// threshold should have status "new_violation" in JSON output.
+	result := &ComparisonResult{
+		Report: &Report{
+			Scores: []Score{
+				makeScore("a.go", "Existing", 5.0, nil),
+				makeScore("b.go", "NewFunc", 25.0, float64Ptr(40.0)),
+			},
+			Summary: Summary{TotalFunctions: 2, CRAPThreshold: 15},
+		},
+		NewFunctions: []Score{
+			makeScore("b.go", "NewFunc", 25.0, float64Ptr(40.0)),
+		},
+		Summary: ComparisonSummary{
+			NewViolations:                1,
+			Passed:                       false,
+			Epsilon:                      0.5,
+			NewFunctionThreshold:         30,
+			NewFunctionGazeCRAPThreshold: 30,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteComparisonJSON(&buf, result); err != nil {
+		t.Fatalf("WriteComparisonJSON() error: %v", err)
+	}
+
+	var output map[string]json.RawMessage
+	if err := json.Unmarshal(buf.Bytes(), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	var newFuncs []map[string]interface{}
+	if err := json.Unmarshal(output["new_functions"], &newFuncs); err != nil {
+		t.Fatalf("parsing new_functions: %v", err)
+	}
+
+	if len(newFuncs) != 1 {
+		t.Fatalf("len(new_functions) = %d, want 1", len(newFuncs))
+	}
+
+	status, ok := newFuncs[0]["status"].(string)
+	if !ok {
+		t.Fatal("new_functions[0].status is not a string")
+	}
+	if status != string(StatusNewViolation) {
+		t.Errorf("new_functions[0].status = %q, want %q",
+			status, StatusNewViolation)
+	}
+}

--- a/internal/crap/compare_test.go
+++ b/internal/crap/compare_test.go
@@ -1096,3 +1096,205 @@ func TestSC006_ComparisonPasses(t *testing.T) {
 		t.Error("text output missing New Functions section")
 	}
 }
+
+// --- Issue #164: GazeCRAP new-function threshold tests ---
+
+// defaultNewFuncOpts returns CompareOptions with default thresholds
+// (30 for both CRAP and GazeCRAP) used by the new-function tests.
+func defaultNewFuncOpts() CompareOptions {
+	return CompareOptions{
+		Epsilon:                      0.5,
+		NewFunctionThreshold:         30,
+		NewFunctionGazeCRAPThreshold: 30,
+	}
+}
+
+func TestSC001_NewFunction_GazeCRAPAboveThreshold(t *testing.T) {
+	// New function with CRAP below threshold but GazeCRAP above
+	// threshold should be classified as new_violation.
+	baseline := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+	}}
+	current := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+		makeScore("b.go", "NewFunc", 25.0, float64Ptr(40.0)),
+	}}
+
+	result := Compare(baseline, current, defaultNewFuncOpts())
+
+	if result.Summary.NewViolations != 1 {
+		t.Errorf("NewViolations = %d, want 1 (GazeCRAP 40 > threshold 30)",
+			result.Summary.NewViolations)
+	}
+	if result.Summary.Passed {
+		t.Error("Summary.Passed = true, want false (GazeCRAP violation)")
+	}
+}
+
+func TestSC001_NewFunction_BothAboveThreshold(t *testing.T) {
+	// New function with both CRAP and GazeCRAP above threshold.
+	baseline := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+	}}
+	current := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+		makeScore("b.go", "NewFunc", 42.0, float64Ptr(55.0)),
+	}}
+
+	result := Compare(baseline, current, defaultNewFuncOpts())
+
+	if result.Summary.NewViolations != 1 {
+		t.Errorf("NewViolations = %d, want 1 (both above threshold)",
+			result.Summary.NewViolations)
+	}
+	if result.Summary.Passed {
+		t.Error("Summary.Passed = true, want false")
+	}
+}
+
+func TestSC001_NewFunction_BothBelowThreshold(t *testing.T) {
+	// New function with both CRAP and GazeCRAP below threshold.
+	baseline := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+	}}
+	current := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+		makeScore("b.go", "NewFunc", 5.0, float64Ptr(8.0)),
+	}}
+
+	result := Compare(baseline, current, defaultNewFuncOpts())
+
+	if result.Summary.NewViolations != 0 {
+		t.Errorf("NewViolations = %d, want 0 (both below threshold)",
+			result.Summary.NewViolations)
+	}
+	if result.Summary.NewFunctions != 1 {
+		t.Errorf("NewFunctions = %d, want 1",
+			result.Summary.NewFunctions)
+	}
+	if !result.Summary.Passed {
+		t.Error("Summary.Passed = false, want true")
+	}
+}
+
+func TestSC001_NewFunction_GazeCRAPEqualToThreshold(t *testing.T) {
+	// GazeCRAP exactly at threshold (30) is NOT a violation
+	// (strict greater-than comparison).
+	baseline := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+	}}
+	current := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+		makeScore("b.go", "NewFunc", 25.0, float64Ptr(30.0)),
+	}}
+
+	result := Compare(baseline, current, defaultNewFuncOpts())
+
+	if result.Summary.NewViolations != 0 {
+		t.Errorf("NewViolations = %d, want 0 (GazeCRAP == threshold, not >)",
+			result.Summary.NewViolations)
+	}
+	if !result.Summary.Passed {
+		t.Error("Summary.Passed = false, want true (equal to threshold is not a violation)")
+	}
+}
+
+func TestSC004_IndependentThresholds(t *testing.T) {
+	// Independent thresholds: CRAP 30, GazeCRAP 40.
+	// New function with CRAP 25, GazeCRAP 38 — both below
+	// their respective thresholds.
+	baseline := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+	}}
+	current := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+		makeScore("b.go", "NewFunc", 25.0, float64Ptr(38.0)),
+	}}
+
+	opts := CompareOptions{
+		Epsilon:                      0.5,
+		NewFunctionThreshold:         30,
+		NewFunctionGazeCRAPThreshold: 40,
+	}
+	result := Compare(baseline, current, opts)
+
+	if result.Summary.NewViolations != 0 {
+		t.Errorf("NewViolations = %d, want 0 (GazeCRAP 38 < threshold 40)",
+			result.Summary.NewViolations)
+	}
+	if !result.Summary.Passed {
+		t.Error("Summary.Passed = false, want true")
+	}
+}
+
+func TestSC004_IndependentThresholds_GazeCRAPExceeds(t *testing.T) {
+	// Independent thresholds: CRAP 30, GazeCRAP 40.
+	// New function with CRAP 25, GazeCRAP 42 — CRAP below its
+	// threshold but GazeCRAP above its threshold.
+	baseline := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+	}}
+	current := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+		makeScore("b.go", "NewFunc", 25.0, float64Ptr(42.0)),
+	}}
+
+	opts := CompareOptions{
+		Epsilon:                      0.5,
+		NewFunctionThreshold:         30,
+		NewFunctionGazeCRAPThreshold: 40,
+	}
+	result := Compare(baseline, current, opts)
+
+	if result.Summary.NewViolations != 1 {
+		t.Errorf("NewViolations = %d, want 1 (GazeCRAP 42 > threshold 40)",
+			result.Summary.NewViolations)
+	}
+	if result.Summary.Passed {
+		t.Error("Summary.Passed = true, want false (GazeCRAP violation)")
+	}
+}
+
+func TestSC003_NilGazeCRAP_CRAPBelowThreshold(t *testing.T) {
+	// When GazeCRAP is nil, only CRAP is evaluated.
+	// CRAP 25 < threshold 30 → not a violation.
+	baseline := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+	}}
+	current := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+		makeScore("b.go", "NewFunc", 25.0, nil),
+	}}
+
+	result := Compare(baseline, current, defaultNewFuncOpts())
+
+	if result.Summary.NewViolations != 0 {
+		t.Errorf("NewViolations = %d, want 0 (nil GazeCRAP, CRAP below threshold)",
+			result.Summary.NewViolations)
+	}
+	if !result.Summary.Passed {
+		t.Error("Summary.Passed = false, want true")
+	}
+}
+
+func TestSC003_NilGazeCRAP_CRAPAboveThreshold(t *testing.T) {
+	// When GazeCRAP is nil, only CRAP is evaluated.
+	// CRAP 35 > threshold 30 → violation.
+	baseline := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+	}}
+	current := &Report{Scores: []Score{
+		makeScore("a.go", "Existing", 5.0, nil),
+		makeScore("b.go", "NewFunc", 35.0, nil),
+	}}
+
+	result := Compare(baseline, current, defaultNewFuncOpts())
+
+	if result.Summary.NewViolations != 1 {
+		t.Errorf("NewViolations = %d, want 1 (CRAP 35 > threshold 30)",
+			result.Summary.NewViolations)
+	}
+	if result.Summary.Passed {
+		t.Error("Summary.Passed = true, want false")
+	}
+}

--- a/internal/crap/crap.go
+++ b/internal/crap/crap.go
@@ -201,15 +201,16 @@ type FunctionDelta struct {
 
 // ComparisonSummary holds aggregate counts for a baseline comparison.
 type ComparisonSummary struct {
-	Regressions          int     `json:"regressions"`
-	Improvements         int     `json:"improvements"`
-	NewFunctions         int     `json:"new_functions"`
-	NewViolations        int     `json:"new_violations"`
-	RemovedFunctions     int     `json:"removed_functions"`
-	Unchanged            int     `json:"unchanged"`
-	Epsilon              float64 `json:"epsilon"`
-	NewFunctionThreshold float64 `json:"new_function_threshold"`
-	Passed               bool    `json:"passed"`
+	Regressions                  int     `json:"regressions"`
+	Improvements                 int     `json:"improvements"`
+	NewFunctions                 int     `json:"new_functions"`
+	NewViolations                int     `json:"new_violations"`
+	RemovedFunctions             int     `json:"removed_functions"`
+	Unchanged                    int     `json:"unchanged"`
+	Epsilon                      float64 `json:"epsilon"`
+	NewFunctionThreshold         float64 `json:"new_function_threshold"`
+	NewFunctionGazeCRAPThreshold float64 `json:"new_function_gaze_crap_threshold"`
+	Passed                       bool    `json:"passed"`
 }
 
 // ComparisonResult is the envelope for a baseline-vs-current

--- a/specs/039-baseline-gazecrap-threshold/checklists/requirements.md
+++ b/specs/039-baseline-gazecrap-threshold/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Baseline GazeCRAP New-Function Threshold
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. The spec is well-scoped around a single behavioral gap (issue #164) with clear before/after behavior.
+- No [NEEDS CLARIFICATION] markers — the design decision (Option 2: separate threshold, default 30) was resolved in conversation before spec generation.
+- Edge cases cover: exact-threshold boundary, zero GazeCRAP, mixed threshold values, invalid configuration.
+- Dependencies are limited to the existing baseline-comparison feature; no new packages or external dependencies anticipated.

--- a/specs/039-baseline-gazecrap-threshold/data-model.md
+++ b/specs/039-baseline-gazecrap-threshold/data-model.md
@@ -1,0 +1,144 @@
+# Data Model: Baseline GazeCRAP New-Function Threshold
+
+**Feature**: 039-baseline-gazecrap-threshold
+**Date**: 2026-06-23
+
+## Type Changes
+
+### `config.BaselineConfig` (internal/config/config.go)
+
+```go
+type BaselineConfig struct {
+    File                        string  `yaml:"file"`
+    Epsilon                     float64 `yaml:"epsilon"`
+    NewFunctionThreshold        float64 `yaml:"new_function_threshold"`
+    // NEW: GazeCRAP threshold for new functions. Must be > 0. Default: 30.
+    NewFunctionGazeCRAPThreshold float64 `yaml:"new_function_gaze_crap_threshold"`
+}
+```
+
+**Default**: 30 (set in `DefaultConfig()`)
+**Validation**: `> 0` (same as `NewFunctionThreshold`)
+**YAML key**: `baseline.new_function_gaze_crap_threshold`
+
+### `crap.CompareOptions` (internal/crap/compare.go)
+
+```go
+type CompareOptions struct {
+    Epsilon              float64
+    NewFunctionThreshold float64
+    // NEW: GazeCRAP score above which a new function is a violation.
+    NewFunctionGazeCRAPThreshold float64
+}
+```
+
+**Purpose**: Carries the GazeCRAP threshold from configuration to the comparison algorithm. No default — set by caller from config.
+
+### `crap.ComparisonSummary` (internal/crap/crap.go)
+
+```go
+type ComparisonSummary struct {
+    Regressions                  int     `json:"regressions"`
+    Improvements                 int     `json:"improvements"`
+    NewFunctions                 int     `json:"new_functions"`
+    NewViolations                int     `json:"new_violations"`
+    RemovedFunctions             int     `json:"removed_functions"`
+    Unchanged                    int     `json:"unchanged"`
+    Epsilon                      float64 `json:"epsilon"`
+    NewFunctionThreshold         float64 `json:"new_function_threshold"`
+    // NEW: GazeCRAP threshold for reproducibility in JSON output.
+    NewFunctionGazeCRAPThreshold float64 `json:"new_function_gaze_crap_threshold"`
+    Passed                       bool    `json:"passed"`
+}
+```
+
+**JSON field**: `new_function_gaze_crap_threshold`
+**Purpose**: Makes the GazeCRAP threshold visible in comparison output for reproducibility (FR-006).
+
+## Algorithm Changes
+
+### `buildComparisonSummary` (internal/crap/compare.go)
+
+Current logic:
+```go
+for _, s := range result.NewFunctions {
+    if s.CRAP > opts.NewFunctionThreshold {
+        summary.NewViolations++
+    } else {
+        summary.NewFunctions++
+    }
+}
+```
+
+New logic:
+```go
+for _, s := range result.NewFunctions {
+    crapViolation := s.CRAP > opts.NewFunctionThreshold
+    gazeViolation := s.GazeCRAP != nil && *s.GazeCRAP > opts.NewFunctionGazeCRAPThreshold
+    if crapViolation || gazeViolation {
+        summary.NewViolations++
+    } else {
+        summary.NewFunctions++
+    }
+}
+```
+
+Key behaviors:
+- **OR semantics**: Either metric exceeding its threshold triggers a violation (D5)
+- **Nil-safe**: `s.GazeCRAP != nil` guard prevents nil dereference (D4)
+- **Strict greater-than**: Consistent with existing CRAP comparison (D3)
+
+### `writeComparisonNewFunctions` (internal/crap/compare_report.go)
+
+The function signature gains a `gazeCRAPThreshold float64` parameter. The violation classification uses the same OR logic as `buildComparisonSummary`. The text output includes GazeCRAP when available:
+
+```
+  complexFunc (complex.go)                    CRAP: 42.0  GazeCRAP: 55.0  [VIOLATION]
+```
+
+When GazeCRAP is nil, the output remains unchanged:
+```
+  complexFunc (complex.go)                    CRAP: 42.0  [VIOLATION]
+```
+
+### `WriteComparisonJSON` (internal/crap/compare_report.go)
+
+The new-function status classification (lines 117-126) uses the same OR logic. The GazeCRAP threshold is read from `result.Summary.NewFunctionGazeCRAPThreshold`.
+
+## Configuration Example
+
+```yaml
+# .gaze.yaml
+baseline:
+  file: ".gaze/baseline.json"
+  epsilon: 0.5
+  new_function_threshold: 30
+  new_function_gaze_crap_threshold: 40  # Higher tolerance for GazeCRAP
+```
+
+## JSON Output Example
+
+```json
+{
+  "comparison": {
+    "regressions": 0,
+    "improvements": 1,
+    "new_functions": 2,
+    "new_violations": 1,
+    "removed_functions": 0,
+    "unchanged": 3,
+    "epsilon": 0.5,
+    "new_function_threshold": 30,
+    "new_function_gaze_crap_threshold": 30,
+    "passed": false
+  }
+}
+```
+
+## No Changes Required
+
+- `Score` struct — GazeCRAP field already exists (`*float64`)
+- `FunctionDelta` struct — no new-function delta tracking needed
+- `ComparisonResult` struct — no structural changes
+- `classifyDelta` function — already handles both metrics for existing functions
+- Baseline JSON format — thresholds come from config, not baseline files

--- a/specs/039-baseline-gazecrap-threshold/plan.md
+++ b/specs/039-baseline-gazecrap-threshold/plan.md
@@ -1,0 +1,127 @@
+# Implementation Plan: Baseline GazeCRAP New-Function Threshold
+
+**Branch**: `039-baseline-gazecrap-threshold` | **Date**: 2026-06-23 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/039-baseline-gazecrap-threshold/spec.md`
+**Issue**: #164
+
+## Summary
+
+The baseline comparison `buildComparisonSummary` function only evaluates classic CRAP against `new_function_threshold` for new functions. GazeCRAP is not evaluated, creating a blind spot where new functions with poor contract coverage pass unchallenged. This fix adds a separate `new_function_gaze_crap_threshold` (default 30) to `BaselineConfig` and evaluates both metrics independently in `buildComparisonSummary`. A new function is classified as `new_violation` if either its CRAP exceeds the CRAP threshold or its GazeCRAP exceeds the GazeCRAP threshold.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+ (per `go.mod` directive)
+**Primary Dependencies**: Standard library only (no new dependencies). Existing: `gopkg.in/yaml.v3` (config), `encoding/json` (report output)
+**Storage**: N/A — no persistence changes
+**Testing**: Standard library `testing` package, `-race -count=1`
+**Target Platform**: CLI binary (darwin/linux, amd64/arm64)
+**Project Type**: Single Go module
+**Performance Goals**: N/A — pure function changes, no performance-sensitive paths
+**Constraints**: Backward compatibility with existing `.gaze.yaml` files and baseline JSON
+**Scale/Scope**: 7 files modified, ~50 lines of production code, ~150 lines of test code
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Design Check
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| **I. Accuracy** | ✅ PASS | This fix closes a false-negative gap: new functions with high GazeCRAP were not flagged as violations. The change makes the gate more accurate by evaluating both risk metrics. Automated regression tests (SC-001 through SC-007) will verify correctness. |
+| **II. Minimal Assumptions** | ✅ PASS | No new assumptions about host projects. When GazeCRAP is unavailable (nil), only CRAP is evaluated — identical to current behavior. The new config field has a sensible default (30) and requires no user action. |
+| **III. Actionable Output** | ✅ PASS | The text and JSON reports will display both CRAP and GazeCRAP scores for new-function violations (FR-007), telling users exactly which metric triggered the violation. The GazeCRAP threshold is included in the comparison summary for reproducibility (FR-006). |
+| **IV. Testability** | ✅ PASS | All modified functions (`buildComparisonSummary`, `writeComparisonNewFunctions`, `WriteComparisonJSON`) are pure functions with injected dependencies. Tests use synthetic `Score` values — no external resources needed. Coverage strategy: unit tests for each acceptance scenario. |
+
+**Gate Result**: PASS — no violations. Proceed to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/039-baseline-gazecrap-threshold/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+cmd/gaze/
+  main.go                    # Wire new config field into CompareOptions
+
+internal/
+  config/
+    config.go                # Add NewFunctionGazeCRAPThreshold to BaselineConfig
+  crap/
+    compare.go               # Add field to CompareOptions, update buildComparisonSummary
+    compare_report.go         # Update violation check in JSON/text output
+    compare_test.go           # New tests for GazeCRAP threshold evaluation
+    compare_report_test.go    # Update report output tests
+    crap.go                   # Add NewFunctionGazeCRAPThreshold to ComparisonSummary
+```
+
+**Structure Decision**: All changes are within the existing package structure. No new packages, files, or directories are introduced. The change touches the `config`, `crap`, and `cmd/gaze` packages — the same packages that implement the existing baseline comparison feature.
+
+## Design Decisions
+
+### D1: Separate threshold field (not reuse existing)
+
+GazeCRAP and CRAP are different metrics with different score distributions. GazeCRAP scores tend to be higher because they incorporate contract coverage gaps. A single shared threshold would force teams to choose between weakening the CRAP gate or accepting false violations from GazeCRAP. Independent thresholds allow calibration per metric.
+
+**Alternative rejected**: Reusing `new_function_threshold` for both — rejected because it conflates two metrics with different scales.
+
+### D2: Default value of 30 (matches CRAP default)
+
+The default of 30 matches the existing `new_function_threshold` default. This is conservative — teams whose GazeCRAP scores naturally run higher can raise it. Starting equal avoids surprising users who haven't configured thresholds.
+
+**Alternative rejected**: A higher default (e.g., 50) — rejected because it would weaken the gate for new adopters. Users who need a higher threshold can configure it explicitly.
+
+### D3: Strict greater-than comparison (consistent with CRAP)
+
+The existing CRAP threshold uses `s.CRAP > opts.NewFunctionThreshold` (strict greater-than). The GazeCRAP check uses the same operator for consistency. A score exactly at the threshold is not a violation.
+
+### D4: Skip GazeCRAP check when nil (backward compatibility)
+
+When `Score.GazeCRAP` is nil (contract coverage not available), only the CRAP threshold is evaluated. This preserves identical behavior for users who don't use GazeCRAP and for baselines created by older gaze versions.
+
+### D5: OR semantics for violation (either metric triggers)
+
+A new function is a `new_violation` if CRAP exceeds its threshold OR GazeCRAP exceeds its threshold. This is consistent with how `classifyDelta` handles regressions (any regression signal wins). The conservative approach catches risk from either dimension.
+
+**Alternative rejected**: AND semantics (both must exceed) — rejected because it would allow a function with extreme GazeCRAP to pass if its CRAP is low, defeating the purpose of the GazeCRAP metric.
+
+### D6: Report output shows both scores for violations
+
+When a new function is a violation, the text report shows both CRAP and GazeCRAP scores so users can see which metric triggered it. This follows Constitution Principle III (Actionable Output) — users need to know what to fix.
+
+## Coverage Strategy
+
+| Layer | Scope | Target |
+|-------|-------|--------|
+| **Unit** | `buildComparisonSummary` — GazeCRAP above threshold, below threshold, nil, equal to threshold, both metrics above | 100% branch coverage of new logic |
+| **Unit** | `writeComparisonNewFunctions` — violation with GazeCRAP displayed, violation without GazeCRAP | 100% of new output paths |
+| **Unit** | `WriteComparisonJSON` — new function status includes GazeCRAP-triggered violations | Verify JSON status field |
+| **Unit** | `config.Load` — validation of `new_function_gaze_crap_threshold` (zero, negative, valid) | 100% of validation branches |
+| **Integration** | Full `Compare` → `WriteComparisonJSON`/`WriteComparisonText` flow with GazeCRAP threshold scenarios | End-to-end data flow |
+
+All tests use synthetic `Score` values and in-memory buffers. No external processes, no filesystem access beyond test fixtures.
+
+## Complexity Tracking
+
+No constitution violations to justify. All changes are within existing patterns and structures.
+
+## Post-Design Constitution Re-Check
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| **I. Accuracy** | ✅ PASS | Closes the false-negative gap (issue #164). Both CRAP and GazeCRAP are evaluated for new functions. Nil GazeCRAP is handled correctly (no false positives). |
+| **II. Minimal Assumptions** | ✅ PASS | Default config works without `.gaze.yaml`. New field is optional with sensible default. No user action required for existing setups. |
+| **III. Actionable Output** | ✅ PASS | Violation output shows both scores. Summary includes both thresholds. Users can see exactly which metric triggered the violation and what the threshold was. |
+| **IV. Testability** | ✅ PASS | Coverage strategy specified above. All new logic is in pure functions with injectable inputs. No global state, no I/O in the comparison algorithm. |
+
+**Gate Result**: PASS — design is constitution-compliant.

--- a/specs/039-baseline-gazecrap-threshold/quickstart.md
+++ b/specs/039-baseline-gazecrap-threshold/quickstart.md
@@ -1,0 +1,59 @@
+# Quickstart: Baseline GazeCRAP New-Function Threshold
+
+**Feature**: 039-baseline-gazecrap-threshold
+**Date**: 2026-06-23
+
+## What This Changes
+
+The `gaze crap --baseline` comparison now evaluates GazeCRAP scores for new functions, not just classic CRAP. A new function is flagged as a violation if either:
+- Its CRAP score exceeds `new_function_threshold` (existing behavior), OR
+- Its GazeCRAP score exceeds `new_function_gaze_crap_threshold` (new behavior)
+
+## Before (Bug)
+
+A new function with CRAP 25 (below threshold 30) but GazeCRAP 40 would pass the baseline gate — even though it carries high change risk due to poor contract coverage.
+
+## After (Fix)
+
+The same function is now flagged as `new_violation` because GazeCRAP 40 exceeds the GazeCRAP threshold of 30.
+
+## Configuration
+
+The new threshold is configured in `.gaze.yaml`:
+
+```yaml
+baseline:
+  new_function_threshold: 30              # CRAP threshold (existing)
+  new_function_gaze_crap_threshold: 40    # GazeCRAP threshold (new)
+```
+
+If not configured, the default is 30 (same as the CRAP threshold default).
+
+## Backward Compatibility
+
+- **No `.gaze.yaml`**: Default threshold of 30 applies. Existing behavior for CRAP is unchanged. GazeCRAP evaluation is new but uses the same default.
+- **GazeCRAP unavailable (nil)**: Only CRAP is evaluated. Identical to current behavior.
+- **Existing `.gaze.yaml` without new field**: Default of 30 is used. No user action required.
+
+## Key Files
+
+| File | What Changes |
+|------|-------------|
+| `internal/config/config.go` | New `NewFunctionGazeCRAPThreshold` field in `BaselineConfig` |
+| `internal/crap/compare.go` | `CompareOptions` gains field; `buildComparisonSummary` evaluates GazeCRAP |
+| `internal/crap/crap.go` | `ComparisonSummary` gains `new_function_gaze_crap_threshold` JSON field |
+| `internal/crap/compare_report.go` | Text/JSON output shows GazeCRAP for violations |
+| `cmd/gaze/main.go` | Wires config field into `CompareOptions` |
+
+## Testing
+
+Run the comparison tests:
+```bash
+go test -race -count=1 ./internal/crap/ -run 'TestSC'
+go test -race -count=1 ./internal/config/ -run 'TestBaseline'
+```
+
+Run all tests:
+```bash
+go test -race -count=1 -short ./...
+```

--- a/specs/039-baseline-gazecrap-threshold/research.md
+++ b/specs/039-baseline-gazecrap-threshold/research.md
@@ -1,0 +1,132 @@
+# Research: Baseline GazeCRAP New-Function Threshold
+
+**Feature**: 039-baseline-gazecrap-threshold
+**Date**: 2026-06-23
+**Status**: Complete
+
+## R1: Current Baseline Comparison Architecture
+
+### How `buildComparisonSummary` works today
+
+The `buildComparisonSummary` function in `internal/crap/compare.go` (lines 159-190) iterates over new functions and classifies each as either `new` or `new_violation` based solely on the classic CRAP score:
+
+```go
+for _, s := range result.NewFunctions {
+    if s.CRAP > opts.NewFunctionThreshold {
+        summary.NewViolations++
+    } else {
+        summary.NewFunctions++
+    }
+}
+```
+
+GazeCRAP is completely ignored for new functions, even when available. This is the bug described in issue #164.
+
+### Contrast with `classifyDelta` (existing functions)
+
+For existing functions (present in both baseline and current), `classifyDelta` (lines 131-155) already evaluates both CRAP and GazeCRAP symmetrically:
+
+```go
+if crapRegression || gazeRegression {
+    return StatusRegression
+}
+```
+
+The new-function threshold check is the only place where GazeCRAP is not evaluated. This fix brings it into alignment.
+
+### Data flow: config → CompareOptions → buildComparisonSummary
+
+1. `.gaze.yaml` → `config.Load()` → `BaselineConfig.NewFunctionThreshold`
+2. `cmd/gaze/main.go:loadAndCompare()` → `CompareOptions{NewFunctionThreshold: cfg.Baseline.NewFunctionThreshold}`
+3. `Compare()` → `buildComparisonSummary(result, opts)`
+4. `buildComparisonSummary` uses `opts.NewFunctionThreshold` for the CRAP check
+
+The new GazeCRAP threshold follows the same path: config → CompareOptions → buildComparisonSummary.
+
+## R2: Score.GazeCRAP Nullability
+
+`Score.GazeCRAP` is `*float64` (pointer, nullable). It is nil when:
+- Contract coverage analysis was not run
+- The function has no side effects to measure
+- The baseline was created by an older gaze version
+
+The new-function GazeCRAP check must handle nil gracefully: when `GazeCRAP` is nil, only the CRAP threshold is evaluated. This is consistent with how `classifyDelta` handles nil GazeCRAP (lines 96-101 of compare.go).
+
+## R3: ComparisonSummary JSON Output
+
+`ComparisonSummary` (lines 203-213 of crap.go) currently includes:
+- `new_function_threshold` (float64) — the CRAP threshold used
+
+Adding `new_function_gaze_crap_threshold` (float64) to this struct makes the GazeCRAP threshold visible in JSON output for reproducibility (FR-006).
+
+## R4: Report Output for New Functions
+
+### Text output (`writeComparisonNewFunctions`)
+
+Currently shows CRAP score only for violations:
+```
+New Functions (violations):
+  complexFunc (complex.go)                    CRAP: 42.0  [VIOLATION]
+```
+
+The fix adds GazeCRAP when available:
+```
+New Functions (violations):
+  complexFunc (complex.go)                    CRAP: 42.0  GazeCRAP: 55.0  [VIOLATION]
+```
+
+### JSON output (`WriteComparisonJSON`)
+
+The `newFunctionJSON` struct determines the status for new functions (lines 117-126 of compare_report.go). Currently:
+```go
+status := StatusNew
+if nf.CRAP > result.Summary.NewFunctionThreshold {
+    status = StatusNewViolation
+}
+```
+
+This must be updated to also check GazeCRAP against the GazeCRAP threshold. The GazeCRAP score is already included in the `Score` struct (embedded in `newFunctionJSON`), so no new fields are needed in the JSON output — only the status classification logic changes.
+
+## R5: Configuration Validation Pattern
+
+The existing `new_function_threshold` validation in `config.Load()` (lines 133-136):
+```go
+if cfg.Baseline.NewFunctionThreshold <= 0 {
+    return nil, fmt.Errorf("baseline.new_function_threshold must be > 0, got %g",
+        cfg.Baseline.NewFunctionThreshold)
+}
+```
+
+The new `new_function_gaze_crap_threshold` follows the same pattern: must be > 0, same error format.
+
+## R6: Backward Compatibility
+
+### Existing `.gaze.yaml` files
+
+YAML unmarshaling into a struct with `DefaultConfig()` as the base means missing fields get the default value. An existing `.gaze.yaml` without `new_function_gaze_crap_threshold` will use the default of 30. No user action required.
+
+### Existing baseline JSON files
+
+Baseline JSON files don't contain threshold configuration — thresholds come from `.gaze.yaml` or defaults. No baseline file changes needed.
+
+### Existing comparison JSON output
+
+The `ComparisonSummary` gains a new field (`new_function_gaze_crap_threshold`). Consumers using `json.Unmarshal` with a struct will ignore unknown fields. Consumers parsing raw JSON will see the new field. This is additive and non-breaking.
+
+## R7: Affected Functions (Complete List)
+
+| Function | File | Change |
+|----------|------|--------|
+| `BaselineConfig` | `internal/config/config.go` | Add `NewFunctionGazeCRAPThreshold float64` field |
+| `DefaultConfig` | `internal/config/config.go` | Set default to 30 |
+| `Load` | `internal/config/config.go` | Add validation (> 0) |
+| `CompareOptions` | `internal/crap/compare.go` | Add `NewFunctionGazeCRAPThreshold float64` field |
+| `buildComparisonSummary` | `internal/crap/compare.go` | Check GazeCRAP against threshold for new functions |
+| `ComparisonSummary` | `internal/crap/crap.go` | Add `NewFunctionGazeCRAPThreshold float64` JSON field |
+| `writeComparisonNewFunctions` | `internal/crap/compare_report.go` | Show GazeCRAP in violation output |
+| `WriteComparisonJSON` | `internal/crap/compare_report.go` | Use GazeCRAP threshold for status classification |
+| `loadAndCompare` | `cmd/gaze/main.go` | Wire `cfg.Baseline.NewFunctionGazeCRAPThreshold` into `CompareOptions` |
+
+## Open Questions
+
+None — all technical questions resolved through code analysis.

--- a/specs/039-baseline-gazecrap-threshold/spec.md
+++ b/specs/039-baseline-gazecrap-threshold/spec.md
@@ -1,0 +1,104 @@
+# Feature Specification: Baseline GazeCRAP New-Function Threshold
+
+**Feature Branch**: `039-baseline-gazecrap-threshold`
+**Created**: 2026-06-23
+**Status**: Draft
+**Input**: User description: "Baseline new-function threshold should evaluate GazeCRAP in addition to CRAP, with a separate configurable threshold (new_function_gaze_crap_threshold, default 30)"
+**Issue**: #164
+
+## User Scenarios & Testing
+
+### User Story 1 - GazeCRAP Violation Detection for New Functions (Priority: P1)
+
+A developer adds a new function to the codebase. The function has moderate complexity and decent line coverage, resulting in a CRAP score of 25 (below the new-function threshold of 30). However, its tests lack contract assertions, resulting in a GazeCRAP score of 40 (above the threshold). The baseline comparison should flag this as a violation and fail the gate, because the function carries high change risk when contract coverage is factored in.
+
+**Why this priority**: This is the core bug fix described in issue #164. Without this, the baseline comparison gate has a blind spot where new functions with poor contract coverage pass unchallenged. This directly undermines the value of GazeCRAP as a risk metric.
+
+**Independent Test**: Can be fully tested by running `gaze crap --baseline` against a baseline that does not contain the new function, where the new function has CRAP below threshold but GazeCRAP above threshold. The comparison should report a `new_violation` and exit non-zero.
+
+**Acceptance Scenarios**:
+
+1. **Given** a baseline with no entry for function `ProcessOrder`, **When** current results show `ProcessOrder` with CRAP 25 and GazeCRAP 40 (threshold 30 for both), **Then** the comparison classifies `ProcessOrder` as `new_violation` and `Summary.Passed` is false.
+2. **Given** a baseline with no entry for function `SimpleHelper`, **When** current results show `SimpleHelper` with CRAP 5 and GazeCRAP 8 (both below threshold 30), **Then** the comparison classifies `SimpleHelper` as `new` and `Summary.Passed` is true (assuming no other violations).
+3. **Given** a baseline with no entry for function `ComplexUntested`, **When** current results show `ComplexUntested` with CRAP 42 and GazeCRAP 55 (both above threshold 30), **Then** the comparison classifies `ComplexUntested` as `new_violation` and `Summary.Passed` is false.
+
+---
+
+### User Story 2 - Independent GazeCRAP Threshold Configuration (Priority: P2)
+
+A team uses `.gaze.yaml` to configure baseline comparison thresholds. Because GazeCRAP scores tend to be higher than classic CRAP scores (they incorporate contract coverage gaps), the team wants to set a higher tolerance for GazeCRAP on new functions (e.g., 40) while keeping the classic CRAP threshold at 30. The `new_function_gaze_crap_threshold` configuration field allows this independent calibration.
+
+**Why this priority**: This provides flexibility for teams whose GazeCRAP scores naturally run higher than their CRAP scores. Without a separate threshold, teams would either need to raise the CRAP threshold (weakening the CRAP gate) or accept false violations from GazeCRAP.
+
+**Independent Test**: Can be tested by creating a `.gaze.yaml` with `new_function_gaze_crap_threshold: 40`, adding a new function with CRAP 25 and GazeCRAP 38, and verifying it passes (GazeCRAP 38 < threshold 40). Then changing GazeCRAP to 42 and verifying it fails.
+
+**Acceptance Scenarios**:
+
+1. **Given** `.gaze.yaml` with `baseline.new_function_gaze_crap_threshold: 40`, **When** a new function has CRAP 25 and GazeCRAP 38, **Then** the function is classified as `new` (not a violation) because both scores are below their respective thresholds.
+2. **Given** `.gaze.yaml` with `baseline.new_function_gaze_crap_threshold: 40`, **When** a new function has CRAP 25 and GazeCRAP 42, **Then** the function is classified as `new_violation` because GazeCRAP exceeds its threshold.
+3. **Given** `.gaze.yaml` with no `new_function_gaze_crap_threshold` field, **When** baseline comparison runs, **Then** the default threshold of 30 is used for GazeCRAP evaluation.
+
+---
+
+### User Story 3 - Backward-Compatible Behavior When GazeCRAP Is Unavailable (Priority: P3)
+
+A developer runs baseline comparison against a codebase where GazeCRAP data is not available (e.g., contract coverage analysis was not run, or the function has nil GazeCRAP). The new-function threshold check should evaluate only classic CRAP, maintaining identical behavior to the current implementation.
+
+**Why this priority**: Backward compatibility is essential. Users who do not use GazeCRAP should see no behavior change. This is also the path taken when comparing against baselines created by older gaze versions that predate GazeCRAP.
+
+**Independent Test**: Can be tested by running baseline comparison where new functions have nil GazeCRAP values. Only the CRAP threshold should be evaluated.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new function with CRAP 25 and GazeCRAP nil, **When** baseline comparison runs with new-function CRAP threshold 30, **Then** the function is classified as `new` (CRAP 25 < 30, GazeCRAP skipped).
+2. **Given** a new function with CRAP 35 and GazeCRAP nil, **When** baseline comparison runs with new-function CRAP threshold 30, **Then** the function is classified as `new_violation` (CRAP 35 > 30, GazeCRAP skipped).
+
+---
+
+### Edge Cases
+
+- What happens when GazeCRAP is exactly equal to the threshold? Following the existing CRAP comparison pattern (`s.CRAP > opts.NewFunctionThreshold`), GazeCRAP at exactly the threshold value should not be a violation (strict greater-than comparison).
+- What happens when GazeCRAP is zero? A GazeCRAP of 0 is a valid score (fully covered simple function). It should be evaluated normally against the threshold (0 < 30, no violation).
+- What happens when the CRAP threshold and GazeCRAP threshold are set to different values in `.gaze.yaml`? Each metric is evaluated independently against its own threshold. A violation in either triggers `new_violation`.
+- What happens when `new_function_gaze_crap_threshold` is set to 0 in `.gaze.yaml`? Configuration validation should reject values <= 0, consistent with the existing `new_function_threshold` validation.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The new-function threshold check MUST evaluate both CRAP and GazeCRAP (when GazeCRAP is available). A new function MUST be classified as `new_violation` if either its CRAP score exceeds the CRAP threshold or its GazeCRAP score exceeds the GazeCRAP threshold.
+- **FR-002**: A `new_function_gaze_crap_threshold` configuration field MUST be added to the baseline configuration, with a default value of 30.
+- **FR-003**: When GazeCRAP is unavailable (nil) for a new function, only the CRAP threshold MUST be evaluated. The absence of GazeCRAP data MUST NOT trigger a violation.
+- **FR-004**: The GazeCRAP threshold MUST be independently configurable from the CRAP threshold, allowing teams to set different tolerance levels for each metric.
+- **FR-005**: Configuration validation MUST reject `new_function_gaze_crap_threshold` values that are zero or negative, consistent with existing `new_function_threshold` validation.
+- **FR-006**: The comparison summary output MUST include the GazeCRAP threshold value alongside the existing CRAP threshold for reproducibility.
+- **FR-007**: The text and JSON report output for new-function violations MUST display both CRAP and GazeCRAP scores when GazeCRAP is available, so users can see which metric triggered the violation.
+
+### Key Entities
+
+- **CompareOptions**: Extended with a GazeCRAP threshold field, carrying the threshold from configuration to the comparison algorithm.
+- **ComparisonSummary**: Extended with the GazeCRAP threshold value for output reproducibility.
+- **BaselineConfig**: Extended with the new configuration field and its default/validation rules.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A new function with CRAP below its threshold but GazeCRAP above its threshold is classified as `new_violation` and the comparison gate fails.
+- **SC-002**: A new function with both CRAP and GazeCRAP below their respective thresholds is classified as `new` and does not cause the gate to fail.
+- **SC-003**: When GazeCRAP is unavailable (nil) for a new function, the comparison behavior is identical to the current implementation (only CRAP evaluated).
+- **SC-004**: The CRAP and GazeCRAP new-function thresholds can be configured independently via `.gaze.yaml`, each with its own numeric value.
+- **SC-005**: The comparison summary JSON output includes the GazeCRAP threshold value, enabling consumers to understand which thresholds were applied.
+- **SC-006**: The text report displays both CRAP and GazeCRAP scores for new-function violations when GazeCRAP data is available.
+- **SC-007**: Invalid configuration values for `new_function_gaze_crap_threshold` (zero or negative) produce a clear validation error at configuration load time.
+
+### Assumptions
+
+- The default value of 30 for `new_function_gaze_crap_threshold` matches the existing `new_function_threshold` default. This is a conservative starting point; teams can adjust independently based on their GazeCRAP score distributions.
+- The strict greater-than comparison (`>`) is used for the GazeCRAP threshold, consistent with the existing CRAP threshold behavior.
+- The `classifyDelta` function (regression detection for existing functions) already evaluates both CRAP and GazeCRAP symmetrically. This spec brings the new-function threshold check into alignment with that established pattern.
+
+### Dependencies
+
+- **baseline-comparison** (prior work): This spec extends the baseline comparison feature. The `Compare`, `CompareOptions`, `ComparisonSummary`, and `buildComparisonSummary` types/functions from that work are the direct targets of modification.
+- **Issue #164**: This spec directly addresses the bug described in the issue.

--- a/specs/039-baseline-gazecrap-threshold/tasks.md
+++ b/specs/039-baseline-gazecrap-threshold/tasks.md
@@ -1,0 +1,200 @@
+# Tasks: Baseline GazeCRAP New-Function Threshold
+
+**Input**: Design documents from `specs/039-baseline-gazecrap-threshold/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+**Issue**: #164
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Foundational Type Changes (Blocking Prerequisites)
+
+**Purpose**: Add the new field to all types that carry the GazeCRAP threshold through the system. These structural changes MUST be complete before any user story logic can be implemented.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T001 [P] Add `NewFunctionGazeCRAPThreshold float64` field to `CompareOptions` struct in `internal/crap/compare.go` with GoDoc comment per data-model.md
+- [x] T002 [P] Add `NewFunctionGazeCRAPThreshold float64` field with `json:"new_function_gaze_crap_threshold"` tag to `ComparisonSummary` struct in `internal/crap/crap.go` with GoDoc comment per data-model.md
+- [x] T003 [P] Add `NewFunctionGazeCRAPThreshold float64` field with `yaml:"new_function_gaze_crap_threshold"` tag to `BaselineConfig` struct in `internal/config/config.go` with GoDoc comment per data-model.md
+- [x] T004 Set default value `NewFunctionGazeCRAPThreshold: 30` in `DefaultConfig()` in `internal/config/config.go`
+- [x] T005 Wire `cfg.Baseline.NewFunctionGazeCRAPThreshold` into `CompareOptions` in `loadAndCompare` function in `cmd/gaze/main.go` (line ~642)
+- [x] T006 Propagate `opts.NewFunctionGazeCRAPThreshold` into `summary.NewFunctionGazeCRAPThreshold` in `buildComparisonSummary` in `internal/crap/compare.go` (line ~162)
+
+**Checkpoint**: All types carry the GazeCRAP threshold field. Compilation must succeed. No behavioral changes yet — the new field exists but is not evaluated.
+
+---
+
+## Phase 2: US1 — GazeCRAP Violation Detection for New Functions (Priority: P1) 🎯 MVP
+
+**Goal**: New functions are classified as `new_violation` if either CRAP exceeds its threshold OR GazeCRAP exceeds its threshold (when GazeCRAP is available).
+
+**Independent Test**: Run `Compare()` with a new function that has CRAP below threshold but GazeCRAP above threshold. Verify `new_violation` classification and `Summary.Passed == false`.
+
+### Tests for US1
+
+- [x] T007 [US1] Add test `TestSC001_NewFunction_GazeCRAPAboveThreshold` in `internal/crap/compare_test.go` — new function with CRAP 25 (below 30) and GazeCRAP 40 (above 30) is classified as `new_violation`, `Summary.Passed` is false
+- [x] T008 [US1] Add test `TestSC001_NewFunction_BothAboveThreshold` in `internal/crap/compare_test.go` — new function with CRAP 42 and GazeCRAP 55 (both above 30) is classified as `new_violation`
+- [x] T009 [US1] Add test `TestSC001_NewFunction_BothBelowThreshold` in `internal/crap/compare_test.go` — new function with CRAP 5 and GazeCRAP 8 (both below 30) is classified as `new` (not violation), `Summary.Passed` is true
+- [x] T010 [US1] Add test `TestSC001_NewFunction_GazeCRAPEqualToThreshold` in `internal/crap/compare_test.go` — new function with GazeCRAP exactly 30 (equal to threshold 30) is NOT a violation (strict greater-than per D3)
+
+### Implementation for US1
+
+- [x] T011 [US1] Update `buildComparisonSummary` in `internal/crap/compare.go` — add GazeCRAP threshold check with nil guard and OR semantics per data-model.md algorithm (lines 177-183)
+
+**Checkpoint**: Core violation detection works. `buildComparisonSummary` evaluates both CRAP and GazeCRAP for new functions. All T007-T010 tests pass.
+
+---
+
+## Phase 3: US2 — Independent Threshold Configuration (Priority: P2)
+
+**Goal**: Teams can configure `new_function_gaze_crap_threshold` independently from `new_function_threshold` in `.gaze.yaml`.
+
+**Independent Test**: Create a `.gaze.yaml` with `baseline.new_function_gaze_crap_threshold: 40`, run comparison with a new function at GazeCRAP 38 (passes) and 42 (fails).
+
+### Tests for US2
+
+- [x] T012 [US2] Add test `TestSC004_IndependentThresholds` in `internal/crap/compare_test.go` — CRAP threshold 30, GazeCRAP threshold 40: new function with CRAP 25 and GazeCRAP 38 passes (both below respective thresholds)
+- [x] T013 [US2] Add test `TestSC004_IndependentThresholds_GazeCRAPExceeds` in `internal/crap/compare_test.go` — CRAP threshold 30, GazeCRAP threshold 40: new function with CRAP 25 and GazeCRAP 42 is `new_violation`
+- [x] T014 [US2] Add test `TestSC007_ConfigValidation_ZeroGazeCRAPThreshold` in `internal/config/config_test.go` — `.gaze.yaml` with `new_function_gaze_crap_threshold: 0` returns validation error
+- [x] T015 [US2] Add test `TestSC007_ConfigValidation_NegativeGazeCRAPThreshold` in `internal/config/config_test.go` — `.gaze.yaml` with `new_function_gaze_crap_threshold: -5` returns validation error
+- [x] T016 [US2] Add test `TestSC004_ConfigDefault_GazeCRAPThreshold` in `internal/config/config_test.go` — `DefaultConfig()` returns `NewFunctionGazeCRAPThreshold == 30`
+
+### Implementation for US2
+
+- [x] T017 [US2] Add validation for `NewFunctionGazeCRAPThreshold` in `Load()` in `internal/config/config.go` — must be > 0, same error format as `NewFunctionThreshold` validation (after line ~136)
+
+**Checkpoint**: Configuration is independently configurable and validated. All T012-T016 tests pass.
+
+---
+
+## Phase 4: US3 — Backward Compatibility When GazeCRAP Unavailable (Priority: P3)
+
+**Goal**: When `Score.GazeCRAP` is nil, only CRAP threshold is evaluated. Behavior is identical to pre-fix implementation.
+
+**Independent Test**: Run comparison with new functions that have nil GazeCRAP. Verify only CRAP threshold determines violation status.
+
+### Tests for US3
+
+- [x] T018 [US3] Add test `TestSC003_NilGazeCRAP_CRAPBelowThreshold` in `internal/crap/compare_test.go` — new function with CRAP 25 and GazeCRAP nil is classified as `new` (not violation)
+- [x] T019 [US3] Add test `TestSC003_NilGazeCRAP_CRAPAboveThreshold` in `internal/crap/compare_test.go` — new function with CRAP 35 and GazeCRAP nil is classified as `new_violation` (CRAP-only evaluation)
+
+### Implementation for US3
+
+No additional implementation needed — the nil guard added in T011 (`s.GazeCRAP != nil &&`) handles this case. These tests verify the backward-compatible behavior.
+
+**Checkpoint**: Nil GazeCRAP is handled correctly. All T018-T019 tests pass. Behavior is identical to pre-fix for nil GazeCRAP.
+
+---
+
+## Phase 5: Report Output Updates
+
+**Purpose**: Update text and JSON report output to display GazeCRAP for new-function violations (FR-006, FR-007).
+
+### Tests
+
+- [x] T020 [P] [US1] Add test `TestSC006_TextReport_ViolationShowsGazeCRAP` in `internal/crap/compare_report_test.go` — text output for a new-function violation includes both `CRAP: X.X` and `GazeCRAP: Y.Y` when GazeCRAP is available
+- [x] T021 [P] [US1] Add test `TestSC006_TextReport_ViolationWithoutGazeCRAP` in `internal/crap/compare_report_test.go` — text output for a violation with nil GazeCRAP shows only `CRAP: X.X` (no GazeCRAP label)
+- [x] T022 [P] [US1] Add test `TestSC005_JSONOutput_SummaryIncludesGazeCRAPThreshold` in `internal/crap/compare_report_test.go` — JSON `comparison` object includes `new_function_gaze_crap_threshold` field
+- [x] T023 [P] [US1] Add test `TestSC005_JSONOutput_NewFunctionStatusUsesGazeCRAP` in `internal/crap/compare_report_test.go` — JSON new-function status is `new_violation` when GazeCRAP exceeds threshold (even if CRAP is below)
+
+### Implementation
+
+- [x] T024 [US1] Update `writeComparisonNewFunctions` in `internal/crap/compare_report.go` — add `gazeCRAPThreshold float64` parameter, use OR logic for violation classification, display GazeCRAP score in violation output when non-nil
+- [x] T025 [US1] Update `WriteComparisonText` call site in `internal/crap/compare_report.go` (line ~186) to pass `result.Summary.NewFunctionGazeCRAPThreshold` to `writeComparisonNewFunctions`
+- [x] T026 [US1] Update `WriteComparisonJSON` new-function status logic in `internal/crap/compare_report.go` (lines 117-121) — add GazeCRAP threshold check with nil guard, using `result.Summary.NewFunctionGazeCRAPThreshold`
+
+**Checkpoint**: Report output shows GazeCRAP for violations. All T020-T023 tests pass. JSON summary includes the GazeCRAP threshold.
+
+---
+
+## Phase 6: Polish & Validation
+
+**Purpose**: Final verification, documentation, and CI readiness.
+
+- [x] T027 Run `go build ./cmd/gaze` — verify clean compilation
+- [x] T028 Run `go test -race -count=1 -short ./internal/crap/...` — verify all comparison tests pass
+- [x] T029 Run `go test -race -count=1 -short ./internal/config/...` — verify all config tests pass
+- [x] T030 Run `go test -race -count=1 -short ./...` — verify no regressions across the full module
+- [x] T031 Run `golangci-lint run` — verify no lint violations
+- [x] T032 Verify GoDoc comments on all new/modified exported fields (`CompareOptions.NewFunctionGazeCRAPThreshold`, `ComparisonSummary.NewFunctionGazeCRAPThreshold`, `BaselineConfig.NewFunctionGazeCRAPThreshold`)
+- [x] T033 Run quickstart.md validation — verify the testing commands from quickstart.md produce expected results
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Foundational)**: No dependencies — can start immediately. BLOCKS all subsequent phases.
+- **Phase 2 (US1 — P1)**: Depends on Phase 1 completion. Core fix.
+- **Phase 3 (US2 — P2)**: Depends on Phase 1 completion. Can run in parallel with Phase 2 (different files: config vs. crap).
+- **Phase 4 (US3 — P3)**: Depends on Phase 2 completion (T011 provides the nil guard). Tests only — no new implementation.
+- **Phase 5 (Report Output)**: Depends on Phase 2 completion (needs the OR logic pattern established).
+- **Phase 6 (Polish)**: Depends on all previous phases.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Phase 1. No dependencies on other stories.
+- **US2 (P2)**: Can start after Phase 1. Independent of US1 (config validation is separate from comparison logic).
+- **US3 (P3)**: Depends on US1 (the nil guard in T011 is what makes backward compatibility work). Tests only.
+
+### Within Each Phase
+
+- T001, T002, T003 can run in parallel (different files)
+- T004 depends on T003 (same file, same function)
+- T005 depends on T001 (needs `CompareOptions` field to exist)
+- T006 depends on T001, T002 (needs both `CompareOptions` and `ComparisonSummary` fields)
+- T007-T010 should be written before T011 (test-first)
+- T020-T023 can run in parallel (different test functions, same file — no conflicts)
+- T024-T026 are sequential (same file, related functions)
+
+### Parallel Opportunities
+
+```
+Phase 1 parallel group:
+  T001 (compare.go)  |  T002 (crap.go)  |  T003 (config.go)
+
+Phase 2+3 parallel (after Phase 1):
+  US1: T007-T011 (compare.go, compare_test.go)
+  US2: T014-T017 (config.go, config_test.go)
+
+Phase 5 test parallel group:
+  T020 | T021 | T022 | T023 (all in compare_report_test.go, different test functions)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Complete Phase 1: Foundational type changes
+2. Complete Phase 2: US1 — GazeCRAP violation detection
+3. **STOP and VALIDATE**: Run `go test -race -count=1 -short ./internal/crap/...`
+4. The core bug (#164) is fixed at this point
+
+### Full Delivery
+
+1. Phase 1 → Foundation ready
+2. Phase 2 (US1) + Phase 3 (US2) → in parallel if desired
+3. Phase 4 (US3) → backward compatibility verified
+4. Phase 5 → report output updated
+5. Phase 6 → full validation, CI readiness
+
+---
+
+## Notes
+
+- All tests use synthetic `Score` values and in-memory buffers — no external processes or filesystem access
+- The `*float64` nil pattern for GazeCRAP is established in the codebase; follow the same `float64Ptr()` test helper
+- Strict greater-than (`>`) comparison per D3 — a score exactly at threshold is NOT a violation
+- Total production code: ~50 lines across 5 files
+- Total test code: ~150 lines across 2 test files
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes #164 — the baseline comparison `new_function_threshold` check only evaluated CRAP, not GazeCRAP. A new function with CRAP 25 (below threshold) but GazeCRAP 40 (above threshold) would silently pass the baseline gate.

### Changes

- **New config field**: `baseline.new_function_gaze_crap_threshold` in `.gaze.yaml` (default: 30), independently configurable from the CRAP threshold
- **OR semantics in `buildComparisonSummary`**: either CRAP or GazeCRAP exceeding its respective threshold triggers `new_violation`
- **Backward compatible**: when GazeCRAP is nil (unavailable), only CRAP is evaluated
- **Report output**: text violations now show both CRAP and GazeCRAP scores; JSON summary includes `new_function_gaze_crap_threshold`
- **15 new tests** covering all acceptance scenarios, edge cases (exact threshold, nil GazeCRAP), config validation, and report output

### Files changed

| File | Change |
|------|--------|
| `internal/config/config.go` | Add `NewFunctionGazeCRAPThreshold` field, default 30, validation |
| `internal/crap/compare.go` | Add field to `CompareOptions`, OR logic in `buildComparisonSummary` |
| `internal/crap/crap.go` | Add field to `ComparisonSummary` |
| `internal/crap/compare_report.go` | Update text/JSON output for GazeCRAP violations |
| `cmd/gaze/main.go` | Wire config to `CompareOptions` |
| `internal/crap/compare_test.go` | 8 new comparison tests |
| `internal/crap/compare_report_test.go` | 4 new report tests |
| `internal/config/config_test.go` | 3 new config tests |

### Spec

`specs/039-baseline-gazecrap-threshold/` — full spec artifacts included (spec.md, plan.md, tasks.md, research.md, data-model.md, quickstart.md).