### PR TITLE
refactor: extract shared CLI helpers to `internal/cliutil`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,7 @@ internal/
   analysis/            Core side effect detection engine (AST + SSA)
   taxonomy/            Domain types: SideEffect, AnalysisResult, Tier, etc.
   classify/            Contractual classification engine
+  cliutil/             CLI-layer shared helpers (format validation, JSON capture)
   config/              Configuration file handling (.gaze.yaml)
   loader/              Go package loading (go/packages wrapper)
   report/              Output formatters (JSON, text, HTML stub)

--- a/cmd/gaze/main.go
+++ b/cmd/gaze/main.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -21,6 +20,7 @@ import (
 	"github.com/unbound-force/gaze/internal/aireport"
 	"github.com/unbound-force/gaze/internal/analysis"
 	"github.com/unbound-force/gaze/internal/classify"
+	"github.com/unbound-force/gaze/internal/cliutil"
 	"github.com/unbound-force/gaze/internal/config"
 	"github.com/unbound-force/gaze/internal/crap"
 	"github.com/unbound-force/gaze/internal/docscan"
@@ -207,8 +207,8 @@ func loadConfig(path string, contractualThresh, incidentalThresh int) (*config.G
 
 // runAnalyze is the extracted, testable body of the analyze command.
 func runAnalyze(p analyzeParams) error {
-	if p.format != "text" && p.format != "json" {
-		return fmt.Errorf("invalid format %q: must be 'text' or 'json'", p.format)
+	if err := cliutil.ValidateFormat(p.format); err != nil {
+		return err
 	}
 
 	// Resolve package patterns to concrete package paths.
@@ -265,11 +265,7 @@ func runAnalyze(p analyzeParams) error {
 			FunctionFilter:    p.function,
 			Version:           version,
 		}
-		// Auto-detect package main per package.
-		if !opts.IncludeUnexported && loader.IsMainPkg(pkgPath) {
-			opts.IncludeUnexported = true
-			logger.Info("package main detected, including unexported functions", "pkg", pkgPath)
-		}
+		autoDetectMainPkg(pkgPath, &opts.IncludeUnexported)
 
 		logger.Info("analyzing package", "pkg", pkgPath)
 		results, loadErr := analysis.LoadAndAnalyze(pkgPath, opts)
@@ -495,8 +491,8 @@ validating output or generating client types.`,
 
 // runCrap is the extracted, testable body of the crap command.
 func runCrap(p crapParams) error {
-	if p.format != "text" && p.format != "json" {
-		return fmt.Errorf("invalid format %q: must be 'text' or 'json'", p.format)
+	if err := cliutil.ValidateFormat(p.format); err != nil {
+		return err
 	}
 
 	// External analyzer path: when --analyzer is set, use the
@@ -654,7 +650,7 @@ func initExternalSession(
 	analyzerFlag, languageFlag, moduleDir string,
 	patterns []string, stderr io.Writer,
 ) (*adapter.Session, *adapter.Providers, error) {
-	cfg := loadGazeConfigBestEffort(moduleDir)
+	cfg := config.LoadFromDir(moduleDir)
 	binary, args, err := adapter.Discover(analyzerFlag, languageFlag, cfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("discovering analyzer: %w", err)
@@ -727,7 +723,7 @@ func resolveBaselinePath(flagPath, moduleDir string) (string, bool) {
 	}
 
 	// Config file baseline.file setting (non-default only).
-	cfg := loadGazeConfigBestEffort(moduleDir)
+	cfg := config.LoadFromDir(moduleDir)
 	if cfg.Baseline.File != "" && cfg.Baseline.File != ".gaze/baseline.json" {
 		return resolveConfigBaselinePath(cfg.Baseline.File, moduleDir), false
 	}
@@ -778,7 +774,7 @@ func loadAndCompare(
 		return nil, nil
 	}
 
-	cfg := loadGazeConfigBestEffort(moduleDir)
+	cfg := config.LoadFromDir(moduleDir)
 	opts := crap.CompareOptions{
 		Epsilon:                      cfg.Baseline.Epsilon,
 		NewFunctionThreshold:         cfg.Baseline.NewFunctionThreshold,
@@ -797,15 +793,14 @@ func openAndLoadBaseline(path string) (*crap.Report, error) {
 	return crap.LoadBaseline(f)
 }
 
-// loadGazeConfigBestEffort loads the GazeConfig from the given
-// module directory, falling back to default config on any error.
-func loadGazeConfigBestEffort(moduleDir string) *config.GazeConfig {
-	cfgPath := filepath.Join(moduleDir, ".gaze.yaml")
-	cfg, err := config.Load(cfgPath)
-	if err != nil {
-		return config.DefaultConfig()
+// autoDetectMainPkg enables unexported function inclusion when the
+// package path identifies a main package. This avoids requiring users
+// to pass --include-unexported explicitly for package main targets.
+func autoDetectMainPkg(pkgPath string, includeUnexported *bool) {
+	if !*includeUnexported && loader.IsMainPkg(pkgPath) {
+		*includeUnexported = true
+		logger.Info("package main detected, including unexported functions", "pkg", pkgPath)
 	}
-	return cfg
 }
 
 // printCISummary prints a one-line CI summary to stderr when
@@ -1054,8 +1049,8 @@ type qualityParams struct {
 
 // runQuality is the extracted, testable body of the quality command.
 func runQuality(p qualityParams) error {
-	if p.format != "text" && p.format != "json" {
-		return fmt.Errorf("invalid format %q: must be 'text' or 'json'", p.format)
+	if err := cliutil.ValidateFormat(p.format); err != nil {
+		return err
 	}
 
 	// External analyzer path: quality requires Go-specific test
@@ -1122,11 +1117,7 @@ func runQuality(p qualityParams) error {
 			Version:           version,
 		}
 
-		// Auto-detect package main per package.
-		if !opts.IncludeUnexported && loader.IsMainPkg(pkgPath) {
-			opts.IncludeUnexported = true
-			logger.Info("package main detected, including unexported functions", "pkg", pkgPath)
-		}
+		autoDetectMainPkg(pkgPath, &opts.IncludeUnexported)
 
 		logger.Info("analyzing package", "pkg", pkgPath)
 		results, loadErr := analysis.LoadAndAnalyze(pkgPath, opts)
@@ -1490,8 +1481,8 @@ type selfCheckParams struct {
 // quality pipeline. This serves as both a dogfooding exercise and
 // a code quality gate.
 func runSelfCheck(p selfCheckParams) error {
-	if p.format != "text" && p.format != "json" {
-		return fmt.Errorf("invalid format %q: must be 'text' or 'json'", p.format)
+	if err := cliutil.ValidateFormat(p.format); err != nil {
+		return err
 	}
 
 	findRoot := p.moduleRootFunc
@@ -1705,7 +1696,7 @@ func runReport(p reportParams) error {
 			MaxGazeCrapload:     p.maxGazeCrapload,
 			MinContractCoverage: p.minContractCoverage,
 		},
-		TestShort:    p.testShort,
+		TestShort: p.testShort,
 	}
 
 	// External analyzer path: when --analyzer is set, override the
@@ -1769,7 +1760,7 @@ func runExternalReportCRAP(pats []string, modDir string, providers *adapter.Prov
 		return nil, fmt.Errorf("CRAP analysis with external analyzer: %w", err)
 	}
 
-	crapJSON, err := captureReportJSON(func(w io.Writer) error {
+	crapJSON, err := cliutil.CaptureJSON(func(w io.Writer) error {
 		return crap.WriteJSON(w, rpt)
 	})
 	if err != nil {
@@ -1787,16 +1778,6 @@ func runExternalReportCRAP(pats []string, modDir string, providers *adapter.Prov
 	payload.Errors.Docscan = &skipped
 
 	return payload, nil
-}
-
-// captureReportJSON runs fn writing JSON to a buffer and returns the bytes.
-// This is a local helper matching the pattern in aireport.captureJSON.
-func captureReportJSON(fn func(w io.Writer) error) (json.RawMessage, error) {
-	var buf bytes.Buffer
-	if err := fn(&buf); err != nil {
-		return nil, err
-	}
-	return json.RawMessage(buf.Bytes()), nil
 }
 
 // newReportCmd creates the "report" subcommand that orchestrates gaze's four

--- a/cmd/gaze/main_test.go
+++ b/cmd/gaze/main_test.go
@@ -2762,3 +2762,34 @@ func TestReportCmd_TestShortFlag(t *testing.T) {
 		t.Errorf("expected default value 'false', got %q", f.DefValue)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// autoDetectMainPkg tests
+// ---------------------------------------------------------------------------
+
+func TestAutoDetectMainPkg_MainPackage(t *testing.T) {
+	// "." resolves to cmd/gaze (package main) when tests run from this directory.
+	enabled := false
+	autoDetectMainPkg(".", &enabled)
+	if !enabled {
+		t.Error("autoDetectMainPkg did not enable includeUnexported for main package")
+	}
+}
+
+func TestAutoDetectMainPkg_LibraryPackage(t *testing.T) {
+	// A library package path — should leave includeUnexported unchanged.
+	enabled := false
+	autoDetectMainPkg("github.com/unbound-force/gaze/internal/cliutil", &enabled)
+	if enabled {
+		t.Error("autoDetectMainPkg incorrectly enabled includeUnexported for library package")
+	}
+}
+
+func TestAutoDetectMainPkg_AlreadyEnabled(t *testing.T) {
+	// When includeUnexported is already true, autoDetectMainPkg is a no-op.
+	enabled := true
+	autoDetectMainPkg(".", &enabled)
+	if !enabled {
+		t.Error("autoDetectMainPkg unexpectedly disabled includeUnexported")
+	}
+}

--- a/internal/aireport/runner.go
+++ b/internal/aireport/runner.go
@@ -337,12 +337,3 @@ func runProductionPipeline(patterns []string, moduleDir string, coverProfile str
 
 	return payload, nil
 }
-
-// captureJSON runs fn writing JSON to a buffer and returns the bytes.
-func captureJSON(fn func(w io.Writer) error) (json.RawMessage, error) {
-	var buf bytes.Buffer
-	if err := fn(&buf); err != nil {
-		return nil, err
-	}
-	return json.RawMessage(buf.Bytes()), nil
-}

--- a/internal/aireport/runner_steps.go
+++ b/internal/aireport/runner_steps.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/unbound-force/gaze/internal/analysis"
 	"github.com/unbound-force/gaze/internal/classify"
+	"github.com/unbound-force/gaze/internal/cliutil"
 	"github.com/unbound-force/gaze/internal/config"
 	"github.com/unbound-force/gaze/internal/crap"
 	"github.com/unbound-force/gaze/internal/docscan"
@@ -117,7 +118,7 @@ func runCRAPStep(patterns []string, moduleDir string, coverProfile string, stder
 		return nil, fmt.Errorf("CRAP analysis: %w", err)
 	}
 
-	raw, err := captureJSON(func(w io.Writer) error {
+	raw, err := cliutil.CaptureJSON(func(w io.Writer) error {
 		return crap.WriteJSON(w, rpt)
 	})
 	if err != nil {
@@ -176,7 +177,7 @@ func runQualityStep(patterns []string, moduleDir string, stderr io.Writer, deps 
 		summary.SSADegraded = true
 		summary.SSADegradedPackages = degradedPkgs
 	}
-	raw, err := captureJSON(func(w io.Writer) error {
+	raw, err := cliutil.CaptureJSON(func(w io.Writer) error {
 		return quality.WriteJSON(w, allReports, summary)
 	})
 	if err != nil {
@@ -282,7 +283,7 @@ func runClassifyStep(patterns []string, moduleDir string, deps ...qualityPipelin
 		allResults = append(allResults, classified...)
 	}
 
-	raw, err := captureJSON(func(w io.Writer) error {
+	raw, err := cliutil.CaptureJSON(func(w io.Writer) error {
 		return report.WriteJSON(w, allResults, "")
 	})
 	if err != nil {
@@ -307,7 +308,7 @@ func runDocscanStep(moduleDir string) (json.RawMessage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("docscan: %w", err)
 	}
-	return captureJSON(func(w io.Writer) error {
+	return cliutil.CaptureJSON(func(w io.Writer) error {
 		enc := json.NewEncoder(w)
 		return enc.Encode(docs)
 	})

--- a/internal/aireport/runner_test.go
+++ b/internal/aireport/runner_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io"
 	"os"
 	"strings"
 	"testing"
@@ -410,30 +409,6 @@ func TestErrString_NonNilError(t *testing.T) {
 	}
 	if *s != "test error" {
 		t.Errorf("expected %q, got %q", "test error", *s)
-	}
-}
-
-// TestCaptureJSON_Success verifies captureJSON captures JSON output from a func.
-func TestCaptureJSON_Success(t *testing.T) {
-	raw, err := captureJSON(func(w io.Writer) error {
-		_, err := w.Write([]byte(`{"key":"value"}`))
-		return err
-	})
-	if err != nil {
-		t.Fatalf("captureJSON: %v", err)
-	}
-	if string(raw) != `{"key":"value"}` {
-		t.Errorf("expected %q, got %q", `{"key":"value"}`, string(raw))
-	}
-}
-
-// TestCaptureJSON_FuncError verifies captureJSON propagates errors from fn.
-func TestCaptureJSON_FuncError(t *testing.T) {
-	_, err := captureJSON(func(_ io.Writer) error {
-		return errors.New("write failed")
-	})
-	if err == nil {
-		t.Fatal("expected error from captureJSON")
 	}
 }
 

--- a/internal/cliutil/cliutil.go
+++ b/internal/cliutil/cliutil.go
@@ -1,0 +1,33 @@
+// Package cliutil provides shared helper functions used across
+// multiple CLI subcommands in cmd/gaze and the report pipeline
+// in internal/aireport. These helpers eliminate duplication of
+// common patterns such as format validation and JSON capture.
+package cliutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// ValidateFormat checks that format is one of the supported output
+// formats ("text" or "json"). Returns nil if valid, or a descriptive
+// error containing the invalid value.
+func ValidateFormat(format string) error {
+	if format != "text" && format != "json" {
+		return fmt.Errorf("invalid format %q: must be 'text' or 'json'", format)
+	}
+	return nil
+}
+
+// CaptureJSON calls fn with a buffer as the writer, then returns the
+// buffer contents as a json.RawMessage. If fn returns an error, it is
+// propagated and the message is nil.
+func CaptureJSON(fn func(w io.Writer) error) (json.RawMessage, error) {
+	var buf bytes.Buffer
+	if err := fn(&buf); err != nil {
+		return nil, err
+	}
+	return json.RawMessage(buf.Bytes()), nil
+}

--- a/internal/cliutil/cliutil_test.go
+++ b/internal/cliutil/cliutil_test.go
@@ -1,0 +1,99 @@
+package cliutil
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestValidateFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		wantErr bool
+		errSub  string // substring expected in error message
+	}{
+		{name: "valid text", format: "text", wantErr: false},
+		{name: "valid json", format: "json", wantErr: false},
+		{name: "invalid csv", format: "csv", wantErr: true, errSub: `"csv"`},
+		{name: "empty string", format: "", wantErr: true, errSub: `""`},
+		{name: "error message format", format: "xml", wantErr: true, errSub: "must be 'text' or 'json'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFormat(tt.format)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateFormat(%q) = nil, want error", tt.format)
+				}
+				if tt.errSub != "" && !strings.Contains(err.Error(), tt.errSub) {
+					t.Errorf("error %q does not contain %q", err, tt.errSub)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("ValidateFormat(%q) = %v, want nil", tt.format, err)
+				}
+			}
+		})
+	}
+}
+
+func TestCaptureJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		fn      func(w io.Writer) error
+		wantNil bool
+		wantStr string
+		wantErr bool
+	}{
+		{
+			name: "success path",
+			fn: func(w io.Writer) error {
+				_, err := fmt.Fprint(w, `{"key":"value"}`)
+				return err
+			},
+			wantStr: `{"key":"value"}`,
+		},
+		{
+			name: "error propagation",
+			fn: func(_ io.Writer) error {
+				return fmt.Errorf("write failed")
+			},
+			wantNil: true,
+			wantErr: true,
+		},
+		{
+			name: "empty output",
+			fn: func(_ io.Writer) error {
+				return nil
+			},
+			wantStr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CaptureJSON(tt.fn)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("CaptureJSON() = nil error, want error")
+				}
+				if got != nil {
+					t.Fatalf("CaptureJSON() returned non-nil message on error: %s", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CaptureJSON() error = %v, want nil", err)
+			}
+			if tt.wantNil && got != nil {
+				t.Fatalf("CaptureJSON() = %s, want nil", got)
+			}
+			if !tt.wantNil && string(got) != tt.wantStr {
+				t.Errorf("CaptureJSON() = %q, want %q", string(got), tt.wantStr)
+			}
+		})
+	}
+}

--- a/internal/cliutil/cliutil_test.go
+++ b/internal/cliutil/cliutil_test.go
@@ -1,6 +1,7 @@
 package cliutil
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -40,6 +41,8 @@ func TestValidateFormat(t *testing.T) {
 	}
 }
 
+var errSentinel = errors.New("sentinel error")
+
 func TestCaptureJSON(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -57,19 +60,19 @@ func TestCaptureJSON(t *testing.T) {
 			wantStr: `{"key":"value"}`,
 		},
 		{
-			name: "error propagation",
+			name: "error propagation preserves identity",
 			fn: func(_ io.Writer) error {
-				return fmt.Errorf("write failed")
+				return errSentinel
 			},
 			wantNil: true,
 			wantErr: true,
 		},
 		{
-			name: "empty output",
+			name: "empty output returns nil message",
 			fn: func(_ io.Writer) error {
 				return nil
 			},
-			wantStr: "",
+			wantNil: true,
 		},
 	}
 
@@ -79,6 +82,9 @@ func TestCaptureJSON(t *testing.T) {
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("CaptureJSON() = nil error, want error")
+				}
+				if !errors.Is(err, errSentinel) {
+					t.Errorf("CaptureJSON() error = %v, want %v (identity preserved)", err, errSentinel)
 				}
 				if got != nil {
 					t.Fatalf("CaptureJSON() returned non-nil message on error: %s", got)
@@ -91,8 +97,16 @@ func TestCaptureJSON(t *testing.T) {
 			if tt.wantNil && got != nil {
 				t.Fatalf("CaptureJSON() = %s, want nil", got)
 			}
-			if !tt.wantNil && string(got) != tt.wantStr {
-				t.Errorf("CaptureJSON() = %q, want %q", string(got), tt.wantStr)
+			if !tt.wantNil {
+				if got == nil {
+					t.Fatal("CaptureJSON() = nil, want non-nil json.RawMessage")
+				}
+				if string(got) != tt.wantStr {
+					t.Errorf("CaptureJSON() = %q, want %q", string(got), tt.wantStr)
+				}
+				if tt.wantStr == "" && len(got) != 0 {
+					t.Errorf("CaptureJSON() len = %d, want 0 for empty output", len(got))
+				}
 			}
 		})
 	}

--- a/openspec/changes/extract-cli-helpers/.openspec.yaml
+++ b/openspec/changes/extract-cli-helpers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-05

--- a/openspec/changes/extract-cli-helpers/design.md
+++ b/openspec/changes/extract-cli-helpers/design.md
@@ -1,0 +1,102 @@
+## Context
+
+`cmd/gaze/main.go` (1,953 lines) contains four duplicated patterns
+confirmed during triage of GitHub issue #199:
+
+1. Format validation if-statement — 4 identical copies
+2. JSON capture function — exact clone across `cmd/gaze` and `internal/aireport`
+3. Main-package auto-detect block — 2 identical 3-line blocks
+4. `loadGazeConfigBestEffort` — local copy that duplicates `config.LoadFromDir`
+
+All four are pure structural duplication with no semantic variation between
+occurrences. The refactor is safe to execute mechanically.
+
+## Goals / Non-Goals
+
+### Goals
+- Create `internal/cliutil` package with `ValidateFormat` and `CaptureJSON`
+- Remove `captureReportJSON` from `cmd/gaze/main.go`
+- Remove `captureJSON` from `internal/aireport/runner.go`
+- Remove `loadGazeConfigBestEffort` from `cmd/gaze/main.go`; replace 3
+  call sites with `config.LoadFromDir`
+- Extract `autoDetectMainPkg` as a private helper within `cmd/gaze/main.go`
+- All existing tests pass without modification
+- No behaviour changes
+
+### Non-Goals
+- Module root discovery consolidation (contextual, low ROI)
+- Format dispatch switch consolidation (not duplication — each handles
+  different types)
+- Any new features or flag changes
+- Changes to test fixtures or JSON schema
+
+## Decisions
+
+### D1: `internal/cliutil` for shared utilities
+
+`ValidateFormat` and `CaptureJSON` are placed in a new `internal/cliutil`
+package rather than `internal/report`. `internal/report` owns output
+formatters; a generic I/O capture helper and format validator are a
+different concern. `cliutil` is honest about what it contains and can
+absorb future CLI-layer utilities without stretching an existing package's
+cohesion. See proposal for full tradeoff analysis.
+
+**Package API:**
+```go
+package cliutil
+
+// ValidateFormat returns an error if format is not "text" or "json".
+func ValidateFormat(format string) error
+
+// CaptureJSON executes fn into a buffer and returns the result as
+// json.RawMessage. Returns an error if fn fails.
+func CaptureJSON(fn func(w io.Writer) error) (json.RawMessage, error)
+```
+
+### D2: `autoDetectMainPkg` stays private in `cmd/gaze`
+
+The auto-detect block imports `internal/loader` (for `IsMainPkg`) and
+calls the package-level logger. Placing it in `cliutil` would require
+`cliutil` to import `internal/loader` and the logger, making it less pure.
+Since only 2 call sites exist (both in `cmd/gaze`), a private helper in
+`cmd/gaze/main.go` is the right scope.
+
+**Helper signature:**
+```go
+func autoDetectMainPkg(pkgPath string, includeUnexported *bool)
+```
+
+### D3: `loadGazeConfigBestEffort` replaced by `config.LoadFromDir`
+
+`config.LoadFromDir` already exists and is semantically identical.
+`internal/aireport/runner_steps.go` and `internal/provider/goprovider/contract.go`
+already use it. The local copy in `cmd/gaze/main.go` is deleted; its 3 call
+sites call `config.LoadFromDir` directly. No wrapper needed.
+
+### D4: `captureJSON` deleted from `internal/aireport/runner.go`
+
+The function is an internal implementation detail with no callers outside
+`runner.go`. After migrating the one call site to `cliutil.CaptureJSON`,
+the local copy is deleted. The `cmd/gaze` copy (`captureReportJSON`) is
+also deleted and its call site updated.
+
+### D5: Test coverage for `internal/cliutil`
+
+`ValidateFormat` and `CaptureJSON` are pure functions with no external
+dependencies. Unit tests in `internal/cliutil/cliutil_test.go` cover:
+- `ValidateFormat`: valid inputs ("text", "json"), invalid input, error
+  message format
+- `CaptureJSON`: success path, error propagation, empty output
+
+## Risks / Trade-offs
+
+**Risk**: `internal/aireport` now depends on `internal/cliutil`.
+This is a new dependency edge. Mitigation: `cliutil` has no internal
+imports, so it cannot create a cycle. The dependency graph is acyclic.
+
+**Risk**: A caller of `captureJSON` in `internal/aireport` is missed.
+Mitigation: grep confirms a single call site in `runner.go` before deletion.
+
+**Trade-off**: `autoDetectMainPkg` is not in `cliutil`, so it cannot be
+unit-tested in isolation. Accepted: it is 3 lines, the logic is trivial,
+and the behaviour is covered by existing integration tests.

--- a/openspec/changes/extract-cli-helpers/proposal.md
+++ b/openspec/changes/extract-cli-helpers/proposal.md
@@ -1,0 +1,97 @@
+## Why
+
+`cmd/gaze/main.go` has grown to 1,953 lines and contains four duplicated
+patterns that increase maintenance burden and risk of divergence. These
+patterns were identified during triage of GitHub issue #199. Extracting
+them into shared helpers reduces duplication, improves testability of
+the CLI layer, and makes individual functions easier to read and reason
+about. This is a pure refactor — no behaviour changes.
+
+## What Changes
+
+1. **`validateFormat`** — a new helper in `internal/cliutil` replacing
+   four identical if-statement validations spread across `runAnalyze`,
+   `runCrap`, `runQuality`, and `runSelfCheck`.
+
+2. **`CaptureJSON`** — a new exported function in `internal/cliutil`
+   replacing the exact code clone between `cmd/gaze/main.go:captureReportJSON`
+   (line 1794) and `internal/aireport/runner.go:captureJSON` (line 342).
+   The local copies in both packages are deleted; both import from `cliutil`.
+
+3. **`autoDetectMainPkg`** — a private helper in `cmd/gaze/main.go`
+   replacing two identical 3-line blocks in `runAnalyze` (line 269) and
+   `runQuality` (line 1126). Stays in `cmd/gaze` because it imports
+   `internal/loader` and logs, making it unsuitable for `cliutil`.
+
+4. **`loadGazeConfigBestEffort` removal** — the local copy in
+   `cmd/gaze/main.go` (lines 800–809) is deleted and its 3 call sites
+   (lines 657, 730, 781) are replaced with `config.LoadFromDir`, which
+   already exists and is already used in `internal/aireport/runner_steps.go`
+   and `internal/provider/goprovider/contract.go`.
+
+## Capabilities
+
+### New Capabilities
+- `internal/cliutil.ValidateFormat(format string) error`: validates that a
+  format string is one of `"text"` or `"json"`, returning a formatted error
+  if not.
+- `internal/cliutil.CaptureJSON(fn func(w io.Writer) error) (json.RawMessage, error)`:
+  executes a writer function into a buffer and returns the result as
+  `json.RawMessage`.
+
+### Modified Capabilities
+- `cmd/gaze/main.go` — format validation call sites updated; JSON capture
+  call site updated; main-package auto-detect extracted to private helper;
+  `loadGazeConfigBestEffort` removed.
+- `internal/aireport/runner.go` — `captureJSON` removed; replaced with
+  import of `internal/cliutil.CaptureJSON`.
+
+### Removed Capabilities
+- `cmd/gaze/main.go:captureReportJSON` — deleted; replaced by `cliutil.CaptureJSON`.
+- `cmd/gaze/main.go:loadGazeConfigBestEffort` — deleted; replaced by `config.LoadFromDir`.
+- `internal/aireport/runner.go:captureJSON` — deleted; replaced by `cliutil.CaptureJSON`.
+
+## Impact
+
+- New package: `internal/cliutil` (new file `internal/cliutil/cliutil.go`)
+- Modified: `cmd/gaze/main.go` (4 patterns updated)
+- Modified: `internal/aireport/runner.go` (1 function removed, import added)
+- No changes to public API, JSON output, CLI flags, or test fixtures
+- All existing tests must pass without modification
+
+## Constitution Alignment
+
+Assessed against the Gaze constitution (`.specify/memory/constitution.md`).
+
+### I. Accuracy
+
+**Assessment**: PASS
+
+This change does not alter any analysis logic, detection behaviour, or
+output content. It is a structural refactor of the CLI layer only.
+All observable outputs remain identical.
+
+### II. Minimal Assumptions
+
+**Assessment**: PASS
+
+No new assumptions are introduced. `internal/cliutil` contains only
+pure utility functions with no project-specific behaviour. The format
+validation values (`"text"`, `"json"`) are the same values already
+enforced at every call site.
+
+### III. Actionable Output
+
+**Assessment**: PASS
+
+Output is unchanged. The refactor only affects how validation and
+capture are structured internally — no user-visible output changes.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Extracting `ValidateFormat` and `CaptureJSON` into `internal/cliutil`
+makes them directly unit-testable in isolation. The private
+`autoDetectMainPkg` helper in `cmd/gaze` is small enough to be verified
+through existing integration tests. Coverage ratchets are unaffected.

--- a/openspec/changes/extract-cli-helpers/specs/extract-cli-helpers.md
+++ b/openspec/changes/extract-cli-helpers/specs/extract-cli-helpers.md
@@ -1,0 +1,219 @@
+# Delta Spec: Extract Shared CLI Helpers
+
+## ADDED Requirements
+
+### Requirement: Format Validation Helper
+
+The `internal/cliutil` package MUST export a `ValidateFormat` function
+with signature `func ValidateFormat(format string) error`.
+
+The function MUST return `nil` when `format` is `"text"` or `"json"`.
+
+The function MUST return a non-nil error for any other value. The error
+message MUST include the invalid format value and the list of valid
+options, matching the existing message format:
+`invalid format %q: must be 'text' or 'json'`.
+
+#### Scenario: Valid format accepted
+
+- **GIVEN** a format string of `"text"` or `"json"`
+- **WHEN** `cliutil.ValidateFormat(format)` is called
+- **THEN** the return value MUST be `nil`
+
+#### Scenario: Invalid format rejected
+
+- **GIVEN** a format string that is not `"text"` or `"json"` (e.g., `"csv"`, `""`)
+- **WHEN** `cliutil.ValidateFormat(format)` is called
+- **THEN** the return value MUST be a non-nil error containing the invalid value
+
+---
+
+### Requirement: JSON Capture Helper
+
+The `internal/cliutil` package MUST export a `CaptureJSON` function
+with signature `func CaptureJSON(fn func(w io.Writer) error) (json.RawMessage, error)`.
+
+The function MUST execute `fn` with a `bytes.Buffer` and return the
+buffer contents as `json.RawMessage` on success.
+
+The function MUST propagate any error returned by `fn` without
+modification, returning `nil` for the `json.RawMessage`.
+
+#### Scenario: Successful JSON capture
+
+- **GIVEN** a writer function that writes valid JSON to the provided `io.Writer`
+- **WHEN** `cliutil.CaptureJSON(fn)` is called
+- **THEN** the returned `json.RawMessage` MUST contain the bytes written by `fn`
+- **AND** the returned error MUST be `nil`
+
+#### Scenario: Writer function returns error
+
+- **GIVEN** a writer function that returns a non-nil error
+- **WHEN** `cliutil.CaptureJSON(fn)` is called
+- **THEN** the returned `json.RawMessage` MUST be `nil`
+- **AND** the returned error MUST be the error from `fn`
+
+#### Scenario: Empty output
+
+- **GIVEN** a writer function that writes zero bytes and returns `nil`
+- **WHEN** `cliutil.CaptureJSON(fn)` is called
+- **THEN** the returned `json.RawMessage` MUST be an empty `json.RawMessage`
+- **AND** the returned error MUST be `nil`
+
+---
+
+### Requirement: Unit Tests for cliutil
+
+The `internal/cliutil` package MUST have a `cliutil_test.go` file with
+table-driven tests covering all scenarios listed above.
+
+Tests MUST use the standard library `testing` package only — no
+third-party assertion libraries.
+
+#### Scenario: Full test coverage
+
+- **GIVEN** the `internal/cliutil` package
+- **WHEN** `go test ./internal/cliutil/...` is run
+- **THEN** all tests MUST pass
+- **AND** line coverage SHOULD be 100%
+
+---
+
+### Requirement: Main Package Auto-Detect Helper
+
+`cmd/gaze/main.go` MUST contain a private function `autoDetectMainPkg`
+that encapsulates the main-package detection and `includeUnexported`
+auto-enable logic.
+
+The function MUST call `loader.IsMainPkg(pkgPath)` and, when true, set
+the pointed-to boolean to `true` and log an info message.
+
+The function MUST NOT modify the boolean if `loader.IsMainPkg` returns
+`false`.
+
+The function MUST NOT modify the boolean if it is already `true`
+(guard against redundant logging).
+
+#### Scenario: Main package detected
+
+- **GIVEN** `pkgPath` resolves to a `package main`
+- **AND** the pointed-to boolean is `false`
+- **WHEN** `autoDetectMainPkg(pkgPath, &includeUnexported)` is called
+- **THEN** the pointed-to boolean MUST be set to `true`
+
+#### Scenario: Non-main package
+
+- **GIVEN** `pkgPath` does not resolve to a `package main`
+- **WHEN** `autoDetectMainPkg(pkgPath, &includeUnexported)` is called
+- **THEN** the pointed-to boolean MUST remain unchanged
+
+#### Scenario: Already enabled
+
+- **GIVEN** the pointed-to boolean is already `true`
+- **WHEN** `autoDetectMainPkg(pkgPath, &includeUnexported)` is called
+- **THEN** the function MUST NOT modify the boolean (no-op)
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: Format Validation in CLI Commands
+
+Previously: Each of `runAnalyze`, `runCrap`, `runQuality`, and
+`runSelfCheck` contained an inline if-statement for format validation.
+
+The four inline format validation blocks MUST be replaced with calls to
+`cliutil.ValidateFormat`. The error message format and the set of valid
+values MUST remain identical to the current behaviour.
+
+#### Scenario: Existing commands reject invalid format
+
+- **GIVEN** a user invokes `gaze analyze --format=csv`
+- **WHEN** the command runs
+- **THEN** the error message MUST match the current format:
+  `invalid format "csv": must be 'text' or 'json'`
+
+---
+
+### Requirement: JSON Capture in CLI and Report Pipeline
+
+Previously: `cmd/gaze/main.go` defined `captureReportJSON` and
+`internal/aireport/runner.go` defined `captureJSON` — identical
+implementations under different names.
+
+Both local definitions MUST be removed. All call sites MUST use
+`cliutil.CaptureJSON` instead.
+
+`internal/aireport/runner.go` MUST import `internal/cliutil` and call
+`cliutil.CaptureJSON` where it previously called `captureJSON`.
+
+`cmd/gaze/main.go` MUST import `internal/cliutil` and call
+`cliutil.CaptureJSON` where it previously called `captureReportJSON`.
+
+#### Scenario: Report pipeline JSON capture unchanged
+
+- **GIVEN** a `gaze report` invocation producing JSON output
+- **WHEN** the report pipeline runs
+- **THEN** the JSON output MUST be byte-identical to the pre-refactor output
+
+---
+
+### Requirement: Config Loading in CLI
+
+Previously: `cmd/gaze/main.go` defined `loadGazeConfigBestEffort`
+(lines 800–809), byte-identical to `config.LoadFromDir`.
+
+The local `loadGazeConfigBestEffort` function MUST be deleted. The
+three call sites (in `initExternalSession`, `resolveBaselinePath`,
+`loadAndCompare`) MUST be replaced with `config.LoadFromDir`.
+
+#### Scenario: Config loading behaviour unchanged
+
+- **GIVEN** a `.gaze.yaml` file exists in the module root
+- **WHEN** any of the three call sites executes
+- **THEN** the returned `*config.GazeConfig` MUST be identical to the
+  pre-refactor result
+
+#### Scenario: Missing config file
+
+- **GIVEN** no `.gaze.yaml` file exists
+- **WHEN** any of the three call sites executes
+- **THEN** `config.DefaultConfig()` MUST be returned (no error)
+
+---
+
+### Requirement: Main Package Auto-Detect in CLI Commands
+
+Previously: `runAnalyze` (line 269) and `runQuality` (line 1126)
+contained identical 3-line blocks for main-package auto-detection.
+
+Both inline blocks MUST be replaced with calls to `autoDetectMainPkg`.
+Observable behaviour (logging, flag mutation) MUST remain identical.
+
+#### Scenario: Analyze detects main package
+
+- **GIVEN** `gaze analyze ./cmd/myapp` where `cmd/myapp` is `package main`
+- **WHEN** `runAnalyze` executes
+- **THEN** unexported functions MUST be included in the analysis output
+
+---
+
+## REMOVED Requirements
+
+### Requirement: `captureReportJSON` in `cmd/gaze/main.go`
+
+Removed because it is an exact duplicate of functionality now provided
+by `cliutil.CaptureJSON`. Keeping it would violate DRY and risk
+divergence.
+
+### Requirement: `captureJSON` in `internal/aireport/runner.go`
+
+Removed because it is an exact duplicate of functionality now provided
+by `cliutil.CaptureJSON`. The `internal/aireport` package MUST import
+`internal/cliutil` instead.
+
+### Requirement: `loadGazeConfigBestEffort` in `cmd/gaze/main.go`
+
+Removed because it is byte-identical to `config.LoadFromDir`, which
+already exists and is used by other packages. Keeping a local copy
+serves no purpose.

--- a/openspec/changes/extract-cli-helpers/tasks.md
+++ b/openspec/changes/extract-cli-helpers/tasks.md
@@ -1,0 +1,35 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Create `internal/cliutil` Package
+
+- [x] 1.1 [P] Create `internal/cliutil/cliutil.go` with `ValidateFormat` and `CaptureJSON` — package doc comment, GoDoc on both exported functions, imports only `bytes`, `encoding/json`, `fmt`, `io`
+- [x] 1.2 [P] Create `internal/cliutil/cliutil_test.go` with table-driven tests: `ValidateFormat` (valid "text", valid "json", invalid "csv", empty string, error message format); `CaptureJSON` (success path, error propagation, empty output)
+
+## 2. Migrate `cmd/gaze/main.go`
+
+- [x] 2.1 Replace the 4 inline format validation blocks (lines 210, 498, 1057, 1493) with `cliutil.ValidateFormat(p.format)` calls; add `cliutil` import
+- [x] 2.2 Extract `autoDetectMainPkg(pkgPath string, includeUnexported *bool)` private function; replace the 2 inline blocks (lines 269–271, 1126–1128) with calls to it
+- [x] 2.3 Delete `loadGazeConfigBestEffort` function (lines 800–809); replace 3 call sites (lines 657, 730, 781) with `config.LoadFromDir(moduleDir)`
+- [x] 2.4 Delete `captureReportJSON` function (lines 1794–1800); replace its call site with `cliutil.CaptureJSON`; remove the acknowledging comment at line 1793
+
+## 3. Migrate `internal/aireport/runner.go`
+
+- [x] 3.1 [P] Delete `captureJSON` function (lines 342–348); replace its call site(s) with `cliutil.CaptureJSON`; add `cliutil` import
+
+## 4. Verify
+
+- [x] 4.1 Run `go build ./cmd/gaze` — MUST compile cleanly
+- [x] 4.2 Run `go test -race -count=1 -short ./...` — all tests MUST pass
+- [x] 4.3 Run `golangci-lint run` — no new lint findings
+- [x] 4.4 Verify constitution alignment: no behaviour changes (Principle I), no new assumptions (Principle II), output unchanged (Principle III), new helpers are unit-tested in isolation (Principle IV)
+<!-- spec-review: passed -->


### PR DESCRIPTION
### Summary

Extracts 4 duplicated patterns from `cmd/gaze/main.go` (1,953 lines) and `internal/aireport` into a new `internal/cliutil` package, reducing code duplication without behavioral changes.

Closes #199

### Changes

#### New: `internal/cliutil` package

| Function | Purpose | Replaces |
|----------|---------|----------|
| `ValidateFormat(format string) error` | Validates format is `"text"` or `"json"` | 4 identical inline if-blocks in `runAnalyze`, `runCrap`, `runQuality`, `runSelfCheck` |
| `CaptureJSON(fn func(w io.Writer) error) (json.RawMessage, error)` | Captures fn output as `json.RawMessage` | `captureReportJSON` (cmd/gaze), `captureJSON` (internal/aireport) — identical implementations |

The package imports only stdlib (`bytes`, `encoding/json`, `fmt`, `io`) — a clean leaf dependency with no internal coupling.

#### Modified: `cmd/gaze/main.go`

- 4 inline format validations → `cliutil.ValidateFormat(p.format)`
- 2 inline `IsMainPkg` + `includeUnexported` blocks → private `autoDetectMainPkg` helper
- 3 `loadGazeConfigBestEffort(moduleDir)` calls → `config.LoadFromDir(moduleDir)` (existing function, identical behavior)
- 1 `captureReportJSON` call → `cliutil.CaptureJSON`
- **Deleted**: `loadGazeConfigBestEffort` function (was byte-identical to `config.LoadFromDir`)
- **Deleted**: `captureReportJSON` function + acknowledging comment

#### Modified: `internal/aireport`

- `runner.go`: deleted `captureJSON` function
- `runner_steps.go`: 4 `captureJSON` calls → `cliutil.CaptureJSON`
- `runner_test.go`: removed 2 `captureJSON` tests (superseded by expanded coverage in `cliutil_test.go`)

#### Documentation

- Added `cliutil/` entry to AGENTS.md architecture package list

### Test coverage

- `cliutil_test.go`: 8 table-driven tests
  - `TestValidateFormat`: valid text, valid json, invalid csv, empty string, error message format
  - `TestCaptureJSON`: success path, error identity preservation (sentinel), empty output nil semantics
- `main_test.go`: 3 new `TestAutoDetectMainPkg` tests covering all branches (main package, library package, already-enabled guard)
- Net: +11 test cases, -2 superseded tests = **+9 net new tests**

### Verification

- `go build ./cmd/gaze` — clean
- `go test -race -count=1 -short ./...` — all 17 packages pass
- `golangci-lint run` — 0 issues
- Review council: APPROVE from all 4 members (Adversary, Architect, Guard, Tester)

### Behavioral impact

**None.** Error messages, output formats, and control flow are byte-identical. The `ValidateFormat` error format string (`invalid format %q: must be 'text' or 'json'`) is preserved exactly.

### Stats

13 files changed, 667 insertions(+), 86 deletions(+)

Net production code: -52 lines, 3 deleted functions. Spec artifacts account for the majority of insertions.

### OpenSpec artifacts

- `openspec/changes/extract-cli-helpers/proposal.md`
- `openspec/changes/extract-cli-helpers/design.md`
- `openspec/changes/extract-cli-helpers/specs/extract-cli-helpers.md`
- `openspec/changes/extract-cli-helpers/tasks.md`