### PR TITLE
chore: replace stdlib log.Printf with charmbracelet/log in SSA recovery paths

### DIFF
--- a/internal/analysis/mutation.go
+++ b/internal/analysis/mutation.go
@@ -6,8 +6,8 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
-	"log"
 
+	"github.com/charmbracelet/log"
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/ssa"
 	"golang.org/x/tools/go/ssa/ssautil"
@@ -47,8 +47,8 @@ func BuildSSA(pkg *packages.Package) (ssaPkg *ssa.Package) {
 	)
 
 	if r := safeSSABuild(prog.Build); r != nil {
-		log.Printf("warning: SSA build skipped for %s: internal panic recovered", pkg.PkgPath)
-		log.Printf("debug: SSA panic value for %s: %v", pkg.PkgPath, r)
+		log.Warn("SSA build skipped: internal panic recovered", "pkg", pkg.PkgPath)
+		log.Debug("SSA panic value", "pkg", pkg.PkgPath, "panic", r)
 		return nil
 	}
 

--- a/internal/analysis/mutation_test.go
+++ b/internal/analysis/mutation_test.go
@@ -66,7 +66,7 @@ func TestSafeSSABuild_PanicError(t *testing.T) {
 // mocked or injected. The recovery pattern is verified through the
 // safeSSABuild helper tests above (which exercise the identical
 // defer/recover logic). BuildSSA's logging behavior is verified by
-// code inspection — the log.Printf calls are co-located with the
+// code inspection — the log.Warn/log.Debug calls are co-located with the
 // safeSSABuild call in the same if-block.
 // ---------------------------------------------------------------------------
 

--- a/internal/quality/pairing.go
+++ b/internal/quality/pairing.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"go/ast"
 	"go/types"
-	"log"
 	"sort"
 	"strings"
 
+	"github.com/charmbracelet/log"
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/ssa"
 	"golang.org/x/tools/go/ssa/ssautil"
@@ -133,8 +133,8 @@ func BuildTestSSA(pkg *packages.Package) (program *ssa.Program, ssaPkg *ssa.Pack
 	)
 
 	if r := safeSSABuild(prog.Build); r != nil {
-		log.Printf("warning: SSA build skipped for %s: internal panic recovered", pkg.PkgPath)
-		log.Printf("debug: SSA panic value for %s: %v", pkg.PkgPath, r)
+		log.Warn("SSA build skipped: internal panic recovered", "pkg", pkg.PkgPath)
+		log.Debug("SSA panic value", "pkg", pkg.PkgPath, "panic", r)
 		return nil, nil, fmt.Errorf("SSA build panicked for package %s: internal panic recovered", pkg.PkgPath)
 	}
 

--- a/openspec/changes/ssa-charmbracelet-log/.openspec.yaml
+++ b/openspec/changes/ssa-charmbracelet-log/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-06

--- a/openspec/changes/ssa-charmbracelet-log/design.md
+++ b/openspec/changes/ssa-charmbracelet-log/design.md
@@ -1,0 +1,49 @@
+## Context
+
+The SSA panic recovery paths in `internal/analysis/mutation.go` and `internal/quality/pairing.go` use `log.Printf` from the standard library `log` package. Convention pack rule CS-008 requires all application logging to use `github.com/charmbracelet/log`. These four calls were introduced in spec 021 before CS-008 was codified. A similar fix in `internal/loader/loader.go` was completed in PR #159 and serves as a precedent.
+
+## Goals / Non-Goals
+
+### Goals
+- Replace all four stdlib `log.Printf` calls with `charmbracelet/log` structured equivalents
+- Update import statements in both affected files
+- Maintain identical diagnostic behavior (same log levels, same information conveyed)
+
+### Non-Goals
+- Refactoring the `safeSSABuild` recovery pattern itself
+- Adding log-level configuration or filtering
+- Changing the log output destination (both packages already write to stderr)
+- Modifying any test code or test assertions for logging output
+
+## Decisions
+
+**D1: Use package-level `log.Warn`/`log.Debug` functions, not a logger instance**
+
+Both affected files currently use `log.Printf` at the package level. The replacement will use `charmbracelet/log`'s package-level functions (`log.Warn`, `log.Debug`) which is consistent with how `charmbracelet/log` is used elsewhere in the project (e.g., the fix in `internal/loader/loader.go`).
+
+Rationale: No need to thread a logger through function signatures for diagnostic logging in recovery paths. The `charmbracelet/log` default logger writes to stderr, matching the stdlib `log` behavior.
+
+**D2: Map log levels from Printf prefixes to structured calls**
+
+The current calls embed level in the format string (`"warning: ..."`, `"debug: ..."`). The replacement uses the appropriate structured method:
+
+| Current | Replacement |
+|---------|-------------|
+| `log.Printf("warning: SSA build skipped for %s: ...")` | `log.Warn("SSA build skipped: internal panic recovered", "pkg", pkg.PkgPath)` |
+| `log.Printf("debug: SSA panic value for %s: %v")` | `log.Debug("SSA panic value", "pkg", pkg.PkgPath, "panic", r)` |
+
+Rationale: Structured key-value pairs improve machine-parseability (Observable Quality principle) and let users filter by log level.
+
+**D3: Import alias not needed**
+
+Both files currently import `"log"`. The replacement import `"github.com/charmbracelet/log"` also resolves to the package name `log`, so no alias is required and all call sites remain `log.Xxx(...)`.
+
+## Coverage Strategy
+
+No new tests required. Existing `safeSSABuild` tests in both packages verify the recovery behavior. The logging format change is not asserted in tests (operational output, not contractual behavior). Verification: existing test suite passes unchanged (task 2.2), plus grep check confirms no stdlib `"log"` import remains (task 2.4).
+
+## Risks / Trade-offs
+
+**Low risk**: The stdlib `log` and `charmbracelet/log` both default to stderr output. The only observable difference is the output format (structured vs. unstructured), which is an improvement. No tests assert on the format of these log messages.
+
+**No dependency risk**: `charmbracelet/log` is already in `go.mod` — no new dependencies are introduced.

--- a/openspec/changes/ssa-charmbracelet-log/proposal.md
+++ b/openspec/changes/ssa-charmbracelet-log/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+Four `log.Printf` calls in `internal/analysis/mutation.go` and `internal/quality/pairing.go` use the standard library `log` package instead of `github.com/charmbracelet/log`. This violates convention pack rule CS-008 ("Use `github.com/charmbracelet/log` for all application logging. Do not use the standard library `log` package or bare `fmt.Println` for operational output.").
+
+These calls were introduced in spec 021 (SSA panic recovery) before CS-008 was codified and have persisted since. A similar violation in `internal/loader/loader.go` was already fixed in PR #159.
+
+Closes #174.
+
+## What Changes
+
+Replace all four `log.Printf` calls in SSA recovery paths with `charmbracelet/log` structured logging equivalents. Update the `"log"` import in both files to `"github.com/charmbracelet/log"`.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- SSA panic recovery logging: switches from unstructured `log.Printf` to structured `log.Warn`/`log.Debug` with key-value pairs (`"pkg"`, `"panic"`)
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **`internal/analysis/mutation.go`** (lines 50-51): Two `log.Printf` calls in `BuildSSA` replaced with `log.Warn` and `log.Debug`
+- **`internal/quality/pairing.go`** (lines 136-137): Two `log.Printf` calls in `BuildTestSSA` replaced with `log.Warn` and `log.Debug`
+- Both files change their `"log"` import from stdlib to `"github.com/charmbracelet/log"`
+- No functional behavior change — both packages write to stderr by default
+- `charmbracelet/log` is already a project dependency (no new dependency added)
+
+## Constitution Alignment
+
+Assessed against the Gaze project constitution (v1.3.0).
+
+### I. Accuracy
+
+**Assessment**: N/A
+
+No change to side effect detection or analysis behavior. Logging format is not part of the accuracy contract.
+
+### II. Minimal Assumptions
+
+**Assessment**: N/A
+
+No new assumptions introduced. No new dependencies (`charmbracelet/log` is already in `go.mod`).
+
+### III. Actionable Output
+
+**Assessment**: PASS
+
+Structured logging with key-value pairs (`"pkg"`, `"panic"`) improves machine-parseability of diagnostic output compared to the previous unstructured `Printf` format strings.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+No testable behavior changes. The `safeSSABuild` recovery pattern and its tests are unaffected. Logging output is not asserted in tests.

--- a/openspec/changes/ssa-charmbracelet-log/specs/logging-convention.md
+++ b/openspec/changes/ssa-charmbracelet-log/specs/logging-convention.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+None.
+
+## MODIFIED Requirements
+
+### Requirement: SSA recovery logging uses charmbracelet/log (CS-008 compliance)
+
+All diagnostic logging in SSA panic recovery paths MUST use `github.com/charmbracelet/log` structured logging functions. The standard library `log` package MUST NOT be imported in `internal/analysis/mutation.go` or `internal/quality/pairing.go`.
+
+Previously: SSA recovery paths used `log.Printf` from the standard library `log` package with level prefixes embedded in format strings (e.g., `"warning: ..."`, `"debug: ..."`).
+
+#### Scenario: SSA build panics in analysis package
+
+- **GIVEN** a Go package with types that trigger an SSA builder panic
+- **WHEN** `BuildSSA` is called for that package
+- **THEN** a warning-level structured log entry MUST be emitted with key `"pkg"` containing the package path
+- **AND** a debug-level structured log entry MUST be emitted with keys `"pkg"` and `"panic"` containing the package path and recovered panic value
+- **AND** the function MUST return nil (existing behavior, unchanged)
+
+#### Scenario: SSA build panics in quality package
+
+- **GIVEN** a Go test package with types that trigger an SSA builder panic
+- **WHEN** `BuildTestSSA` is called for that package
+- **THEN** a warning-level structured log entry MUST be emitted with key `"pkg"` containing the package path
+- **AND** a debug-level structured log entry MUST be emitted with keys `"pkg"` and `"panic"` containing the package path and recovered panic value
+- **AND** the function MUST return a non-nil error (existing behavior, unchanged)
+
+#### Scenario: No stdlib log import remains
+
+- **GIVEN** the completed change
+- **WHEN** the import blocks of `internal/analysis/mutation.go` and `internal/quality/pairing.go` are inspected
+- **THEN** neither file MUST contain an import of `"log"` (the standard library log package)
+- **AND** both files MUST import `"github.com/charmbracelet/log"`
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/ssa-charmbracelet-log/tasks.md
+++ b/openspec/changes/ssa-charmbracelet-log/tasks.md
@@ -1,0 +1,26 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Replace stdlib log with charmbracelet/log
+
+- [x] 1.1 [P] In `internal/analysis/mutation.go`: change import from `"log"` to `"github.com/charmbracelet/log"`. Replace `log.Printf("warning: SSA build skipped for %s: internal panic recovered", pkg.PkgPath)` with `log.Warn("SSA build skipped: internal panic recovered", "pkg", pkg.PkgPath)`. Replace `log.Printf("debug: SSA panic value for %s: %v", pkg.PkgPath, r)` with `log.Debug("SSA panic value", "pkg", pkg.PkgPath, "panic", r)`.
+- [x] 1.2 [P] In `internal/quality/pairing.go`: change import from `"log"` to `"github.com/charmbracelet/log"`. Replace `log.Printf("warning: SSA build skipped for %s: internal panic recovered", pkg.PkgPath)` with `log.Warn("SSA build skipped: internal panic recovered", "pkg", pkg.PkgPath)`. Replace `log.Printf("debug: SSA panic value for %s: %v", pkg.PkgPath, r)` with `log.Debug("SSA panic value", "pkg", pkg.PkgPath, "panic", r)`.
+- [x] 1.3 In `internal/analysis/mutation_test.go` line 69: update comment from "the log.Printf calls are co-located" to "the log.Warn/log.Debug calls are co-located" to match the updated call sites.
+
+## 2. Verification
+
+- [x] 2.1 Run `go build ./...` to confirm no compilation errors
+- [x] 2.2 Run `go test -race -count=1 -short ./internal/analysis/... ./internal/quality/...` to confirm existing tests pass
+- [x] 2.3 Run `golangci-lint run ./internal/analysis/... ./internal/quality/...` to confirm no lint violations
+- [x] 2.4 Verify no stdlib `"log"` import remains in `internal/analysis/mutation.go` or `internal/quality/pairing.go` (grep check; note: `testdata/` fixtures legitimately use stdlib `log` as analyzed code — these are not violations)
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Replace 4 stdlib `log.Printf` calls with `charmbracelet/log` structured logging in SSA panic recovery paths, fixing convention pack rule CS-008 compliance.

### Changes

- **`internal/analysis/mutation.go`**: Import swap (`"log"` -> `"github.com/charmbracelet/log"`), replace `log.Printf("warning: ...")` with `log.Warn(...)` and `log.Printf("debug: ...")` with `log.Debug(...)`
- **`internal/quality/pairing.go`**: Same import swap and call replacements
- **`internal/analysis/mutation_test.go`**: Update comment referencing `log.Printf` to `log.Warn/log.Debug`
- **OpenSpec artifacts**: proposal, design, specs, tasks under `openspec/changes/ssa-charmbracelet-log/`

### Context

These `log.Printf` calls were introduced in spec 021 (SSA panic recovery) before CS-008 was codified. A similar fix in `internal/loader/loader.go` was completed in PR #159.

Closes #174