### PR TITLE
chore: add DI and tests for 6 zero-coverage pipeline functions

### DIFF
--- a/.uf/dewey/learnings/crapload-di-coverage-20260702T081517-yvonne-devlin.md
+++ b/.uf/dewey/learnings/crapload-di-coverage-20260702T081517-yvonne-devlin.md
@@ -1,0 +1,10 @@
+---
+tag: crapload-di-coverage
+author: yvonne-devlin
+category: gotcha
+created_at: 2026-07-02T08:15:17Z
+identity: crapload-di-coverage-20260702T081517-yvonne-devlin
+tier: draft
+---
+
+When adding dependency injection to Go functions that already have a variadic parameter (like `aiMapperFn ...quality.AIMapperFunc`), the existing variadic must be absorbed into the new deps struct because Go does not allow two variadic parameters. This was discovered during spec review of the crapload-di-coverage-pr1a change where `analyzePackageCoverage` already had a variadic `aiMapperFn`. The solution was to add `aiMapperFn` as a regular field on the `contractCoverageDeps` struct and update the caller (`BuildContractCoverageFunc`) to pass it through the struct. Five spec reviewers independently flagged the `pipelineStepFuncs` signature cascade as an ambiguity — when step functions gain variadic deps, the function types stored in `pipelineStepFuncs` must also change, and test fake closures must be updated to match.

--- a/.uf/dewey/learnings/crapload-di-coverage-20260702T081523-yvonne-devlin.md
+++ b/.uf/dewey/learnings/crapload-di-coverage-20260702T081523-yvonne-devlin.md
@@ -1,0 +1,10 @@
+---
+tag: crapload-di-coverage
+author: yvonne-devlin
+category: pattern
+created_at: 2026-07-02T08:15:23Z
+identity: crapload-di-coverage-20260702T081523-yvonne-devlin
+tier: draft
+---
+
+The `gaze crap` CRAPload metric internally runs `go test -short -coverprofile=<tmpfile>` to generate coverage data. Tests guarded by `testing.Short()` are skipped during this coverage generation and contribute zero coverage to the CRAPload calculation. This means that adding tests with `-short` guards will NOT reduce CRAPload. To reduce CRAPload for functions that call heavy I/O operations (like `packages.Load`, `analysis.LoadAndAnalyze`), dependency injection is required so tests can use synthetic data and run without the `-short` guard. The existing `pipelineStepFuncs` pattern in `internal/aireport/runner.go` proves this approach works. After adding DI to 4 orchestration functions and direct fixture tests for 2 leaf functions, CRAPload dropped from 38 to 32 (6-function reduction, matching the target).

--- a/internal/aireport/pipeline_internal_test.go
+++ b/internal/aireport/pipeline_internal_test.go
@@ -22,13 +22,13 @@ func fakeSteps() pipelineStepFuncs {
 				TotalFunctions: 20,
 			}, nil
 		},
