### PR TITLE
fix: prevent TestSC002 from leaking fake content to GITHUB_STEP_SUMMARY (#172)

### DIFF
--- a/cmd/gaze/main_test.go
+++ b/cmd/gaze/main_test.go
@@ -1658,6 +1658,11 @@ func TestSC001_GithubActionsReport(t *testing.T) {
 // TestSC002_ReportStructure verifies that the formatted report contains all
 // four required emoji section markers in order (SC-002).
 func TestSC002_ReportStructure(t *testing.T) {
+	// Clear GITHUB_STEP_SUMMARY to prevent fakeRunnerFunc from
+	// writing fake section headers to the real CI step summary
+	// file (#172).
+	t.Setenv("GITHUB_STEP_SUMMARY", "")
+
 	report := "🔍 CRAP Analysis\n\n📊 Quality\n\n🧪 Classification\n\n🏥 Health\n"
 	var stdout, stderr bytes.Buffer
 	err := runReport(reportParams{


### PR DESCRIPTION
## Summary

Fixes #172 — `TestSC002_ReportStructure` was writing fake section headers to the real `GITHUB_STEP_SUMMARY` file during CI runs.

### Problem

`TestSC002_ReportStructure` calls `fakeRunnerFunc` which honours `StepSummaryPath`. The test did not override `GITHUB_STEP_SUMMARY` with `t.Setenv`, so in CI the fake headers (CRAP Analysis, Quality, Classification, Health) were written to the real step summary file.

On push-to-main runs, the real AI report appends afterward and masks the issue. On PR runs (where secrets are unavailable and the AI report step is skipped), only the fake headers remain — producing "headers with no content" in the job summary.

### Fix

Add `t.Setenv("GITHUB_STEP_SUMMARY", "")` to clear the env var before the test runs, matching the pattern already used by `TestSC001_GithubActionsReport` and `TestRunReport_StepSummaryUnwritable_Succeeds`.

### Change

`cmd/gaze/main_test.go` — 5 lines added (comment + `t.Setenv` call).