### PR TITLE
chore: fix pre-existing gofmt violations

### DIFF
--- a/internal/adapter/sideeffect.go
+++ b/internal/adapter/sideeffect.go
@@ -225,4 +225,3 @@ func convertAnalysisResults(funcs []protocol.AnalyzedFunction, stderr io.Writer)
 	}
 	return results
 }
-

--- a/internal/taxonomy/types_test.go
+++ b/internal/taxonomy/types_test.go
@@ -384,10 +384,10 @@ func TestErrorSignal_TierBoost(t *testing.T) {
 func TestSideEffect_DetailMarshal(t *testing.T) {
 	t.Run("round-trip", func(t *testing.T) {
 		se := SideEffect{
-			ID:       "se-deadbeef",
-			Type:     GeneratorYield,
-			Tier:     TierP1,
-			Location: "gen.py:42:1",
+			ID:          "se-deadbeef",
+			Type:        GeneratorYield,
+			Tier:        TierP1,
+			Location:    "gen.py:42:1",
 			Description: "yields value",
 			Target:      "int",
 			Detail: map[string]any{


### PR DESCRIPTION
## Summary

Fix two pre-existing `gofmt` formatting violations that cause `golangci-lint` failures on feature branches.

## Changes

| File | Issue | Introduced by |
|------|-------|---------------|
| `internal/adapter/sideeffect.go` | Trailing blank line at EOF | PR #180 (provider-cleanup) |
| `internal/taxonomy/types_test.go` | Misaligned struct field tags in `TestSideEffect_DetailMarshal` | PR #184 (universal-taxonomy) |

## Context

These violations exist on `main` today and are caught by `golangci-lint run` (gofmt linter). They block CI on any feature branch that includes these files in its diff. Discovered during Phase 2a of CRAPload reduction (issue #166).

This follows the same pattern as PR #186 (`chore: fix pre-existing gofmt formatting violations across 9 files`).

## Verification

```bash
golangci-lint run  # 0 issues
```

No behavior changes. Formatting only.