-		qualityStep: func(_ []string, _ string, _ io.Writer) (*qualityStepResult, error) {
+		qualityStep: func(_ []string, _ string, _ io.Writer, _ ...qualityPipelineDeps) (*qualityStepResult, error) {
 			return &qualityStepResult{
 				JSON:                json.RawMessage(`{"quality":"ok"}`),
 				AvgContractCoverage: 85,
 			}, nil
 		},
-		classifyStep: func(_ []string, _ string) (*classifyStepResult, error) {
+		classifyStep: func(_ []string, _ string, _ ...qualityPipelineDeps) (*classifyStepResult, error) {
 			return &classifyStepResult{
 				JSON:        json.RawMessage(`{"classify":"ok"}`),
 				Contractual: 10,
@@ -169,7 +169,7 @@ func TestRunProductionPipeline_CRAPStepFails(t *testing.T) {
 func TestRunProductionPipeline_QualityStepFails(t *testing.T) {
 	var stderr bytes.Buffer
 	steps := fakeSteps()
-	steps.qualityStep = func(_ []string, _ string, _ io.Writer) (*qualityStepResult, error) {
+	steps.qualityStep = func(_ []string, _ string, _ io.Writer, _ ...qualityPipelineDeps) (*qualityStepResult, error) {
 		return nil, fmt.Errorf("quality analysis failed")
 	}
 
@@ -192,7 +192,7 @@ func TestRunProductionPipeline_QualityStepFails(t *testing.T) {
 func TestRunProductionPipeline_ClassifyStepFails(t *testing.T) {
 	var stderr bytes.Buffer
 	steps := fakeSteps()
-	steps.classifyStep = func(_ []string, _ string) (*classifyStepResult, error) {
+	steps.classifyStep = func(_ []string, _ string, _ ...qualityPipelineDeps) (*classifyStepResult, error) {
 		return nil, fmt.Errorf("classify failed")
 	}
 
@@ -247,7 +247,7 @@ func TestRunProductionPipeline_MultipleStepsFail(t *testing.T) {
 	steps.crapStep = func(_ []string, _ string, _ string, _ io.Writer, _ crap.ContractCoverageProvider) (*crapStepResult, error) {
 		return nil, fmt.Errorf("crap failed")
 	}
-	steps.qualityStep = func(_ []string, _ string, _ io.Writer) (*qualityStepResult, error) {
+	steps.qualityStep = func(_ []string, _ string, _ io.Writer, _ ...qualityPipelineDeps) (*qualityStepResult, error) {
 		return nil, fmt.Errorf("quality failed")
 	}
 

--- a/internal/aireport/runner.go
+++ b/internal/aireport/runner.go
@@ -242,8 +242,8 @@ func errString(err error) *string {
 // real analysis.
 type pipelineStepFuncs struct {
 	crapStep     func([]string, string, string, io.Writer, crap.ContractCoverageProvider) (*crapStepResult, error)
-	qualityStep  func([]string, string, io.Writer) (*qualityStepResult, error)
-	classifyStep func([]string, string) (*classifyStepResult, error)
+	qualityStep  func([]string, string, io.Writer, ...qualityPipelineDeps) (*qualityStepResult, error)
+	classifyStep func([]string, string, ...qualityPipelineDeps) (*classifyStepResult, error)
 	docscanStep  func(string) (json.RawMessage, error)
 }
 

--- a/internal/aireport/runner_steps.go
+++ b/internal/aireport/runner_steps.go
@@ -21,6 +21,59 @@ import (
 	"github.com/unbound-force/gaze/internal/taxonomy"
 )
 
+// qualityPipelineDeps holds injectable function dependencies for
+// runQualityStep, runQualityForPackage, and runClassifyStep. When a
+// field is nil, the real implementation is used. This enables unit
+// testing of the quality/classify orchestration logic without running
+// real package loading or SSA analysis.
+//
+// Design decision: follows the pipelineStepFuncs pattern
+// (runner.go:243) — variadic parameter with nil-means-default
+// resolution. Chosen over interface-based DI per SOLID Interface
+// Segregation: these are internal, co-located functions, not a
+// public contract.
+type qualityPipelineDeps struct {
+	resolvePackagePaths func([]string, string) ([]string, error)
+	loadAndAnalyze      func(string, analysis.Options) ([]taxonomy.AnalysisResult, error)
+	classifyResults     func([]taxonomy.AnalysisResult, string, *config.GazeConfig, []*packages.Package) ([]taxonomy.AnalysisResult, error)
+	loadTestPkg         func(string) (*packages.Package, error)
+	assess              func([]taxonomy.AnalysisResult, *packages.Package, quality.Options) ([]taxonomy.QualityReport, *taxonomy.PackageSummary, error)
+	resolveModulePkgs   func(string) []*packages.Package
+	loadConfig          func(string) *config.GazeConfig
+}
+
+// resolveQualityDeps resolves nil fields to their production defaults.
+// Accepts a variadic slice for ergonomic call-site usage: callers pass
+// zero or one qualityPipelineDeps value.
+func resolveQualityDeps(deps []qualityPipelineDeps) qualityPipelineDeps {
+	var d qualityPipelineDeps
+	if len(deps) > 0 {
+		d = deps[0]
+	}
+	if d.resolvePackagePaths == nil {
+		d.resolvePackagePaths = loader.ResolvePackagePaths
+	}
+	if d.loadAndAnalyze == nil {
+		d.loadAndAnalyze = analysis.LoadAndAnalyze
+	}
+	if d.classifyResults == nil {
+		d.classifyResults = runClassifyResults
+	}
+	if d.loadTestPkg == nil {
+		d.loadTestPkg = loadTestPackageForQuality
+	}
+	if d.assess == nil {
+		d.assess = quality.Assess
+	}
+	if d.resolveModulePkgs == nil {
+		d.resolveModulePkgs = resolveModulePackages
+	}
+	if d.loadConfig == nil {
+		d.loadConfig = loadGazeConfigBestEffort
+	}
+	return d
+}
+
 // crapStepResult holds the outputs of runCRAPStep.
 type crapStepResult struct {
 	JSON                json.RawMessage
@@ -86,8 +139,10 @@ type qualityStepResult struct {
 // runQualityStep runs the quality pipeline across all matched packages and
 // returns the aggregated JSON output alongside the typed AvgContractCoverage
 // value for threshold evaluation.
-func runQualityStep(patterns []string, moduleDir string, stderr io.Writer) (*qualityStepResult, error) {
-	pkgPaths, err := loader.ResolvePackagePaths(patterns, moduleDir)
+func runQualityStep(patterns []string, moduleDir string, stderr io.Writer, deps ...qualityPipelineDeps) (*qualityStepResult, error) {
+	d := resolveQualityDeps(deps)
+
+	pkgPaths, err := d.resolvePackagePaths(patterns, moduleDir)
 	if err != nil {
 		return nil, fmt.Errorf("resolving packages for quality: %w", err)
 	}
@@ -95,15 +150,15 @@ func runQualityStep(patterns []string, moduleDir string, stderr io.Writer) (*qua
 		return nil, fmt.Errorf("no packages matched patterns %v", patterns)
 	}
 
-	gazeConfig := loadGazeConfigBestEffort(moduleDir)
+	gazeConfig := d.loadConfig(moduleDir)
 
 	// Hoist LoadModule out of the per-package loop — O(1) instead of O(n).
-	modPkgs := resolveModulePackages(moduleDir)
+	modPkgs := d.resolveModulePkgs(moduleDir)
 
 	var allReports []taxonomy.QualityReport
 	var degradedPkgs []string
 	for _, pkgPath := range pkgPaths {
-		reports, degradedPkg := runQualityForPackage(pkgPath, gazeConfig, modPkgs, stderr)
+		reports, degradedPkg := runQualityForPackage(pkgPath, gazeConfig, modPkgs, stderr, deps...)
 		if degradedPkg != "" {
 			degradedPkgs = append(degradedPkgs, degradedPkg)
 		}
@@ -144,30 +199,33 @@ func runQualityForPackage(
 	gazeConfig *config.GazeConfig,
 	modPkgs []*packages.Package,
 	stderr io.Writer,
+	deps ...qualityPipelineDeps,
 ) ([]taxonomy.QualityReport, string) {
+	d := resolveQualityDeps(deps)
+
 	includeUnexported := loader.IsMainPkg(pkgPath)
 	if includeUnexported {
 		_, _ = fmt.Fprintf(stderr, "package main detected for %s, including unexported functions\n", pkgPath)
 	}
 	analysisOpts := analysis.Options{IncludeUnexported: includeUnexported}
-	results, err := analysis.LoadAndAnalyze(pkgPath, analysisOpts)
+	results, err := d.loadAndAnalyze(pkgPath, analysisOpts)
 	if err != nil || len(results) == 0 {
 		return nil, ""
 	}
 
 	cfg := gazeConfig
-	classified, err := runClassifyResults(results, pkgPath, cfg, modPkgs)
+	classified, err := d.classifyResults(results, pkgPath, cfg, modPkgs)
 	if err != nil || len(classified) == 0 {
 		return nil, ""
 	}
 
-	testPkg, err := loadTestPackageForQuality(pkgPath)
+	testPkg, err := d.loadTestPkg(pkgPath)
 	if err != nil {
 		return nil, ""
 	}
 
 	qualOpts := quality.Options{Stderr: stderr}
-	reports, summary, err := quality.Assess(classified, testPkg, qualOpts)
+	reports, summary, err := d.assess(classified, testPkg, qualOpts)
 	if err != nil {
 		return nil, ""
 	}
@@ -187,9 +245,11 @@ type classifyStepResult struct {
 
 // runClassifyStep runs classification on all matched packages and returns the JSON output
 // alongside typed classification label counts.
-func runClassifyStep(patterns []string, moduleDir string) (*classifyStepResult, error) {
+func runClassifyStep(patterns []string, moduleDir string, deps ...qualityPipelineDeps) (*classifyStepResult, error) {
+	d := resolveQualityDeps(deps)
+
 	// Use the first resolved package path for analysis + classify.
-	pkgPaths, err := loader.ResolvePackagePaths(patterns, moduleDir)
+	pkgPaths, err := d.resolvePackagePaths(patterns, moduleDir)
 	if err != nil {
 		return nil, fmt.Errorf("resolving packages for classification: %w", err)
 	}
@@ -198,18 +258,18 @@ func runClassifyStep(patterns []string, moduleDir string) (*classifyStepResult, 
 	}
 
 	// Hoist LoadModule out of the per-package loop — O(1) instead of O(n).
-	modPkgs := resolveModulePackages(moduleDir)
+	modPkgs := d.resolveModulePkgs(moduleDir)
 
-	gazeConfig := loadGazeConfigBestEffort(moduleDir)
+	gazeConfig := d.loadConfig(moduleDir)
 	var allResults []taxonomy.AnalysisResult
 
 	for _, pkgPath := range pkgPaths {
 		analysisOpts := analysis.Options{IncludeUnexported: loader.IsMainPkg(pkgPath)}
-		results, err := analysis.LoadAndAnalyze(pkgPath, analysisOpts)
+		results, err := d.loadAndAnalyze(pkgPath, analysisOpts)
 		if err != nil || len(results) == 0 {
 			continue
 		}
-		classified, err := runClassifyResults(results, pkgPath, gazeConfig, modPkgs)
+		classified, err := d.classifyResults(results, pkgPath, gazeConfig, modPkgs)
 		if err != nil {
 			continue
 		}

--- a/internal/aireport/runner_steps_test.go
+++ b/internal/aireport/runner_steps_test.go
@@ -1,10 +1,19 @@
 package aireport
 
 import (
+	"fmt"
 	"io"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+
+	"golang.org/x/tools/go/packages"
+
+	"github.com/unbound-force/gaze/internal/analysis"
+	"github.com/unbound-force/gaze/internal/config"
+	"github.com/unbound-force/gaze/internal/quality"
+	"github.com/unbound-force/gaze/internal/taxonomy"
 )
 
 // TestLoadGazeConfigBestEffort_AlwaysNonNil verifies that the function always
@@ -115,5 +124,452 @@ func TestRunProductionPipeline_RealPackage(t *testing.T) {
 	// CRAP step must succeed for a real package.
 	if payload.CRAP == nil && payload.Errors.CRAP == nil {
 		t.Error("expected either CRAP JSON or CRAP error, got both nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers: synthetic data builders for DI tests
+// ---------------------------------------------------------------------------
+
+// syntheticAnalysisResult returns a minimal AnalysisResult with one side
+// effect. When label is non-nil, the effect carries a Classification.
+func syntheticAnalysisResult(pkg, fn string, label *taxonomy.ClassificationLabel) []taxonomy.AnalysisResult {
+	se := taxonomy.SideEffect{
+		ID:          "se-test0001",
+		Type:        taxonomy.ReturnValue,
+		Tier:        taxonomy.TierP0,
+		Location:    "fake.go:1:1",
+		Description: "returns int",
+		Target:      "result",
+	}
+	if label != nil {
+		se.Classification = &taxonomy.Classification{
+			Label:      *label,
+			Confidence: 90,
+		}
+	}
+	return []taxonomy.AnalysisResult{{
+		Target: taxonomy.FunctionTarget{
+			Package:  pkg,
+			Function: fn,
+		},
+		SideEffects: []taxonomy.SideEffect{se},
+	}}
+}
+
+// syntheticQualityReport returns a minimal QualityReport for testing.
+func syntheticQualityReport(fn string) taxonomy.QualityReport {
+	return taxonomy.QualityReport{
+		TestFunction: "Test_" + fn,
+		TargetFunction: taxonomy.FunctionTarget{
+			Function: fn,
+		},
+		ContractCoverage: taxonomy.ContractCoverage{Percentage: 80},
+	}
+}
+
+// fakeDepsSuccess returns a qualityPipelineDeps where every function
+// succeeds with minimal synthetic data. Individual fields can be
+// overridden after construction.
+func fakeDepsSuccess() qualityPipelineDeps {
+	contractual := taxonomy.Contractual
+	return qualityPipelineDeps{
+		resolvePackagePaths: func(patterns []string, _ string) ([]string, error) {
+			return patterns, nil
+		},
+		loadAndAnalyze: func(pattern string, _ analysis.Options) ([]taxonomy.AnalysisResult, error) {
+			return syntheticAnalysisResult(pattern, "Foo", &contractual), nil
+		},
+		classifyResults: func(results []taxonomy.AnalysisResult, _ string, _ *config.GazeConfig, _ []*packages.Package) ([]taxonomy.AnalysisResult, error) {
+			return results, nil
+		},
+		loadTestPkg: func(_ string) (*packages.Package, error) {
+			return &packages.Package{Name: "fake_test"}, nil
+		},
+		assess: func(_ []taxonomy.AnalysisResult, _ *packages.Package, _ quality.Options) ([]taxonomy.QualityReport, *taxonomy.PackageSummary, error) {
+			return []taxonomy.QualityReport{syntheticQualityReport("Foo")}, &taxonomy.PackageSummary{
+				TotalTests:              1,
+				AverageContractCoverage: 80,
+			}, nil
+		},
+		resolveModulePkgs: func(_ string) []*packages.Package {
+			return []*packages.Package{{Name: "fake"}}
+		},
+		loadConfig: func(_ string) *config.GazeConfig {
+			return config.DefaultConfig()
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Task 2.2: Unit tests for runQualityForPackage
+// ---------------------------------------------------------------------------
+
+func TestRunQualityForPackage_DI_Success(t *testing.T) {
+	deps := fakeDepsSuccess()
+	reports, degraded := runQualityForPackage("fake/pkg", config.DefaultConfig(), nil, io.Discard, deps)
+	if reports == nil {
+		t.Fatal("expected non-nil reports on success path")
+	}
+	if len(reports) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(reports))
+	}
+	if degraded != "" {
+		t.Errorf("expected empty degraded string, got %q", degraded)
+	}
+}
+
+func TestRunQualityForPackage_DI_AnalysisError(t *testing.T) {
+	deps := fakeDepsSuccess()
+	deps.loadAndAnalyze = func(_ string, _ analysis.Options) ([]taxonomy.AnalysisResult, error) {
+		return nil, fmt.Errorf("analysis failed")
+	}
+	reports, degraded := runQualityForPackage("fake/pkg", config.DefaultConfig(), nil, io.Discard, deps)
+	if reports != nil {
+		t.Errorf("expected nil reports on analysis error, got %d", len(reports))
+	}
+	if degraded != "" {
+		t.Errorf("expected empty degraded string, got %q", degraded)
+	}
+}
+
+func TestRunQualityForPackage_DI_EmptyResults(t *testing.T) {
+	deps := fakeDepsSuccess()
+	deps.loadAndAnalyze = func(_ string, _ analysis.Options) ([]taxonomy.AnalysisResult, error) {
+		return []taxonomy.AnalysisResult{}, nil
+	}
+	reports, degraded := runQualityForPackage("fake/pkg", config.DefaultConfig(), nil, io.Discard, deps)
+	if reports != nil {
+		t.Errorf("expected nil reports on empty results, got %d", len(reports))
+	}
+	if degraded != "" {
+		t.Errorf("expected empty degraded string, got %q", degraded)
+	}
+}
+
+func TestRunQualityForPackage_DI_ClassifyError(t *testing.T) {
+	deps := fakeDepsSuccess()
+	deps.classifyResults = func(_ []taxonomy.AnalysisResult, _ string, _ *config.GazeConfig, _ []*packages.Package) ([]taxonomy.AnalysisResult, error) {
+		return nil, fmt.Errorf("classify failed")
+	}
+	reports, degraded := runQualityForPackage("fake/pkg", config.DefaultConfig(), nil, io.Discard, deps)
+	if reports != nil {
+		t.Errorf("expected nil reports on classify error, got %d", len(reports))
+	}
+	if degraded != "" {
+		t.Errorf("expected empty degraded string, got %q", degraded)
+	}
+}
+
+func TestRunQualityForPackage_DI_LoadTestError(t *testing.T) {
+	deps := fakeDepsSuccess()
+	deps.loadTestPkg = func(_ string) (*packages.Package, error) {
+		return nil, fmt.Errorf("no test package found")
+	}
+	reports, degraded := runQualityForPackage("fake/pkg", config.DefaultConfig(), nil, io.Discard, deps)
+	if reports != nil {
+		t.Errorf("expected nil reports on loadTestPkg error, got %d", len(reports))
+	}
+	if degraded != "" {
+		t.Errorf("expected empty degraded string, got %q", degraded)
+	}
+}
+
+func TestRunQualityForPackage_DI_AssessError(t *testing.T) {
+	deps := fakeDepsSuccess()
+	deps.assess = func(_ []taxonomy.AnalysisResult, _ *packages.Package, _ quality.Options) ([]taxonomy.QualityReport, *taxonomy.PackageSummary, error) {
+		return nil, nil, fmt.Errorf("assess failed")
+	}
+	reports, degraded := runQualityForPackage("fake/pkg", config.DefaultConfig(), nil, io.Discard, deps)
+	if reports != nil {
+		t.Errorf("expected nil reports on assess error, got %d", len(reports))
+	}
+	if degraded != "" {
+		t.Errorf("expected empty degraded string, got %q", degraded)
+	}
+}
+
+func TestRunQualityForPackage_DI_SSADegraded(t *testing.T) {
+	deps := fakeDepsSuccess()
+	deps.assess = func(_ []taxonomy.AnalysisResult, _ *packages.Package, _ quality.Options) ([]taxonomy.QualityReport, *taxonomy.PackageSummary, error) {
+		return []taxonomy.QualityReport{syntheticQualityReport("Foo")}, &taxonomy.PackageSummary{
+			TotalTests:              1,
+			AverageContractCoverage: 50,
+			SSADegraded:             true,
+		}, nil
+	}
+	reports, degraded := runQualityForPackage("fake/pkg", config.DefaultConfig(), nil, io.Discard, deps)
+	if reports == nil {
+		t.Fatal("expected non-nil reports on SSA degradation")
+	}
+	if degraded != "fake/pkg" {
+		t.Errorf("expected degraded=%q, got %q", "fake/pkg", degraded)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Task 2.3: Unit tests for runQualityStep
+// ---------------------------------------------------------------------------
+
+func TestRunQualityStep_DI_SinglePackage(t *testing.T) {
+	deps := fakeDepsSuccess()
+	result, err := runQualityStep([]string{"fake/pkg"}, "/tmp", io.Discard, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil qualityStepResult")
+	}
+	if result.JSON == nil {
+		t.Error("expected non-nil JSON")
+	}
+	if result.SSADegraded {
+		t.Error("expected SSADegraded=false")
+	}
+}
+
+func TestRunQualityStep_DI_MultiplePackages(t *testing.T) {
+	deps := fakeDepsSuccess()
+	deps.resolvePackagePaths = func(_ []string, _ string) ([]string, error) {
+		return []string{"fake/pkg1", "fake/pkg2"}, nil
+	}
+	result, err := runQualityStep([]string{"./..."}, "/tmp", io.Discard, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil qualityStepResult")
+	}
+	if result.JSON == nil {
+		t.Error("expected non-nil JSON")
+	}
+	// AvgContractCoverage should be computed from 2 reports.
+	// Both fake reports return 80% coverage, so the average should be 80.
+	if result.AvgContractCoverage != 80 {
+		t.Errorf("expected AvgContractCoverage=80, got %d", result.AvgContractCoverage)
+	}
+}
+
+func TestRunQualityStep_DI_ResolveError(t *testing.T) {
+	deps := fakeDepsSuccess()
+	deps.resolvePackagePaths = func(_ []string, _ string) ([]string, error) {
+		return nil, fmt.Errorf("resolve failed")
+	}
+	_, err := runQualityStep([]string{"./..."}, "/tmp", io.Discard, deps)
+	if err == nil {
+		t.Fatal("expected error on resolve failure")
+	}
+	if !strings.Contains(err.Error(), "resolving packages") {
+		t.Errorf("expected 'resolving packages' in error, got: %v", err)
+	}
+}
+
+func TestRunQualityStep_DI_ResolveEmpty(t *testing.T) {
+	deps := fakeDepsSuccess()
+	deps.resolvePackagePaths = func(_ []string, _ string) ([]string, error) {
+		return []string{}, nil
+	}
+	_, err := runQualityStep([]string{"./..."}, "/tmp", io.Discard, deps)
+	if err == nil {
+		t.Fatal("expected error on empty resolve result")
+	}
+	if !strings.Contains(err.Error(), "no packages matched") {
+		t.Errorf("expected 'no packages matched' in error, got: %v", err)
+	}
+}
+
+func TestRunQualityStep_DI_SSADegradation(t *testing.T) {
+	deps := fakeDepsSuccess()
+	deps.assess = func(_ []taxonomy.AnalysisResult, _ *packages.Package, _ quality.Options) ([]taxonomy.QualityReport, *taxonomy.PackageSummary, error) {
+		return []taxonomy.QualityReport{syntheticQualityReport("Foo")}, &taxonomy.PackageSummary{
+			TotalTests:              1,
+			AverageContractCoverage: 50,
+			SSADegraded:             true,
+		}, nil
+	}
+	result, err := runQualityStep([]string{"fake/pkg"}, "/tmp", io.Discard, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.SSADegraded {
+		t.Error("expected SSADegraded=true")
+	}
+	if len(result.SSADegradedPackages) != 1 || result.SSADegradedPackages[0] != "fake/pkg" {
+		t.Errorf("expected SSADegradedPackages=[fake/pkg], got %v", result.SSADegradedPackages)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Task 2.4: Unit tests for runClassifyStep
+// ---------------------------------------------------------------------------
+
+func TestRunClassifyStep_DI_Success(t *testing.T) {
+	contractual := taxonomy.Contractual
+	ambiguous := taxonomy.Ambiguous
+	deps := fakeDepsSuccess()
+	deps.resolvePackagePaths = func(_ []string, _ string) ([]string, error) {
+		return []string{"fake/pkg"}, nil
+	}
+	deps.loadAndAnalyze = func(_ string, _ analysis.Options) ([]taxonomy.AnalysisResult, error) {
+		// Return results with 2 contractual + 1 ambiguous effects.
+		return []taxonomy.AnalysisResult{{
+			Target: taxonomy.FunctionTarget{Package: "fake/pkg", Function: "Foo"},
+			SideEffects: []taxonomy.SideEffect{
+				{ID: "se-1", Type: taxonomy.ReturnValue, Classification: &taxonomy.Classification{Label: contractual, Confidence: 90}},
+				{ID: "se-2", Type: taxonomy.ErrorReturn, Classification: &taxonomy.Classification{Label: contractual, Confidence: 85}},
+				{ID: "se-3", Type: taxonomy.MapMutation, Classification: &taxonomy.Classification{Label: ambiguous, Confidence: 55}},
+			},
+		}}, nil
+	}
+	deps.classifyResults = func(results []taxonomy.AnalysisResult, _ string, _ *config.GazeConfig, _ []*packages.Package) ([]taxonomy.AnalysisResult, error) {
+		return results, nil // passthrough — labels already set
+	}
+	result, err := runClassifyStep([]string{"./..."}, "/tmp", deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Contractual != 2 {
+		t.Errorf("expected Contractual=2, got %d", result.Contractual)
+	}
+	if result.Ambiguous != 1 {
+		t.Errorf("expected Ambiguous=1, got %d", result.Ambiguous)
+	}
+	if result.Incidental != 0 {
+		t.Errorf("expected Incidental=0, got %d", result.Incidental)
+	}
+	if result.JSON == nil {
+		t.Error("expected non-nil JSON")
+	}
+}
+
+func TestRunClassifyStep_DI_ResolveError(t *testing.T) {
+	deps := fakeDepsSuccess()
+	deps.resolvePackagePaths = func(_ []string, _ string) ([]string, error) {
+		return nil, fmt.Errorf("resolve failed")
+	}
+	_, err := runClassifyStep([]string{"./..."}, "/tmp", deps)
+	if err == nil {
+		t.Fatal("expected error on resolve failure")
+	}
+	if !strings.Contains(err.Error(), "resolving packages for classification") {
+		t.Errorf("expected 'resolving packages for classification' in error, got: %v", err)
+	}
+}
+
+func TestRunClassifyStep_DI_ResolveEmpty(t *testing.T) {
+	deps := fakeDepsSuccess()
+	deps.resolvePackagePaths = func(_ []string, _ string) ([]string, error) {
+		return []string{}, nil
+	}
+	_, err := runClassifyStep([]string{"./..."}, "/tmp", deps)
+	if err == nil {
+		t.Fatal("expected error on empty resolve result")
+	}
+	if !strings.Contains(err.Error(), "no packages matched") {
+		t.Errorf("expected 'no packages matched' in error, got: %v", err)
+	}
+}
+
+func TestRunClassifyStep_DI_AnalysisErrorSkip(t *testing.T) {
+	contractual := taxonomy.Contractual
+	callCount := 0
+	deps := fakeDepsSuccess()
+	deps.resolvePackagePaths = func(_ []string, _ string) ([]string, error) {
+		return []string{"fake/pkg1", "fake/pkg2"}, nil
+	}
+	deps.loadAndAnalyze = func(pattern string, _ analysis.Options) ([]taxonomy.AnalysisResult, error) {
+		callCount++
+		if pattern == "fake/pkg1" {
+			return nil, fmt.Errorf("analysis failed for pkg1")
+		}
+		return syntheticAnalysisResult(pattern, "Bar", &contractual), nil
+	}
+	result, err := runClassifyStep([]string{"./..."}, "/tmp", deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("expected loadAndAnalyze called 2 times, got %d", callCount)
+	}
+	// Only pkg2's results should contribute (1 contractual effect).
+	if result.Contractual != 1 {
+		t.Errorf("expected Contractual=1 (from pkg2 only), got %d", result.Contractual)
+	}
+}
+
+func TestRunClassifyStep_DI_EmptyResultsSkip(t *testing.T) {
+	contractual := taxonomy.Contractual
+	deps := fakeDepsSuccess()
+	deps.resolvePackagePaths = func(_ []string, _ string) ([]string, error) {
+		return []string{"fake/empty", "fake/notempty"}, nil
+	}
+	deps.loadAndAnalyze = func(pattern string, _ analysis.Options) ([]taxonomy.AnalysisResult, error) {
+		if pattern == "fake/empty" {
+			return []taxonomy.AnalysisResult{}, nil
+		}
+		return syntheticAnalysisResult(pattern, "Baz", &contractual), nil
+	}
+	result, err := runClassifyStep([]string{"./..."}, "/tmp", deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Contractual != 1 {
+		t.Errorf("expected Contractual=1 (from notempty only), got %d", result.Contractual)
+	}
+}
+
+func TestRunClassifyStep_DI_ClassifyErrorSkip(t *testing.T) {
+	contractual := taxonomy.Contractual
+	deps := fakeDepsSuccess()
+	deps.resolvePackagePaths = func(_ []string, _ string) ([]string, error) {
+		return []string{"fake/bad", "fake/good"}, nil
+	}
+	deps.loadAndAnalyze = func(pattern string, _ analysis.Options) ([]taxonomy.AnalysisResult, error) {
+		return syntheticAnalysisResult(pattern, "Qux", &contractual), nil
+	}
+	deps.classifyResults = func(results []taxonomy.AnalysisResult, pkgPath string, _ *config.GazeConfig, _ []*packages.Package) ([]taxonomy.AnalysisResult, error) {
+		if pkgPath == "fake/bad" {
+			return nil, fmt.Errorf("classify failed for bad pkg")
+		}
+		return results, nil
+	}
+	result, err := runClassifyStep([]string{"./..."}, "/tmp", deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Only fake/good's results should contribute.
+	if result.Contractual != 1 {
+		t.Errorf("expected Contractual=1 (from good only), got %d", result.Contractual)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Task 2.5: Unit tests for loadTestPackageForQuality
+// ---------------------------------------------------------------------------
+
+func TestLoadTestPackageForQuality_WithTests(t *testing.T) {
+	pkg, err := loadTestPackageForQuality("github.com/unbound-force/gaze/internal/quality/testdata/src/welltested")
+	if err != nil {
+		t.Fatalf("expected success for package with tests, got error: %v", err)
+	}
+	if pkg == nil {
+		t.Fatal("expected non-nil package")
+	}
+}
+
+func TestLoadTestPackageForQuality_WithoutTests(t *testing.T) {
+	_, err := loadTestPackageForQuality("github.com/unbound-force/gaze/internal/analysis/testdata/src/returns")
+	if err == nil {
+		t.Fatal("expected error for package without tests")
+	}
+	if !strings.Contains(err.Error(), "no test package found") {
+		t.Errorf("expected 'no test package found' in error, got: %v", err)
+	}
+}
+
+func TestLoadTestPackageForQuality_NonExistent(t *testing.T) {
+	_, err := loadTestPackageForQuality("github.com/nonexistent/does-not-exist")
+	if err == nil {
+		t.Fatal("expected error for non-existent package")
 	}
 }

--- a/internal/crap/analyze.go
+++ b/internal/crap/analyze.go
@@ -155,8 +155,6 @@ func Analyze(patterns []string, moduleDir string, opts Options) (*Report, error)
 	}, nil
 }
 
-
-
 // ResolvePatterns converts Go package patterns (./...) to filesystem
 // paths that tools like gocyclo can walk. Exported for use by Go
 // provider adapters in internal/provider/goprovider/ (see D9).

--- a/internal/crap/analyze_internal_test.go
+++ b/internal/crap/analyze_internal_test.go
@@ -494,5 +494,3 @@ func TestBuildSummary_RecommendedActions_Truncated(t *testing.T) {
 		t.Errorf("expected 20 recommended actions (truncated), got %d", len(summary.RecommendedActions))
 	}
 }
-
-

--- a/internal/provider/goprovider/contract.go
+++ b/internal/provider/goprovider/contract.go
@@ -139,7 +139,11 @@ func BuildContractCoverageFunc(
 			}
 		}
 
-		reports, degradedPkg := analyzePackageCoverage(pkgPath, moduleDir, gazeConfig, stderr, aiMapperFn...)
+		var ccDeps contractCoverageDeps
+		if len(aiMapperFn) > 0 && aiMapperFn[0] != nil {
+			ccDeps.aiMapperFn = aiMapperFn[0]
+		}
+		reports, degradedPkg := analyzePackageCoverage(pkgPath, moduleDir, gazeConfig, stderr, ccDeps)
 		if degradedPkg != "" {
 			degradedPkgs = append(degradedPkgs, degradedPkg)
 		}
@@ -211,26 +215,56 @@ func BuildContractCoverageFunc(
 	}, degradedPkgs
 }
 
+// contractCoverageDeps holds injectable dependencies for
+// analyzePackageCoverage, enabling unit testing with synthetic
+// implementations instead of loading real Go packages.
+type contractCoverageDeps struct {
+	loadAndAnalyze  func(string, analysis.Options) ([]taxonomy.AnalysisResult, error)
+	classifyResults func([]taxonomy.AnalysisResult, string, string, *config.GazeConfig) []taxonomy.AnalysisResult
+	loadTestPkg     func(string) (*packages.Package, error)
+	assess          func([]taxonomy.AnalysisResult, *packages.Package, quality.Options) ([]taxonomy.QualityReport, *taxonomy.PackageSummary, error)
+	aiMapperFn      quality.AIMapperFunc
+}
+
 // analyzePackageCoverage runs the 4-step quality pipeline on a single
 // package (analysis -> classify -> test-load -> quality assess) and
 // returns the quality reports. The second return value is the degraded
 // package path (empty if SSA succeeded). Returns nil if any step fails.
 //
-// The optional aiMapperFn parameter enables AI-assisted assertion
-// mapping when non-nil. It is passed through to quality.Options.AIMapperFunc.
+// The optional deps parameter enables dependency injection for
+// testing. When omitted (or when individual fields are nil),
+// production implementations are used as defaults.
 func analyzePackageCoverage(
 	pkgPath string,
 	moduleDir string,
 	gazeConfig *config.GazeConfig,
 	stderr io.Writer,
-	aiMapperFn ...quality.AIMapperFunc,
+	deps ...contractCoverageDeps,
 ) ([]taxonomy.QualityReport, string) {
+	// Resolve deps with nil-means-default pattern.
+	var d contractCoverageDeps
+	if len(deps) > 0 {
+		d = deps[0]
+	}
+	if d.loadAndAnalyze == nil {
+		d.loadAndAnalyze = analysis.LoadAndAnalyze
+	}
+	if d.classifyResults == nil {
+		d.classifyResults = classifyResults
+	}
+	if d.loadTestPkg == nil {
+		d.loadTestPkg = loadTestPackage
+	}
+	if d.assess == nil {
+		d.assess = quality.Assess
+	}
+
 	analysisOpts := analysis.Options{
 		IncludeUnexported: loader.IsMainPkg(pkgPath),
 	}
 
 	// Step 1: Analyze (Spec 001).
-	results, err := analysis.LoadAndAnalyze(pkgPath, analysisOpts)
+	results, err := d.loadAndAnalyze(pkgPath, analysisOpts)
 	if err != nil {
 		return nil, ""
 	}
@@ -239,13 +273,13 @@ func analyzePackageCoverage(
 	}
 
 	// Step 2: Classify (Spec 002).
-	classified := classifyResults(results, pkgPath, moduleDir, gazeConfig)
+	classified := d.classifyResults(results, pkgPath, moduleDir, gazeConfig)
 	if classified == nil {
 		return nil, ""
 	}
 
 	// Step 3: Load test package.
-	testPkg, err := loadTestPackage(pkgPath)
+	testPkg, err := d.loadTestPkg(pkgPath)
 	if err != nil {
 		return nil, ""
 	}
@@ -254,10 +288,10 @@ func analyzePackageCoverage(
 	qualOpts := quality.Options{
 		Stderr: stderr,
 	}
-	if len(aiMapperFn) > 0 && aiMapperFn[0] != nil {
-		qualOpts.AIMapperFunc = aiMapperFn[0]
+	if d.aiMapperFn != nil {
+		qualOpts.AIMapperFunc = d.aiMapperFn
 	}
-	reports, summary, err := quality.Assess(classified, testPkg, qualOpts)
+	reports, summary, err := d.assess(classified, testPkg, qualOpts)
 	if err != nil {
 		return nil, ""
 	}

--- a/internal/provider/goprovider/contract_internal_test.go
+++ b/internal/provider/goprovider/contract_internal_test.go
@@ -2,9 +2,16 @@ package goprovider
 
 import (
 	"bytes"
+	"errors"
+	"strings"
 	"testing"
 
+	"golang.org/x/tools/go/packages"
+
+	"github.com/unbound-force/gaze/internal/analysis"
 	"github.com/unbound-force/gaze/internal/config"
+	"github.com/unbound-force/gaze/internal/quality"
+	"github.com/unbound-force/gaze/internal/taxonomy"
 )
 
 // ---------------------------------------------------------------------------
@@ -120,5 +127,223 @@ func TestBuildContractCoverageFunc_WelltestedPackage(t *testing.T) {
 	}
 	if info.Percentage <= 0 {
 		t.Errorf("expected pct > 0 for welltested:Add (well-tested fixture should have non-zero coverage), got %.1f", info.Percentage)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// analyzePackageCoverage DI tests (Task 1.2)
+// ---------------------------------------------------------------------------
+
+// syntheticResult returns a minimal AnalysisResult for DI tests.
+func syntheticResult() taxonomy.AnalysisResult {
+	return taxonomy.AnalysisResult{
+		Target: taxonomy.FunctionTarget{
+			Package:  "example.com/pkg",
+			Function: "DoWork",
+		},
+		SideEffects: []taxonomy.SideEffect{
+			{
+				ID:   "se-abc12345",
+				Type: taxonomy.ReturnValue,
+				Tier: taxonomy.TierP0,
+			},
+		},
+	}
+}
+
+// successDeps returns a contractCoverageDeps that simulates a
+// successful 4-step pipeline with synthetic data.
+func successDeps() contractCoverageDeps {
+	return contractCoverageDeps{
+		loadAndAnalyze: func(_ string, _ analysis.Options) ([]taxonomy.AnalysisResult, error) {
+			return []taxonomy.AnalysisResult{syntheticResult()}, nil
+		},
+		classifyResults: func(results []taxonomy.AnalysisResult, _ string, _ string, _ *config.GazeConfig) []taxonomy.AnalysisResult {
+			return results
+		},
+		loadTestPkg: func(_ string) (*packages.Package, error) {
+			return &packages.Package{Name: "test"}, nil
+		},
+		assess: func(_ []taxonomy.AnalysisResult, _ *packages.Package, _ quality.Options) ([]taxonomy.QualityReport, *taxonomy.PackageSummary, error) {
+			return []taxonomy.QualityReport{
+				{
+					TestFunction: "TestDoWork",
+					TargetFunction: taxonomy.FunctionTarget{
+						Package:  "example.com/pkg",
+						Function: "DoWork",
+					},
+					ContractCoverage: taxonomy.ContractCoverage{
+						Percentage: 75.0,
+					},
+				},
+			}, &taxonomy.PackageSummary{TotalTests: 1}, nil
+		},
+	}
+}
+
+func TestAnalyzePackageCoverage_DI_Success(t *testing.T) {
+	var stderr bytes.Buffer
+	reports, degradedPkg := analyzePackageCoverage(
+		"example.com/pkg", ".", config.DefaultConfig(), &stderr,
+		successDeps(),
+	)
+	if len(reports) == 0 {
+		t.Fatal("expected non-empty reports for successful pipeline")
+	}
+	if reports[0].ContractCoverage.Percentage != 75.0 {
+		t.Errorf("expected 75.0%% coverage, got %.1f%%", reports[0].ContractCoverage.Percentage)
+	}
+	if degradedPkg != "" {
+		t.Errorf("expected empty degradedPkg, got %q", degradedPkg)
+	}
+}
+
+func TestAnalyzePackageCoverage_DI_AnalysisError(t *testing.T) {
+	deps := successDeps()
+	deps.loadAndAnalyze = func(_ string, _ analysis.Options) ([]taxonomy.AnalysisResult, error) {
+		return nil, errors.New("analysis failed")
+	}
+	var stderr bytes.Buffer
+	reports, degradedPkg := analyzePackageCoverage(
+		"example.com/pkg", ".", config.DefaultConfig(), &stderr, deps,
+	)
+	if reports != nil {
+		t.Errorf("expected nil reports on analysis error, got %d reports", len(reports))
+	}
+	if degradedPkg != "" {
+		t.Errorf("expected empty degradedPkg, got %q", degradedPkg)
+	}
+}
+
+func TestAnalyzePackageCoverage_DI_EmptyResults(t *testing.T) {
+	deps := successDeps()
+	deps.loadAndAnalyze = func(_ string, _ analysis.Options) ([]taxonomy.AnalysisResult, error) {
+		return []taxonomy.AnalysisResult{}, nil
+	}
+	var stderr bytes.Buffer
+	reports, degradedPkg := analyzePackageCoverage(
+		"example.com/pkg", ".", config.DefaultConfig(), &stderr, deps,
+	)
+	if reports != nil {
+		t.Errorf("expected nil reports on empty results, got %d reports", len(reports))
+	}
+	if degradedPkg != "" {
+		t.Errorf("expected empty degradedPkg, got %q", degradedPkg)
+	}
+}
+
+func TestAnalyzePackageCoverage_DI_ClassifyNil(t *testing.T) {
+	deps := successDeps()
+	deps.classifyResults = func(_ []taxonomy.AnalysisResult, _ string, _ string, _ *config.GazeConfig) []taxonomy.AnalysisResult {
+		return nil
+	}
+	var stderr bytes.Buffer
+	reports, degradedPkg := analyzePackageCoverage(
+		"example.com/pkg", ".", config.DefaultConfig(), &stderr, deps,
+	)
+	if reports != nil {
+		t.Errorf("expected nil reports when classify returns nil, got %d reports", len(reports))
+	}
+	if degradedPkg != "" {
+		t.Errorf("expected empty degradedPkg, got %q", degradedPkg)
+	}
+}
+
+func TestAnalyzePackageCoverage_DI_LoadTestError(t *testing.T) {
+	deps := successDeps()
+	deps.loadTestPkg = func(_ string) (*packages.Package, error) {
+		return nil, errors.New("no test files")
+	}
+	var stderr bytes.Buffer
+	reports, degradedPkg := analyzePackageCoverage(
+		"example.com/pkg", ".", config.DefaultConfig(), &stderr, deps,
+	)
+	if reports != nil {
+		t.Errorf("expected nil reports on loadTestPkg error, got %d reports", len(reports))
+	}
+	if degradedPkg != "" {
+		t.Errorf("expected empty degradedPkg, got %q", degradedPkg)
+	}
+}
+
+func TestAnalyzePackageCoverage_DI_AssessError(t *testing.T) {
+	deps := successDeps()
+	deps.assess = func(_ []taxonomy.AnalysisResult, _ *packages.Package, _ quality.Options) ([]taxonomy.QualityReport, *taxonomy.PackageSummary, error) {
+		return nil, nil, errors.New("assess failed")
+	}
+	var stderr bytes.Buffer
+	reports, degradedPkg := analyzePackageCoverage(
+		"example.com/pkg", ".", config.DefaultConfig(), &stderr, deps,
+	)
+	if reports != nil {
+		t.Errorf("expected nil reports on assess error, got %d reports", len(reports))
+	}
+	if degradedPkg != "" {
+		t.Errorf("expected empty degradedPkg, got %q", degradedPkg)
+	}
+}
+
+func TestAnalyzePackageCoverage_DI_SSADegraded(t *testing.T) {
+	deps := successDeps()
+	deps.assess = func(_ []taxonomy.AnalysisResult, _ *packages.Package, _ quality.Options) ([]taxonomy.QualityReport, *taxonomy.PackageSummary, error) {
+		reports := []taxonomy.QualityReport{
+			{
+				TestFunction: "TestDoWork",
+				TargetFunction: taxonomy.FunctionTarget{
+					Package:  "example.com/pkg",
+					Function: "DoWork",
+				},
+			},
+		}
+		summary := &taxonomy.PackageSummary{
+			TotalTests:  1,
+			SSADegraded: true,
+		}
+		return reports, summary, nil
+	}
+	var stderr bytes.Buffer
+	reports, degradedPkg := analyzePackageCoverage(
+		"example.com/pkg", ".", config.DefaultConfig(), &stderr, deps,
+	)
+	if len(reports) == 0 {
+		t.Fatal("expected non-empty reports when SSA is degraded")
+	}
+	if degradedPkg != "example.com/pkg" {
+		t.Errorf("expected degradedPkg = %q, got %q", "example.com/pkg", degradedPkg)
+	}
+	// Verify the warning was emitted to stderr.
+	if !strings.Contains(stderr.String(), "SSA degraded") {
+		t.Errorf("expected SSA degradation warning in stderr, got %q", stderr.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// loadTestPackage tests (Task 1.3)
+// ---------------------------------------------------------------------------
+
+func TestLoadTestPackage_WithTests(t *testing.T) {
+	pkg, err := loadTestPackage("github.com/unbound-force/gaze/internal/quality/testdata/src/welltested")
+	if err != nil {
+		t.Fatalf("expected no error for package with tests, got: %v", err)
+	}
+	if pkg == nil {
+		t.Fatal("expected non-nil package")
+	}
+}
+
+func TestLoadTestPackage_WithoutTests(t *testing.T) {
+	_, err := loadTestPackage("github.com/unbound-force/gaze/internal/analysis/testdata/src/returns")
+	if err == nil {
+		t.Fatal("expected error for package without test files")
+	}
+	if !strings.Contains(err.Error(), "no test files found") {
+		t.Errorf("expected error containing %q, got %q", "no test files found", err.Error())
+	}
+}
+
+func TestLoadTestPackage_NonExistent(t *testing.T) {
+	_, err := loadTestPackage("github.com/nonexistent/does-not-exist")
+	if err == nil {
+		t.Fatal("expected error for non-existent package")
 	}
 }

--- a/openspec/changes/crapload-di-coverage-pr1a/.openspec.yaml
+++ b/openspec/changes/crapload-di-coverage-pr1a/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-01

--- a/openspec/changes/crapload-di-coverage-pr1a/design.md
+++ b/openspec/changes/crapload-di-coverage-pr1a/design.md
@@ -60,7 +60,7 @@ Rather than 4 separate deps structs, use 2:
   `runClassifyResults`, `loadTestPkg`, `qualityAssess`, `resolveModulePkgs`,
   and `loadConfig`.
 
-- **`contractCoverageDeps`** in `internal/crap/contract.go` — used by
+- **`contractCoverageDeps`** in `internal/provider/goprovider/contract.go` — used by
   `analyzePackageCoverage`. Contains injectable fields for `loadAndAnalyze`,
   `classifyResults`, `loadTestPkg`, and `qualityAssess`.
 

--- a/openspec/changes/crapload-di-coverage-pr1a/design.md
+++ b/openspec/changes/crapload-di-coverage-pr1a/design.md
@@ -1,0 +1,145 @@
+## Context
+
+Six functions in `internal/crap/` and `internal/aireport/` have 0% line coverage
+and CRAP scores between 30 and 110, contributing to CRAPload sitting at exactly
+38/38 (the CI threshold). These functions are orchestration functions that
+hardcode calls to heavy I/O operations (`packages.Load`,
+`analysis.LoadAndAnalyze`, `quality.Assess`).
+
+`gaze crap` generates coverage profiles via `go test -short`, so tests guarded
+by `testing.Short()` are skipped and contribute zero coverage. To reduce
+CRAPload, new tests must run without the `-short` guard, which requires
+dependency injection so tests can substitute synthetic implementations for
+the expensive I/O calls.
+
+The existing `pipelineStepFuncs` pattern in `internal/aireport/runner.go:243`
+proves this approach works in the same codebase.
+
+## Goals / Non-Goals
+
+### Goals
+- Make 6 zero-coverage functions testable in isolation (Principle IV: Testability)
+- Add unit tests that run without `-short` guard and produce coverage data
+- Reduce CRAPload from 38 toward ~32 (drop ~6 functions below CRAP threshold)
+- Follow the established `pipelineStepFuncs` DI pattern
+- Zero behavioral change to production code paths
+
+### Non-Goals
+- Decomposing `BuildContractCoverageFunc` (deferred to PR 2a)
+- Deduplicating `loadTestPackage` / `loadTestPackageForQuality` (deferred to PR 2a)
+- Modifying any exported API surface
+- Changing the CRAP threshold value (deferred to Phase 3)
+- Achieving 100% coverage on target functions (50%+ is sufficient to drop below CRAP 15)
+
+## Decisions
+
+### D1: Deps struct pattern with nil-means-default
+
+Each orchestration function that needs DI will accept an optional deps struct
+parameter. When a field is nil, the real implementation is used. This mirrors the
+existing `pipelineStepFuncs` pattern exactly.
+
+**Rationale**: Proven pattern in the same package. Zero-value struct means
+production behavior — no risk of accidentally using a test double in production.
+Callers that don't need injection pass zero-value or omit the parameter.
+
+### D2: Two deps structs, not four
+
+The 4 orchestration functions form a call hierarchy:
+
+```
+runQualityStep → runQualityForPackage → (leaf calls)
+runClassifyStep → (leaf calls)
+```
+
+Rather than 4 separate deps structs, use 2:
+
+- **`qualityPipelineDeps`** in `internal/aireport/runner_steps.go` — shared by
+  `runQualityStep`, `runQualityForPackage`, and `runClassifyStep`. Contains
+  injectable fields for `resolvePackagePaths`, `loadAndAnalyze`,
+  `runClassifyResults`, `loadTestPkg`, `qualityAssess`, `resolveModulePkgs`,
+  and `loadConfig`.
+
+- **`contractCoverageDeps`** in `internal/crap/contract.go` — used by
+  `analyzePackageCoverage`. Contains injectable fields for `loadAndAnalyze`,
+  `classifyResults`, `loadTestPkg`, and `qualityAssess`.
+
+**Rationale**: Fewer types to maintain. The aireport functions share the same
+dependency set because they're all part of the same pipeline. The crap package
+has its own copy of some dependencies (e.g., `classifyResults` differs from
+`runClassifyResults`) so it needs a separate struct.
+
+### D3: Variadic deps parameter for backward compatibility
+
+Functions will accept deps as a variadic parameter:
+
+```go
+func analyzePackageCoverage(..., deps ...contractCoverageDeps) (...)
+```
+
+When no deps argument is supplied, the function uses its default (real)
+implementations. This preserves all existing call sites without modification.
+
+**Rationale**: Minimizes diff size and risk. Production callers don't change at
+all. Only test callers pass the deps struct.
+
+### D4: Leaf functions tested with real fixtures, no DI
+
+`loadTestPackage` and `loadTestPackageForQuality` are leaf functions that call
+`packages.Load` directly. There's nothing meaningful to inject — the function
+*is* the `packages.Load` call plus error handling and test-syntax detection.
+
+These will be tested with small `testdata/` fixture packages that load in
+sub-second time:
+- `internal/quality/testdata/src/welltested` — success path (has test files)
+- `internal/analysis/testdata/src/returns` — error path (no test files)
+
+**Rationale**: The fixtures already exist, load quickly, and have no external
+imports that would require `go mod download` state. Testing with real packages
+exercises the actual `packages.Config` setup, which is the main thing to verify.
+
+### D5: Internal package tests (same package, not `_test` suffix)
+
+New tests will be in the same package (internal tests) to access unexported
+functions and deps structs. This matches the existing test file patterns:
+- `contract_test.go` uses `package crap`
+- `pipeline_internal_test.go` uses `package aireport`
+
+**Rationale**: The target functions are all unexported. External package tests
+cannot access them.
+
+## Risks / Trade-offs
+
+### Risk: Deps structs increase API surface within the package
+
+Adding deps structs introduces new unexported types. If poorly designed, they
+could become a maintenance burden as function signatures evolve.
+
+**Mitigation**: Keep deps structs minimal — only inject the calls that are
+actually expensive I/O operations. Pure functions (`classify.CountLabels`,
+`quality.BuildPackageSummary`) are not injected.
+
+### Risk: Leaf function tests may be slow on some CI environments
+
+`loadTestPackage` tests call `packages.Load`, which invokes the Go compiler
+toolchain. On slow CI runners, even small fixtures could take several seconds.
+
+**Mitigation**: The existing `testdata/` fixtures are minimal Go packages (4-10
+source files, no external imports). If timing becomes an issue, these specific
+tests can be `-short`-guarded as a fallback without losing the DI-based coverage
+gains on the orchestration functions.
+
+### Trade-off: Two similar deps patterns in two packages
+
+`contractCoverageDeps` (crap) and `qualityPipelineDeps` (aireport) share some
+field types (e.g., `loadAndAnalyze`, `loadTestPkg`). Deduplication would require
+a shared package for the deps type, which introduces coupling between `crap` and
+`aireport`. We accept the duplication as the lesser cost.
+
+### Trade-off: Coverage may not reach 50% on all functions
+
+Some functions have high cyclomatic complexity with many branches (e.g.,
+`analyzePackageCoverage` at complexity 10). Achieving 50% coverage requires
+exercising at least 5 distinct paths. The test plan targets the most impactful
+paths (success, analysis failure, no results, classify failure, no test files,
+quality failure, SSA degradation) which should exceed 50%.

--- a/openspec/changes/crapload-di-coverage-pr1a/proposal.md
+++ b/openspec/changes/crapload-di-coverage-pr1a/proposal.md
@@ -1,0 +1,106 @@
+## Why
+
+The CI CRAPload threshold is `--max-crapload=38` and `main` is at exactly
+`CRAPload: 38/38`. Six functions in `internal/crap/` and `internal/aireport/`
+have 0% line coverage and CRAP scores between 30 and 110, contributing to this
+fragile boundary. Any complexity increase to these functions risks breaking CI,
+as already happened in #131 / PR #160.
+
+These functions are currently untestable in isolation because they hardcode calls
+to heavy I/O operations (`packages.Load`, `analysis.LoadAndAnalyze`,
+`quality.Assess`). The only existing tests are guarded by `testing.Short()`,
+which means they are **skipped** during `gaze crap`'s internal coverage
+generation (`go test -short -coverprofile=...`) and contribute zero coverage
+to the CRAPload calculation.
+
+Adding dependency injection to these functions enables fast unit tests that run
+without the `-short` guard, producing real coverage data that reduces CRAP scores
+and creates headroom below the threshold.
+
+This is Phase 1a of issue #166 (CRAPload fragility reduction).
+
+## What Changes
+
+### Production code (light refactoring)
+
+Add injectable dependency structs to 4 orchestration functions, following the
+existing `pipelineStepFuncs` pattern in `internal/aireport/runner.go`:
+
+- `analyzePackageCoverage` in `internal/crap/contract.go`
+- `runQualityForPackage` in `internal/aireport/runner_steps.go`
+- `runQualityStep` in `internal/aireport/runner_steps.go`
+- `runClassifyStep` in `internal/aireport/runner_steps.go`
+
+Each function gains an optional deps parameter (or uses a struct with default
+constructors) so that tests can substitute synthetic implementations for heavy
+I/O calls while production call sites remain unchanged.
+
+### Test code
+
+Add unit tests for all 6 target functions:
+
+- `loadTestPackage` (crap) -- test with small `testdata/` fixtures, no `-short` guard
+- `loadTestPackageForQuality` (aireport) -- same approach
+- `analyzePackageCoverage` (crap) -- test via injected deps
+- `runQualityForPackage` (aireport) -- test via injected deps
+- `runQualityStep` (aireport) -- test via injected deps
+- `runClassifyStep` (aireport) -- test via injected deps
+
+## Capabilities
+
+### New Capabilities
+- None (internal testability improvement only)
+
+### Modified Capabilities
+- `analyzePackageCoverage`: Accepts optional injectable dependencies for testing
+- `runQualityForPackage`: Accepts optional injectable dependencies for testing
+- `runQualityStep`: Accepts optional injectable dependencies for testing
+- `runClassifyStep`: Accepts optional injectable dependencies for testing
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Files modified**: `internal/crap/contract.go`, `internal/aireport/runner_steps.go`
+- **Test files modified**: `internal/crap/contract_test.go`, `internal/aireport/runner_steps_test.go`
+- **No API surface changes**: All functions are unexported; no callers outside their package
+- **No behavioral changes**: Production code paths remain identical; DI structs default to the real implementations
+- **Expected CRAPload reduction**: ~6 functions drop below the CRAP threshold (15), reducing CRAPload from 38 to ~32
+
+## Constitution Alignment
+
+Assessed against the Gaze project constitution (v1.3.0).
+
+### I. Accuracy
+
+**Assessment**: N/A
+
+This change does not modify side effect detection, classification, or reporting
+logic. All production code paths remain identical.
+
+### II. Minimal Assumptions
+
+**Assessment**: PASS
+
+No new assumptions are introduced. The DI pattern uses zero-value defaults that
+wire to the real implementations, requiring no configuration from users or
+callers.
+
+### III. Actionable Output
+
+**Assessment**: N/A
+
+This change does not modify output formats, report content, or metrics. CRAPload
+numbers will change as a consequence of increased coverage, but the metric
+definition and computation are unchanged.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+This change directly advances Principle IV. It makes 6 functions testable in
+isolation by decoupling them from heavy I/O dependencies. Tests verify observable
+side effects (return values, error conditions, degradation signals) rather than
+implementation details. Coverage strategy: unit tests with synthetic dependencies,
+no `-short` guard, targeting >= 50% line coverage per function.

--- a/openspec/changes/crapload-di-coverage-pr1a/proposal.md
+++ b/openspec/changes/crapload-di-coverage-pr1a/proposal.md
@@ -26,7 +26,7 @@ This is Phase 1a of issue #166 (CRAPload fragility reduction).
 Add injectable dependency structs to 4 orchestration functions, following the
 existing `pipelineStepFuncs` pattern in `internal/aireport/runner.go`:
 
-- `analyzePackageCoverage` in `internal/crap/contract.go`
+- `analyzePackageCoverage` in `internal/provider/goprovider/contract.go`
 - `runQualityForPackage` in `internal/aireport/runner_steps.go`
 - `runQualityStep` in `internal/aireport/runner_steps.go`
 - `runClassifyStep` in `internal/aireport/runner_steps.go`
@@ -62,8 +62,8 @@ Add unit tests for all 6 target functions:
 
 ## Impact
 
-- **Files modified**: `internal/crap/contract.go`, `internal/aireport/runner_steps.go`
-- **Test files modified**: `internal/crap/contract_test.go`, `internal/aireport/runner_steps_test.go`
+- **Files modified**: `internal/provider/goprovider/contract.go`, `internal/aireport/runner_steps.go`
+- **Test files modified**: `internal/provider/goprovider/contract_internal_test.go`, `internal/aireport/runner_steps_test.go`
 - **No API surface changes**: All functions are unexported; no callers outside their package
 - **No behavioral changes**: Production code paths remain identical; DI structs default to the real implementations
 - **Expected CRAPload reduction**: ~6 functions drop below the CRAP threshold (15), reducing CRAPload from 38 to ~32

--- a/openspec/changes/crapload-di-coverage-pr1a/specs/di-coverage.md
+++ b/openspec/changes/crapload-di-coverage-pr1a/specs/di-coverage.md
@@ -1,0 +1,177 @@
+## ADDED Requirements
+
+### Requirement: contractCoverageDeps injection for analyzePackageCoverage
+
+`analyzePackageCoverage` in `internal/crap/contract.go` MUST accept an optional
+variadic `contractCoverageDeps` parameter. When no deps argument is supplied, the
+function MUST use the real implementations (`analysis.LoadAndAnalyze`,
+`classifyResults`, `loadTestPackage`, `quality.Assess`). When a deps argument is
+supplied, the function MUST use the injected implementations.
+
+The `contractCoverageDeps` struct MUST contain the following injectable fields:
+- `loadAndAnalyze` — replaces `analysis.LoadAndAnalyze`
+- `classifyResults` — replaces `classifyResults`
+- `loadTestPkg` — replaces `loadTestPackage`
+- `assess` — replaces `quality.Assess`
+
+The struct MUST be unexported (package-internal).
+
+#### Scenario: Production call site unchanged
+- **GIVEN** `analyzePackageCoverage` is called without a deps argument
+- **WHEN** the function executes
+- **THEN** it MUST use the real implementations and produce identical results to
+  the current behavior
+
+#### Scenario: Test with injected deps — success path
+- **GIVEN** `analyzePackageCoverage` is called with a deps argument providing
+  synthetic implementations that return valid results
+- **WHEN** the function executes
+- **THEN** it MUST return non-nil quality reports using the injected data
+
+#### Scenario: Test with injected deps — analysis failure
+- **GIVEN** `analyzePackageCoverage` is called with a deps argument where
+  `loadAndAnalyze` returns an error
+- **WHEN** the function executes
+- **THEN** it MUST return `(nil, "")` without calling subsequent pipeline steps
+
+#### Scenario: Test with injected deps — SSA degradation
+- **GIVEN** `analyzePackageCoverage` is called with a deps argument where
+  `assess` returns a summary with `SSADegraded=true`
+- **WHEN** the function executes
+- **THEN** the second return value MUST be the package path (non-empty string)
+
+### Requirement: qualityPipelineDeps injection for aireport orchestration functions
+
+`runQualityStep`, `runQualityForPackage`, and `runClassifyStep` in
+`internal/aireport/runner_steps.go` MUST accept an optional variadic
+`qualityPipelineDeps` parameter. When no deps argument is supplied, the functions
+MUST use the real implementations. When a deps argument is supplied, the
+functions MUST use the injected implementations.
+
+The `qualityPipelineDeps` struct MUST contain injectable fields for all heavy
+I/O operations called by these functions:
+- `resolvePackagePaths` — replaces `loader.ResolvePackagePaths`
+- `loadAndAnalyze` — replaces `analysis.LoadAndAnalyze`
+- `classifyResults` — replaces `runClassifyResults`
+- `loadTestPkg` — replaces `loadTestPackageForQuality`
+- `assess` — replaces `quality.Assess`
+- `resolveModulePkgs` — replaces `resolveModulePackages`
+- `loadConfig` — replaces `loadGazeConfigBestEffort`
+
+The struct MUST be unexported (package-internal).
+
+#### Scenario: runQualityStep — success with multiple packages
+- **GIVEN** `runQualityStep` is called with deps where `resolvePackagePaths`
+  returns 2 package paths and `runQualityForPackage` returns valid reports
+  for each
+- **WHEN** the function executes
+- **THEN** it MUST return a `qualityStepResult` with aggregated reports from
+  both packages and non-nil JSON
+
+#### Scenario: runQualityStep — resolve failure
+- **GIVEN** `runQualityStep` is called with deps where `resolvePackagePaths`
+  returns an error
+- **WHEN** the function executes
+- **THEN** it MUST return an error without calling any subsequent pipeline steps
+
+#### Scenario: runQualityStep — SSA degradation propagation
+- **GIVEN** `runQualityStep` is called with deps where one package's quality
+  assessment returns `SSADegraded=true`
+- **WHEN** the function executes
+- **THEN** the result MUST have `SSADegraded=true` and the degraded package path
+  in `SSADegradedPackages`
+
+#### Scenario: runClassifyStep — success with label counts
+- **GIVEN** `runClassifyStep` is called with deps where analysis and
+  classification succeed for a package
+- **WHEN** the function executes
+- **THEN** the result MUST contain correct `Contractual`, `Ambiguous`, and
+  `Incidental` counts from `classify.CountLabels`
+
+#### Scenario: runClassifyStep — resolve failure
+- **GIVEN** `runClassifyStep` is called with deps where `resolvePackagePaths`
+  returns an error
+- **WHEN** the function executes
+- **THEN** it MUST return an error
+
+#### Scenario: runQualityForPackage — success path
+- **GIVEN** `runQualityForPackage` is called with deps where all sub-steps
+  succeed
+- **WHEN** the function executes
+- **THEN** it MUST return non-nil quality reports and an empty degraded
+  package path
+
+#### Scenario: runQualityForPackage — no test files
+- **GIVEN** `runQualityForPackage` is called with deps where `loadTestPkg`
+  returns an error (no test files found)
+- **WHEN** the function executes
+- **THEN** it MUST return `(nil, "")`
+
+### Requirement: loadTestPackage unit tests
+
+`loadTestPackage` in `internal/crap/contract.go` MUST have unit tests that
+exercise both the success and error paths. Tests MUST NOT be guarded by
+`testing.Short()`.
+
+#### Scenario: Package with test files
+- **GIVEN** a package path pointing to a testdata fixture with test files
+  (e.g., `internal/quality/testdata/src/welltested`)
+- **WHEN** `loadTestPackage` is called
+- **THEN** it MUST return a non-nil `*packages.Package` with test syntax
+
+#### Scenario: Package without test files
+- **GIVEN** a package path pointing to a testdata fixture without test files
+  (e.g., `internal/analysis/testdata/src/returns`)
+- **WHEN** `loadTestPackage` is called
+- **THEN** it MUST return an error containing "no test files found"
+
+#### Scenario: Non-existent package
+- **GIVEN** a package path that does not exist
+- **WHEN** `loadTestPackage` is called
+- **THEN** it MUST return an error
+
+### Requirement: loadTestPackageForQuality unit tests
+
+`loadTestPackageForQuality` in `internal/aireport/runner_steps.go` MUST have
+unit tests that exercise both the success and error paths. Tests MUST NOT be
+guarded by `testing.Short()`.
+
+#### Scenario: Package with test files
+- **GIVEN** a package path pointing to a testdata fixture with test files
+- **WHEN** `loadTestPackageForQuality` is called
+- **THEN** it MUST return a non-nil `*packages.Package` with test syntax
+
+#### Scenario: Package without test files
+- **GIVEN** a package path pointing to a testdata fixture without test files
+- **WHEN** `loadTestPackageForQuality` is called
+- **THEN** it MUST return an error containing "no test package found"
+
+## MODIFIED Requirements
+
+### Requirement: analyzePackageCoverage signature
+
+`analyzePackageCoverage` MUST accept an optional variadic `contractCoverageDeps`
+parameter as the last argument. Previously: the function accepted only
+`pkgPath`, `moduleDir`, `gazeConfig`, `stderr`, and optional `aiMapperFn`.
+
+### Requirement: runQualityStep signature
+
+`runQualityStep` MUST accept an optional variadic `qualityPipelineDeps`
+parameter as the last argument. Previously: the function accepted only
+`patterns`, `moduleDir`, and `stderr`.
+
+### Requirement: runClassifyStep signature
+
+`runClassifyStep` MUST accept an optional variadic `qualityPipelineDeps`
+parameter as the last argument. Previously: the function accepted only
+`patterns` and `moduleDir`.
+
+### Requirement: runQualityForPackage signature
+
+`runQualityForPackage` MUST accept an optional variadic `qualityPipelineDeps`
+parameter as the last argument. Previously: the function accepted only
+`pkgPath`, `gazeConfig`, `modPkgs`, and `stderr`.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/crapload-di-coverage-pr1a/specs/di-coverage.md
+++ b/openspec/changes/crapload-di-coverage-pr1a/specs/di-coverage.md
@@ -2,7 +2,7 @@
 
 ### Requirement: contractCoverageDeps injection for analyzePackageCoverage
 
-`analyzePackageCoverage` in `internal/crap/contract.go` MUST accept an optional
+`analyzePackageCoverage` in `internal/provider/goprovider/contract.go` MUST accept an optional
 variadic `contractCoverageDeps` parameter. When no deps argument is supplied, the
 function MUST use the real implementations (`analysis.LoadAndAnalyze`,
 `classifyResults`, `loadTestPackage`, `quality.Assess`). When a deps argument is
@@ -109,7 +109,7 @@ The struct MUST be unexported (package-internal).
 
 ### Requirement: loadTestPackage unit tests
 
-`loadTestPackage` in `internal/crap/contract.go` MUST have unit tests that
+`loadTestPackage` in `internal/provider/goprovider/contract.go` MUST have unit tests that
 exercise both the success and error paths. Tests MUST NOT be guarded by
 `testing.Short()`.
 

--- a/openspec/changes/crapload-di-coverage-pr1a/tasks.md
+++ b/openspec/changes/crapload-di-coverage-pr1a/tasks.md
@@ -12,7 +12,7 @@
 
 ## 1. Add contractCoverageDeps to internal/crap/
 
-- [x] 1.1 Define `contractCoverageDeps` struct in `internal/crap/contract.go`
+- [x] 1.1 Define `contractCoverageDeps` struct in `internal/provider/goprovider/contract.go`
   with injectable fields: `loadAndAnalyze`, `classifyResults`, `loadTestPkg`,
   `assess`. Absorb the existing `aiMapperFn` variadic parameter into the struct
   as a field (Go does not allow two variadic parameters). Add a nil-means-default
@@ -22,7 +22,7 @@
   through the deps struct (no behavioral change).
 
 - [x] 1.2 Add unit tests for `analyzePackageCoverage` in
-  `internal/crap/contract_test.go` using injected deps. Test cases:
+  `internal/provider/goprovider/contract_internal_test.go` using injected deps. Test cases:
   - Success path (all deps return valid data)
   - `loadAndAnalyze` returns error → returns `(nil, "")`
   - `loadAndAnalyze` returns empty results → returns `(nil, "")`
@@ -33,7 +33,7 @@
   Tests MUST NOT be guarded by `testing.Short()`.
 
 - [x] 1.3 Add unit tests for `loadTestPackage` in
-  `internal/crap/contract_test.go`. Test cases:
+  `internal/provider/goprovider/contract_internal_test.go`. Test cases:
   - Package with test files (`internal/quality/testdata/src/welltested`) → success
   - Package without test files (`internal/analysis/testdata/src/returns`) → error
   - Non-existent package → error

--- a/openspec/changes/crapload-di-coverage-pr1a/tasks.md
+++ b/openspec/changes/crapload-di-coverage-pr1a/tasks.md
@@ -1,0 +1,122 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add contractCoverageDeps to internal/crap/
+
+- [x] 1.1 Define `contractCoverageDeps` struct in `internal/crap/contract.go`
+  with injectable fields: `loadAndAnalyze`, `classifyResults`, `loadTestPkg`,
+  `assess`. Absorb the existing `aiMapperFn` variadic parameter into the struct
+  as a field (Go does not allow two variadic parameters). Add a nil-means-default
+  resolution block at the top of `analyzePackageCoverage`. Update
+  `analyzePackageCoverage` signature to accept variadic `...contractCoverageDeps`.
+  Update the call site in `BuildContractCoverageFunc` to pass the `aiMapperFn`
+  through the deps struct (no behavioral change).
+
+- [x] 1.2 Add unit tests for `analyzePackageCoverage` in
+  `internal/crap/contract_test.go` using injected deps. Test cases:
+  - Success path (all deps return valid data)
+  - `loadAndAnalyze` returns error → returns `(nil, "")`
+  - `loadAndAnalyze` returns empty results → returns `(nil, "")`
+  - `classifyResults` returns nil → returns `(nil, "")`
+  - `loadTestPkg` returns error → returns `(nil, "")`
+  - `assess` returns error → returns `(nil, "")`
+  - `assess` returns `SSADegraded=true` → returns `(reports, pkgPath)`
+  Tests MUST NOT be guarded by `testing.Short()`.
+
+- [x] 1.3 Add unit tests for `loadTestPackage` in
+  `internal/crap/contract_test.go`. Test cases:
+  - Package with test files (`internal/quality/testdata/src/welltested`) → success
+  - Package without test files (`internal/analysis/testdata/src/returns`) → error
+  - Non-existent package → error
+  Tests MUST NOT be guarded by `testing.Short()`.
+
+## 2. Add qualityPipelineDeps to internal/aireport/
+
+- [x] 2.1 Define `qualityPipelineDeps` struct in
+  `internal/aireport/runner_steps.go` with injectable fields:
+  `resolvePackagePaths`, `loadAndAnalyze`, `classifyResults`, `loadTestPkg`,
+  `assess`, `resolveModulePkgs`, `loadConfig`. Add nil-means-default resolution.
+  Update signatures of `runQualityStep`, `runQualityForPackage`, and
+  `runClassifyStep` to accept variadic `...qualityPipelineDeps`. Update call
+  sites: `runQualityStep` calling `runQualityForPackage` must forward deps.
+  `runProductionPipeline` call sites pass zero-value (no behavioral change).
+
+- [x] 2.2 Add unit tests for `runQualityForPackage` in
+  `internal/aireport/runner_steps_test.go` using injected deps. Test cases:
+  - Success path (all deps return valid data) → non-nil reports
+  - `loadAndAnalyze` returns error → returns `(nil, "")`
+  - `loadAndAnalyze` returns empty results → returns `(nil, "")`
+  - `classifyResults` returns error → returns `(nil, "")`
+  - `loadTestPkg` returns error → returns `(nil, "")`
+  - `assess` returns error → returns `(nil, "")`
+  - `assess` returns `SSADegraded=true` → returns `(reports, pkgPath)`
+  Tests MUST NOT be guarded by `testing.Short()`.
+
+- [x] 2.3 Add unit tests for `runQualityStep` in
+  `internal/aireport/runner_steps_test.go` using injected deps. Test cases:
+  - Success with single package → valid `qualityStepResult`
+  - Success with multiple packages → aggregated reports
+  - `resolvePackagePaths` returns error → error
+  - `resolvePackagePaths` returns empty → error
+  - SSA degradation from one package propagates to result
+  Tests MUST NOT be guarded by `testing.Short()`.
+
+- [x] 2.4 Add unit tests for `runClassifyStep` in
+  `internal/aireport/runner_steps_test.go` using injected deps. Test cases:
+  - Success with label counts → correct Contractual/Ambiguous/Incidental
+  - `resolvePackagePaths` returns error → error
+  - `resolvePackagePaths` returns empty → error
+  - `loadAndAnalyze` returns error for one package → skip, continue
+  - `loadAndAnalyze` returns empty results for one package → skip, continue
+  - `classifyResults` returns error for one package → skip, continue
+  Tests MUST NOT be guarded by `testing.Short()`.
+
+- [x] 2.5 Add unit tests for `loadTestPackageForQuality` in
+  `internal/aireport/runner_steps_test.go`. Test cases:
+  - Package with test files (`internal/quality/testdata/src/welltested`) → success
+  - Package without test files (`internal/analysis/testdata/src/returns`) → error
+  - Non-existent package → error
+  Tests MUST NOT be guarded by `testing.Short()`.
+
+## 3. Update pipelineStepFuncs call sites
+
+- [x] 3.1 Update the `pipelineStepFuncs` function type signatures in
+  `internal/aireport/runner.go` to match the new variadic signatures of
+  `runQualityStep` and `runClassifyStep`. Update the fake step closures in
+  `pipeline_internal_test.go` to match the new function types (minimal
+  signature adaptation — add the variadic deps parameter, ignore it in
+  the fake body). Verify that the nil-defaults in `runProductionPipeline`
+  still correctly wire to the real functions. Existing
+  `pipeline_internal_test.go` tests MUST continue to pass with the same
+  behavioral assertions.
+
+## 4. Verification
+
+- [x] 4.1 Run `go test -race -count=1 -short ./internal/crap/... ./internal/aireport/...`
+  and verify all new and existing tests pass.
+
+- [x] 4.2 Run `go build ./cmd/gaze` and verify the binary builds without errors.
+
+- [x] 4.3 Run `golangci-lint run ./internal/crap/... ./internal/aireport/...`
+  and verify zero lint issues.
+
+- [x] 4.4 Run `./gaze crap ./...` and verify CRAPload has decreased from 38
+  toward the target of ~32. Record the new CRAPload value: **32**.
+  Documentation impact: none (all changes are internal/unexported).
+
+- [x] 4.5 Verify constitution alignment (Principle IV: Testability): confirm
+  all new tests verify observable side effects (return values, error conditions,
+  degradation signals) rather than implementation details. Confirm no new tests
+  are guarded by `testing.Short()`.
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Reduce CRAPload from 38 to 32 by adding dependency injection and unit tests to 6 functions in `internal/crap/` and `internal/aireport/` that previously had 0% line coverage. This creates an 8-function buffer below the CI threshold
(`--max-crapload=38`), addressing the fragility described in #166.

### Problem

CRAPload sat at exactly 38/38 (the CI threshold). Six pipeline orchestration functions had 0% coverage because their only tests were guarded by `testing.Short()`, which is skipped during `gaze crap`'s internal coverage generation (`go test -short -coverprofile=...`).

### Solution

- Added `contractCoverageDeps` struct to `internal/crap/contract.go` — injectable dependencies for `analyzePackageCoverage` (absorbs existing `aiMapperFn` variadic)
- Added `qualityPipelineDeps` struct to `internal/aireport/runner_steps.go` — injectable dependencies for `runQualityStep`, `runQualityForPackage`, `runClassifyStep`
- Added 31 new unit tests (10 in `crap`, 21 in `aireport`) — none guarded by `testing.Short()` so they contribute real coverage to CRAPload
- Updated `pipelineStepFuncs` signatures and test fakes in `pipeline_internal_test.go`
- Follows the established `pipelineStepFuncs` nil-means-default DI pattern

### Functions covered

| Function | Package | CRAP Before | CRAP After |
|----------|---------|------------|------------|
| `analyzePackageCoverage` | `crap` | 110.0 | 14.7 |
| `runQualityForPackage` | `aireport` | 110.0 | 10.0 |
| `loadTestPackage` | `crap` | 72.0 | < 15 |
| `runQualityStep` | `aireport` | 72.0 | < 15 |
| `runClassifyStep` | `aireport` | 72.0 | < 15 |
| `loadTestPackageForQuality` | `aireport` | 30.0 | < 15 |

### Files changed

- `internal/crap/contract.go` — DI struct + signature change (+54 lines)
- `internal/crap/contract_test.go` — 10 new tests (+225 lines)
- `internal/aireport/runner_steps.go` — DI struct + 3 signature changes (+90 lines)
- `internal/aireport/runner_steps_test.go` — 21 new tests (+456 lines)
- `internal/aireport/runner.go` — `pipelineStepFuncs` type updates (+4/-4 lines)
- `internal/aireport/pipeline_internal_test.go` — fake closure signature updates (+10/-10 lines)
- `openspec/changes/crapload-di-coverage-pr1a/` — spec artifacts

### Verification

- `go build ./...` — PASS
- `go test -race -count=1 -short ./...` — PASS (all 16 packages)
- `golangci-lint run` — 0 issues in changed files
- CRAPload: **38 → 32** (target met)

**RE: MEDIUM — duplicate DI resolution logic**
Acknowledged. The duplication between `contractCoverageDeps` (crap) and `qualityPipelineDeps` (aireport) is intentional — the `classifyResults` signatures genuinely differ between packages (design decision D2). 
Consolidation of `loadTestPackage`/`loadTestPackageForQuality` and related dedup is planned for PR 2a (`BuildContractCoverageFunc` decomposition).

Partially addresses #166 (Phase 1a).