### PR TITLE
fix: display GazeCRAP deltas in baseline text comparison table (#163)

### DIFF
--- a/.uf/dewey/learnings/compare-report-20260623T200449-jay-flowers.md
+++ b/.uf/dewey/learnings/compare-report-20260623T200449-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: compare-report
+author: jay-flowers
+category: pattern
+created_at: 2026-06-23T20:04:49Z
+identity: compare-report-20260623T200449-jay-flowers
+tier: draft
+---
+
+The writeComparisonDeltaTable function in internal/crap/compare_report.go uses a conditional rendering pattern for optional data: it first scans all matching deltas to detect whether any have GazeCRAP data (hasGaze flag), then uses one of two rendering branches — a two-row format when GazeCRAP exists (function name on its own line, then indented GazeCRAP and CRAP metric rows) or the original single-row format when no GazeCRAP data is present. This pattern keeps backward compatibility while extending the display. The 80-column terminal width constraint from AGENTS.md was the key architectural driver — adding inline columns would have exceeded 108 chars, so the two-row format was chosen to stay under 80. The width compliance test scopes its assertion to the comparison section only (after the "--- Baseline Comparison" header), not the preceding WriteText output which has its own width management.

--- a/internal/crap/compare_report.go
+++ b/internal/crap/compare_report.go
@@ -193,6 +193,12 @@ func WriteComparisonText(w io.Writer, result *ComparisonResult) error {
 
 // writeComparisonDeltaTable writes a table of function deltas
 // filtered by the given status. Omitted if no deltas match.
+//
+// When any matching delta has GazeCRAP data, the table uses a
+// two-row-per-function format: function name on its own line,
+// then indented GazeCRAP row (first) and CRAP row (second).
+// When no GazeCRAP data is available, the single-row format is
+// preserved for backward compatibility.
 func writeComparisonDeltaTable(w io.Writer, title string, deltas []FunctionDelta, status FunctionStatus) {
 	var matching []FunctionDelta
 	for _, d := range deltas {
@@ -204,14 +210,48 @@ func writeComparisonDeltaTable(w io.Writer, title string, deltas []FunctionDelta
 		return
 	}
 
+	// Detect whether any matching delta has GazeCRAP data.
+	hasGaze := false
+	for _, d := range matching {
+		if d.GazeCRAPDelta != nil {
+			hasGaze = true
+			break
+		}
+	}
+
 	_, _ = fmt.Fprintf(w, "\n%s:\n", title)
 	_, _ = fmt.Fprintf(w, "  %-40s  %-10s  %-10s  %-10s\n",
 		"Function", "Baseline", "Current", "Delta")
-	for _, d := range matching {
-		label := fmt.Sprintf("%s (%s)",
-			d.Current.Function, shortenPath(d.Current.File))
-		_, _ = fmt.Fprintf(w, "  %-40s  %-10.1f  %-10.1f  %+.1f\n",
-			label, d.Baseline.CRAP, d.Current.CRAP, d.CRAPDelta)
+
+	if hasGaze {
+		// Two-row format: function name on its own line,
+		// then indented GazeCRAP (first) and CRAP (second).
+		for _, d := range matching {
+			label := fmt.Sprintf("%s (%s)",
+				d.Current.Function, shortenPath(d.Current.File))
+			_, _ = fmt.Fprintf(w, "  %s\n", label)
+
+			if d.GazeCRAPDelta != nil &&
+				d.Baseline.GazeCRAP != nil &&
+				d.Current.GazeCRAP != nil {
+				_, _ = fmt.Fprintf(w, "    %-38s  %-10.1f  %-10.1f  %+.1f\n",
+					"GazeCRAP", *d.Baseline.GazeCRAP,
+					*d.Current.GazeCRAP, *d.GazeCRAPDelta)
+			}
+
+			_, _ = fmt.Fprintf(w, "    %-38s  %-10.1f  %-10.1f  %+.1f\n",
+				"CRAP", d.Baseline.CRAP, d.Current.CRAP,
+				d.CRAPDelta)
+		}
+	} else {
+		// Single-row format (no GazeCRAP data).
+		for _, d := range matching {
+			label := fmt.Sprintf("%s (%s)",
+				d.Current.Function, shortenPath(d.Current.File))
+			_, _ = fmt.Fprintf(w, "  %-40s  %-10.1f  %-10.1f  %+.1f\n",
+				label, d.Baseline.CRAP, d.Current.CRAP,
+				d.CRAPDelta)
+		}
 	}
 }
 

--- a/internal/crap/compare_report_test.go
+++ b/internal/crap/compare_report_test.go
@@ -411,3 +411,269 @@ func TestSC008_WriteComparisonText_RegressionTable(t *testing.T) {
 		t.Error("output missing 'Removed Functions:' section")
 	}
 }
+
+// --- Issue #163: GazeCRAP delta table display tests ---
+
+func TestDeltaTable_TwoRowFormat_WithGazeCRAP(t *testing.T) {
+	// When a delta has GazeCRAP data, the two-row format should
+	// show function name on its own line, then indented GazeCRAP
+	// and CRAP rows.
+	result := &ComparisonResult{
+		Report: &Report{
+			Scores: []Score{
+				makeScore("internal/crap/analyze.go", "Analyze", 12.0, float64Ptr(12.1)),
+			},
+			Summary: Summary{TotalFunctions: 1, CRAPThreshold: 15},
+		},
+		Deltas: []FunctionDelta{
+			{
+				Baseline:      makeScore("internal/crap/analyze.go", "Analyze", 12.0, float64Ptr(8.5)),
+				Current:       makeScore("internal/crap/analyze.go", "Analyze", 12.0, float64Ptr(12.1)),
+				CRAPDelta:     0.0,
+				GazeCRAPDelta: float64Ptr(3.6),
+				Status:        StatusRegression,
+			},
+		},
+		Summary: ComparisonSummary{
+			Regressions:          1,
+			Passed:               false,
+			Epsilon:              0.5,
+			NewFunctionThreshold: 30,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteComparisonText(&buf, result); err != nil {
+		t.Fatalf("WriteComparisonText() error: %v", err)
+	}
+
+	output := buf.String()
+
+	// Function name should appear on its own line.
+	if !strings.Contains(output, "Analyze (") {
+		t.Error("output missing function name")
+	}
+	// GazeCRAP row with values.
+	if !strings.Contains(output, "GazeCRAP") {
+		t.Error("output missing GazeCRAP label")
+	}
+	if !strings.Contains(output, "8.5") {
+		t.Error("output missing GazeCRAP baseline value 8.5")
+	}
+	if !strings.Contains(output, "12.1") {
+		t.Error("output missing GazeCRAP current value 12.1")
+	}
+	if !strings.Contains(output, "+3.6") {
+		t.Error("output missing GazeCRAP delta +3.6")
+	}
+	// CRAP row with values.
+	if !strings.Contains(output, "+0.0") {
+		t.Error("output missing CRAP delta +0.0")
+	}
+}
+
+func TestDeltaTable_TwoRowFormat_MixedGazeCRAP(t *testing.T) {
+	// One function has GazeCRAP, another doesn't. The one with
+	// GazeCRAP gets both rows, the one without gets only CRAP.
+	result := &ComparisonResult{
+		Report: &Report{
+			Scores: []Score{
+				makeScore("a.go", "WithGaze", 10.0, float64Ptr(15.0)),
+				makeScore("b.go", "NoGaze", 8.0, nil),
+			},
+			Summary: Summary{TotalFunctions: 2, CRAPThreshold: 15},
+		},
+		Deltas: []FunctionDelta{
+			{
+				Baseline:      makeScore("a.go", "WithGaze", 8.0, float64Ptr(10.0)),
+				Current:       makeScore("a.go", "WithGaze", 10.0, float64Ptr(15.0)),
+				CRAPDelta:     2.0,
+				GazeCRAPDelta: float64Ptr(5.0),
+				Status:        StatusRegression,
+			},
+			{
+				Baseline:  makeScore("b.go", "NoGaze", 5.0, nil),
+				Current:   makeScore("b.go", "NoGaze", 8.0, nil),
+				CRAPDelta: 3.0,
+				Status:    StatusRegression,
+			},
+		},
+		Summary: ComparisonSummary{
+			Regressions:          2,
+			Passed:               false,
+			Epsilon:              0.5,
+			NewFunctionThreshold: 30,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteComparisonText(&buf, result); err != nil {
+		t.Fatalf("WriteComparisonText() error: %v", err)
+	}
+
+	output := buf.String()
+
+	// WithGaze should have GazeCRAP row.
+	if !strings.Contains(output, "GazeCRAP") {
+		t.Error("output missing GazeCRAP label for WithGaze function")
+	}
+
+	// NoGaze should NOT have a GazeCRAP row — count occurrences.
+	// GazeCRAP label should appear exactly once (for WithGaze only).
+	count := strings.Count(output, "GazeCRAP")
+	if count != 1 {
+		t.Errorf("GazeCRAP label appears %d times, want 1 (only for WithGaze)", count)
+	}
+
+	// Both functions should have CRAP rows.
+	crapCount := strings.Count(output, "    CRAP")
+	if crapCount != 2 {
+		t.Errorf("CRAP label appears %d times, want 2 (one per function)", crapCount)
+	}
+}
+
+func TestDeltaTable_SingleRowFormat_NoGazeCRAP(t *testing.T) {
+	// When no function has GazeCRAP data, use the single-row
+	// format (backward compatible).
+	result := &ComparisonResult{
+		Report: &Report{
+			Scores: []Score{
+				makeScore("a.go", "FuncA", 15.0, nil),
+			},
+			Summary: Summary{TotalFunctions: 1, CRAPThreshold: 15},
+		},
+		Deltas: []FunctionDelta{
+			{
+				Baseline:  makeScore("a.go", "FuncA", 10.0, nil),
+				Current:   makeScore("a.go", "FuncA", 15.0, nil),
+				CRAPDelta: 5.0,
+				Status:    StatusRegression,
+			},
+		},
+		Summary: ComparisonSummary{
+			Regressions:          1,
+			Passed:               false,
+			Epsilon:              0.5,
+			NewFunctionThreshold: 30,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteComparisonText(&buf, result); err != nil {
+		t.Fatalf("WriteComparisonText() error: %v", err)
+	}
+
+	output := buf.String()
+
+	// Should NOT contain indented metric labels (two-row format).
+	if strings.Contains(output, "    CRAP") {
+		t.Error("single-row format should not contain indented CRAP label")
+	}
+	if strings.Contains(output, "GazeCRAP") {
+		t.Error("single-row format should not contain GazeCRAP label")
+	}
+
+	// Should contain the function with values on one line.
+	if !strings.Contains(output, "FuncA") {
+		t.Error("output missing function name")
+	}
+	if !strings.Contains(output, "+5.0") {
+		t.Error("output missing delta +5.0")
+	}
+}
+
+func TestDeltaTable_GazeCRAPBeforeCRAP(t *testing.T) {
+	// Verify GazeCRAP row appears before CRAP row (D1).
+	result := &ComparisonResult{
+		Report: &Report{
+			Scores: []Score{
+				makeScore("a.go", "Func", 10.0, float64Ptr(20.0)),
+			},
+			Summary: Summary{TotalFunctions: 1, CRAPThreshold: 15},
+		},
+		Deltas: []FunctionDelta{
+			{
+				Baseline:      makeScore("a.go", "Func", 8.0, float64Ptr(15.0)),
+				Current:       makeScore("a.go", "Func", 10.0, float64Ptr(20.0)),
+				CRAPDelta:     2.0,
+				GazeCRAPDelta: float64Ptr(5.0),
+				Status:        StatusRegression,
+			},
+		},
+		Summary: ComparisonSummary{
+			Regressions:          1,
+			Passed:               false,
+			Epsilon:              0.5,
+			NewFunctionThreshold: 30,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteComparisonText(&buf, result); err != nil {
+		t.Fatalf("WriteComparisonText() error: %v", err)
+	}
+
+	output := buf.String()
+
+	gazeIdx := strings.Index(output, "GazeCRAP")
+	crapIdx := strings.Index(output, "    CRAP")
+	if gazeIdx < 0 {
+		t.Fatal("output missing GazeCRAP label")
+	}
+	if crapIdx < 0 {
+		t.Fatal("output missing indented CRAP label")
+	}
+	if gazeIdx >= crapIdx {
+		t.Errorf("GazeCRAP (pos %d) should appear before CRAP (pos %d)",
+			gazeIdx, crapIdx)
+	}
+}
+
+func TestDeltaTable_TwoRowFormat_WidthCompliance(t *testing.T) {
+	// Verify no line in the comparison section (after "--- Baseline
+	// Comparison") exceeds 80 characters. The preceding WriteText
+	// output has its own width constraints.
+	result := &ComparisonResult{
+		Report: &Report{
+			Scores: []Score{
+				makeScore("internal/crap/analyze.go", "AnalyzeVeryLongFunctionName", 12.5, float64Ptr(18.3)),
+			},
+			Summary: Summary{TotalFunctions: 1, CRAPThreshold: 15},
+		},
+		Deltas: []FunctionDelta{
+			{
+				Baseline:      makeScore("internal/crap/analyze.go", "AnalyzeVeryLongFunctionName", 9.2, float64Ptr(14.1)),
+				Current:       makeScore("internal/crap/analyze.go", "AnalyzeVeryLongFunctionName", 12.5, float64Ptr(18.3)),
+				CRAPDelta:     3.3,
+				GazeCRAPDelta: float64Ptr(4.2),
+				Status:        StatusRegression,
+			},
+		},
+		Summary: ComparisonSummary{
+			Regressions:          1,
+			Passed:               false,
+			Epsilon:              0.5,
+			NewFunctionThreshold: 30,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteComparisonText(&buf, result); err != nil {
+		t.Fatalf("WriteComparisonText() error: %v", err)
+	}
+
+	output := buf.String()
+	comparisonStart := strings.Index(output, "--- Baseline Comparison")
+	if comparisonStart < 0 {
+		t.Fatal("output missing '--- Baseline Comparison' header")
+	}
+
+	comparisonSection := output[comparisonStart:]
+	lines := strings.Split(comparisonSection, "\n")
+	for i, line := range lines {
+		if len(line) > 80 {
+			t.Errorf("comparison line %d exceeds 80 columns (%d chars): %q",
+				i+1, len(line), line)
+		}
+	}
+}

--- a/openspec/changes/baseline-text-gazecrap-delta/.openspec.yaml
+++ b/openspec/changes/baseline-text-gazecrap-delta/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-23

--- a/openspec/changes/baseline-text-gazecrap-delta/design.md
+++ b/openspec/changes/baseline-text-gazecrap-delta/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The baseline comparison text report (`writeComparisonDeltaTable` in `internal/crap/compare_report.go`) renders a table of function deltas for regressions and improvements. Currently it only shows CRAP values (baseline, current, delta). The `FunctionDelta` struct already carries `GazeCRAPDelta *float64` and the baseline/current `Score` structs carry `GazeCRAP *float64`, but these are not rendered in the text output.
+
+The 80-column terminal width constraint (AGENTS.md) prevents simply adding three more columns to the existing table — the current header is already 78 chars wide.
+
+## Goals / Non-Goals
+
+### Goals
+- Display GazeCRAP baseline, current, and delta values in the text comparison table when GazeCRAP data is available
+- Stay within the 80-column terminal width constraint
+- Preserve the existing single-row format when no GazeCRAP data is available (backward compatible output)
+
+### Non-Goals
+- Modifying JSON output (already includes all GazeCRAP fields)
+- Adding new types or config fields
+- Changing regression/improvement classification logic (already correct)
+- Changing the new-function or removed-function sections (separate concern)
+
+## Decisions
+
+### D1: Two-row-per-function format with GazeCRAP first
+
+When any matching delta in the table has GazeCRAP data, switch to a two-row format where the function name appears on its own line, followed by indented metric rows. GazeCRAP is rendered first, CRAP second.
+
+```
+Regressions:
+  Function                                  Baseline    Current     Delta
+  doSomething (internal/crap/c...)
+    GazeCRAP                                8.5         12.1        +3.6
+    CRAP                                    12.0        12.0        +0.0
+```
+
+**Rationale**: GazeCRAP first because it incorporates contract coverage — the richer, more actionable metric. When a function regresses on GazeCRAP but not CRAP, the GazeCRAP row (first) immediately explains the classification. CRAP second provides the traditional baseline for comparison.
+
+**Alternative considered**: GazeCRAP second. Rejected because the eye naturally reads top-down, and the metric that most often explains the classification should come first.
+
+### D2: Conditional format based on data availability
+
+Detect whether any function in the matching set has GazeCRAP delta data. If none do, use the current single-row format unchanged. This avoids visual noise when GazeCRAP data is absent (e.g., older baselines, runs without contract coverage).
+
+**Detection**: Check if any `d.GazeCRAPDelta != nil` in the matching deltas.
+
+### D3: Function name on its own row in two-row mode
+
+In two-row mode, the function name (with file path) is printed on a line by itself, with the metric rows indented below it. This keeps each metric row's column values cleanly aligned without needing to truncate function names further.
+
+**Rationale**: Putting the function name on the same row as GazeCRAP values would require reducing the function name column width from 40 to ~30 chars to fit all values, causing more name truncation. A separate name row avoids this tradeoff.
+
+### D4: Omit GazeCRAP row for functions without GazeCRAP data
+
+When the table is in two-row mode (because at least one function has GazeCRAP data), functions that lack GazeCRAP data still show the CRAP row but omit the GazeCRAP row. This avoids printing empty/zero GazeCRAP lines.
+
+### D5: No signature change to writeComparisonDeltaTable
+
+The function already receives `[]FunctionDelta` which contains all the needed data (`GazeCRAPDelta`, `Baseline.GazeCRAP`, `Current.GazeCRAP`). No parameter changes required.
+
+## Risks / Trade-offs
+
+- **Vertical space increase**: Two-row mode uses ~2x vertical space per function. For tables with many regressions/improvements, this could produce longer output. Accepted because the additional context (GazeCRAP values) justifies the space, and the regression/improvement tables are typically short (most functions are unchanged).
+- **Mixed format within a table**: When some functions have GazeCRAP data and others don't, the table will have a mix of two-row entries (with GazeCRAP) and entries with just the CRAP row (no GazeCRAP). This is slightly uneven visually but preferable to printing empty GazeCRAP rows.
+- **Observable Quality** (Constitution III): This change improves text output observability by surfacing computed GazeCRAP data that was previously hidden. The JSON format is unchanged and continues to carry full provenance.

--- a/openspec/changes/baseline-text-gazecrap-delta/proposal.md
+++ b/openspec/changes/baseline-text-gazecrap-delta/proposal.md
@@ -1,0 +1,76 @@
+## Why
+
+The baseline comparison text report (`writeComparisonDeltaTable` in `internal/crap/compare_report.go`) only displays CRAP values in its delta table. When a function regresses due to GazeCRAP (but not CRAP), the user sees it marked as "regression" without understanding why — the GazeCRAP numbers that triggered the classification are invisible.
+
+The JSON format already includes all fields (`baseline_gaze_crap`, `gaze_crap_delta`), so this is a display-only gap in the human-readable text report.
+
+Fixes #163.
+
+## What Changes
+
+Update `writeComparisonDeltaTable` to display GazeCRAP data using a two-row-per-function format. When GazeCRAP deltas are available for any function in the table, each function gets two rows: a GazeCRAP row first, then the CRAP row second. This keeps the output within the 80-column terminal constraint while making both metrics visible.
+
+Before:
+```
+Regressions:
+  Function                                  Baseline    Current     Delta
+  doSomething (internal/crap/c...)          12.0        12.0        +0.0
+```
+
+After (when GazeCRAP data is available):
+```
+Regressions:
+  Function                                  Baseline    Current     Delta
+  doSomething (internal/crap/c...)
+    GazeCRAP                                8.5         12.1        +3.6
+    CRAP                                    12.0        12.0        +0.0
+```
+
+When no function in the table has GazeCRAP data, the current single-row format is preserved unchanged.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `writeComparisonDeltaTable`: Displays GazeCRAP deltas alongside CRAP deltas in a two-row-per-function format when GazeCRAP data is available
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **`internal/crap/compare_report.go`**: `writeComparisonDeltaTable` updated with two-row format and GazeCRAP rendering
+- **`internal/crap/compare_report_test.go`**: Tests updated/added for GazeCRAP delta display
+- Text output width stays within 80-column constraint
+- JSON output is unchanged — this is a text-only fix
+- No new types, config fields, or CLI flags
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This is a display-only change to a text formatter. No artifact interfaces, inter-hero communication, or self-describing outputs are affected.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No new dependencies or mandatory couplings are introduced. The change is confined to one internal function in one file.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The change improves observable quality by surfacing GazeCRAP delta data that was already computed and available in the JSON format but hidden from the human-readable text report. Users can now see which metric triggered a regression or improvement classification.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+`writeComparisonDeltaTable` is a pure function that writes to `io.Writer` with synthetic `FunctionDelta` inputs — fully testable in isolation without external services. All new behavior will be covered by unit tests using in-memory buffers.

--- a/openspec/changes/baseline-text-gazecrap-delta/specs/delta-table-gazecrap.md
+++ b/openspec/changes/baseline-text-gazecrap-delta/specs/delta-table-gazecrap.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: GazeCRAP delta display in text comparison table
+
+When GazeCRAP delta data is available for any function in a regression or improvement table, `writeComparisonDeltaTable` MUST render each function using a two-row format: the function name on its own line, followed by indented GazeCRAP and CRAP metric rows. GazeCRAP MUST be rendered before CRAP.
+
+#### Scenario: Function with both CRAP and GazeCRAP deltas
+
+- **GIVEN** a baseline comparison result where function `doSomething` has CRAP delta +0.0 and GazeCRAP delta +3.6
+- **WHEN** `writeComparisonDeltaTable` renders the regressions table
+- **THEN** the output contains the function name on its own line, followed by a `GazeCRAP` row showing baseline 8.5, current 12.1, delta +3.6, followed by a `CRAP` row showing baseline 12.0, current 12.0, delta +0.0
+
+#### Scenario: Function with CRAP delta only (no GazeCRAP)
+
+- **GIVEN** a baseline comparison result where function `helperFunc` has CRAP delta -2.0 and GazeCRAP delta is nil, but another function in the same table has GazeCRAP data
+- **WHEN** `writeComparisonDeltaTable` renders the improvements table
+- **THEN** the output contains the function name on its own line, followed by only a `CRAP` row (no GazeCRAP row), and the `CRAP` row shows the correct baseline, current, and delta values
+
+### Requirement: Conditional format based on GazeCRAP data availability
+
+`writeComparisonDeltaTable` MUST detect whether any matching delta has non-nil `GazeCRAPDelta`. When no matching delta has GazeCRAP data, the function MUST use the existing single-row format unchanged.
+
+#### Scenario: No GazeCRAP data available in any delta
+
+- **GIVEN** a baseline comparison result where all functions have nil GazeCRAP deltas
+- **WHEN** `writeComparisonDeltaTable` renders the regressions table
+- **THEN** the output uses the current single-row format: function name, baseline CRAP, current CRAP, and CRAP delta on one line
+
+### Requirement: 80-column terminal width compliance
+
+All output lines from `writeComparisonDeltaTable` MUST fit within 80 columns.
+
+#### Scenario: Two-row format width compliance
+
+- **GIVEN** a function name of maximum typical length (40 chars including file path)
+- **WHEN** `writeComparisonDeltaTable` renders the two-row format
+- **THEN** no output line exceeds 80 characters
+
+## MODIFIED Requirements
+
+_None._
+
+## REMOVED Requirements
+
+_None._

--- a/openspec/changes/baseline-text-gazecrap-delta/tasks.md
+++ b/openspec/changes/baseline-text-gazecrap-delta/tasks.md
@@ -1,0 +1,28 @@
+## 1. Tests (write before implementation)
+
+- [x] 1.1 Add test `TestDeltaTable_TwoRowFormat_WithGazeCRAP` in `internal/crap/compare_report_test.go` — build a `ComparisonResult` with a regression that has both CRAP and GazeCRAP deltas, call `WriteComparisonText`, verify output contains function name on its own line, indented `GazeCRAP` row with baseline/current/delta, and indented `CRAP` row with baseline/current/delta
+- [x] 1.2 Add test `TestDeltaTable_TwoRowFormat_MixedGazeCRAP` in `internal/crap/compare_report_test.go` — one function has GazeCRAP data, another does not; verify the function with GazeCRAP gets both rows, the function without GazeCRAP gets only the `CRAP` row (no empty GazeCRAP row)
+- [x] 1.3 Add test `TestDeltaTable_SingleRowFormat_NoGazeCRAP` in `internal/crap/compare_report_test.go` — all functions have nil GazeCRAP deltas; verify output uses the existing single-row format unchanged (backward compatibility)
+- [x] 1.4 Add test `TestDeltaTable_GazeCRAPBeforeCRAP` in `internal/crap/compare_report_test.go` — verify `GazeCRAP` row appears before `CRAP` row in two-row output (order constraint from D1)
+- [x] 1.5 Add test `TestDeltaTable_TwoRowFormat_WidthCompliance` in `internal/crap/compare_report_test.go` — verify no output line exceeds 80 characters when rendering the two-row format with a 40-char function name
+
+## 2. Implementation
+
+- [x] 2.1 Update `writeComparisonDeltaTable` in `internal/crap/compare_report.go` — add detection of whether any matching delta has non-nil `GazeCRAPDelta`; if so, switch to two-row rendering per D1/D2/D3/D4
+- [x] 2.2 In two-row mode: print function name (with file path) on its own line, then indented `GazeCRAP` row (if non-nil) with `Baseline.GazeCRAP`, `Current.GazeCRAP`, `GazeCRAPDelta`, then indented `CRAP` row with `Baseline.CRAP`, `Current.CRAP`, `CRAPDelta`
+- [x] 2.3 In single-row mode (no GazeCRAP data in any matching delta): preserve the existing format unchanged
+
+## 3. Validation
+
+- [x] 3.1 Run `go build ./cmd/gaze` — verify clean compilation
+- [x] 3.2 Run `go test -race -count=1 -short ./internal/crap/...` — verify all comparison and report tests pass
+- [x] 3.3 Run `go test -race -count=1 -short ./...` — verify no regressions across the full module
+- [x] 3.4 Run `golangci-lint run` — verify no lint violations in changed packages
+
+## 4. Constitution Alignment Verification
+
+- [x] 4.1 Verify Observable Quality (III): text output now surfaces GazeCRAP delta data that was previously hidden; JSON output unchanged
+- [x] 4.2 Verify Testability (IV): all new behavior covered by unit tests using in-memory buffers and synthetic `FunctionDelta` inputs
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes #163 — the baseline text comparison table now displays GazeCRAP delta values alongside CRAP deltas using a two-row-per-function format.

### Problem

When a function regresses due to GazeCRAP (but not CRAP), the user sees it marked as "regression" without understanding why — the GazeCRAP numbers that triggered the classification are invisible in the text output.

### Solution

Updated `writeComparisonDeltaTable` to use a two-row format when GazeCRAP data is available:
- Function name on its own line
- Indented **GazeCRAP** row first (baseline, current, delta)
- Indented **CRAP** row second (baseline, current, delta)
- When no GazeCRAP data exists, the original single-row format is preserved
- All output stays within the 80-column terminal constraint

### Tests

5 new tests: two-row format, mixed GazeCRAP availability, single-row backward compat, GazeCRAP-before-CRAP ordering, and 80-column width compliance.