### PR TITLE
fix(quality): resolve staticcheck QF1012 in ai_mapper.go

### DIFF
--- a/internal/quality/ai_mapper.go
+++ b/internal/quality/ai_mapper.go
@@ -135,8 +135,8 @@ func BuildAIMapperPrompt(ctx AIMapperContext) string {
 	b.WriteString(ctx.TargetFunc)
 	b.WriteString(" produces these side effects:\n")
 	for i, se := range ctx.SideEffects {
-		b.WriteString(fmt.Sprintf("  %d. [%s] %s (ID: %s)\n",
-			i+1, se.Type, se.Description, se.ID))
+		fmt.Fprintf(&b, "  %d. [%s] %s (ID: %s)\n",
+			i+1, se.Type, se.Description, se.ID)
 	}
 	b.WriteString("\n")
 


### PR DESCRIPTION
## Summary

Fixes a pre-existing staticcheck QF1012 lint violation in `internal/quality/ai_mapper.go`.

### Problem

`BuildAIMapperPrompt` uses `b.WriteString(fmt.Sprintf(...))` which allocates an intermediate string unnecessarily. `strings.Builder` implements `io.Writer`, so `fmt.Fprintf(&b, ...)` writes directly to the builder without the extra allocation.

### Change

`internal/quality/ai_mapper.go:138` — replaced `b.WriteString(fmt.Sprintf(...))` with `fmt.Fprintf(&b, ...)`.

### Verification

- `golangci-lint run` — 0 issues (previously 1)
- `go test -race -count=1 -short ./internal/quality/...` — pass

Assisted-by: OpenCode (claude-opus-4-6)