### PR TITLE
fix: fail CI gate when analysis step errors and threshold is set

### DIFF
--- a/cmd/gaze/main.go
+++ b/cmd/gaze/main.go
@@ -1811,7 +1811,8 @@ func runExternalReportCRAP(pats []string, modDir string, providers *adapter.Prov
 	}
 
 	payload := &aireport.ReportPayload{CRAP: crapJSON}
-	payload.Summary.CRAPload = rpt.Summary.CRAPload
+	crapload := rpt.Summary.CRAPload
+	payload.Summary.CRAPload = &crapload
 	payload.Summary.GazeCRAPload = rpt.Summary.GazeCRAPload
 	payload.Summary.TotalFunctions = rpt.Summary.TotalFunctions
 

--- a/cmd/gaze/main_test.go
+++ b/cmd/gaze/main_test.go
@@ -2039,8 +2039,9 @@ func TestSC002_ReportStructure(t *testing.T) {
 // with no I/O — its performance is validated by the BenchmarkEvaluateThresholds
 // benchmark in threshold_test.go.
 func TestSC003_ThresholdEvaluation_Correctness(t *testing.T) {
+	intPtr := func(v int) *int { return &v }
 	payload := &aireport.ReportPayload{
-		Summary: aireport.ReportSummary{CRAPload: 3},
+		Summary: aireport.ReportSummary{CRAPload: intPtr(3)},
 	}
 	maxCrapload := 10
 	cfg := aireport.ThresholdConfig{MaxCrapload: &maxCrapload}
@@ -2314,31 +2315,31 @@ func TestRunReport_ThresholdEnforcement(t *testing.T) {
 	}{
 		{
 			name:       "SC1: CRAPload exceeds max → fail",
-			payload:    &aireport.ReportPayload{Summary: aireport.ReportSummary{TotalFunctions: 20, CRAPload: 13}},
+			payload:    &aireport.ReportPayload{Summary: aireport.ReportSummary{TotalFunctions: 20, CRAPload: intPtr(13)}},
 			thresholds: aireport.ThresholdConfig{MaxCrapload: intPtr(10)},
 			expectFail: true,
 		},
 		{
 			name:       "SC2: CRAPload within max → pass",
-			payload:    &aireport.ReportPayload{Summary: aireport.ReportSummary{TotalFunctions: 20, CRAPload: 8}},
+			payload:    &aireport.ReportPayload{Summary: aireport.ReportSummary{TotalFunctions: 20, CRAPload: intPtr(8)}},
 			thresholds: aireport.ThresholdConfig{MaxCrapload: intPtr(10)},
 			expectFail: false,
 		},
 		{
 			name:       "SC3: avg coverage below min → fail",
-			payload:    &aireport.ReportPayload{Summary: aireport.ReportSummary{TotalFunctions: 20, AvgContractCoverage: 40}},
+			payload:    &aireport.ReportPayload{Summary: aireport.ReportSummary{TotalFunctions: 20, AvgContractCoverage: intPtr(40)}},
 			thresholds: aireport.ThresholdConfig{MinContractCoverage: intPtr(60)},
 			expectFail: true,
 		},
 		{
 			name:       "SC4: no thresholds → pass",
-			payload:    &aireport.ReportPayload{Summary: aireport.ReportSummary{TotalFunctions: 20, CRAPload: 999}},
+			payload:    &aireport.ReportPayload{Summary: aireport.ReportSummary{TotalFunctions: 20, CRAPload: intPtr(999)}},
 			thresholds: aireport.ThresholdConfig{},
 			expectFail: false,
 		},
 		{
 			name:       "SC5: max-crapload=0 with positive actual → fail",
-			payload:    &aireport.ReportPayload{Summary: aireport.ReportSummary{TotalFunctions: 20, CRAPload: 1}},
+			payload:    &aireport.ReportPayload{Summary: aireport.ReportSummary{TotalFunctions: 20, CRAPload: intPtr(1)}},
 			thresholds: aireport.ThresholdConfig{MaxCrapload: intPtr(0)},
 			expectFail: true,
 		},

--- a/internal/aireport/compact.go
+++ b/internal/aireport/compact.go
@@ -24,9 +24,9 @@ type compactPayload struct {
 // compactSummary mirrors ReportSummary with JSON tags so it appears in
 // the compact payload output.
 type compactSummary struct {
-	CRAPload            int      `json:"crapload"`
-	GazeCRAPload        *int     `json:"gaze_crapload"`
-	AvgContractCoverage int      `json:"avg_contract_coverage"`
+	CRAPload            *int     `json:"crapload,omitempty"`
+	GazeCRAPload        *int     `json:"gaze_crapload,omitempty"`
+	AvgContractCoverage *int     `json:"avg_contract_coverage,omitempty"`
 	SSADegraded         bool     `json:"ssa_degraded"`
 	SSADegradedPackages []string `json:"ssa_degraded_packages"`
 	Contractual         int      `json:"contractual"`

--- a/internal/aireport/compact_test.go
+++ b/internal/aireport/compact_test.go
@@ -176,9 +176,9 @@ func buildFullPayload(t *testing.T) *ReportPayload {
 
 	return &ReportPayload{
 		Summary: ReportSummary{
-			CRAPload:            1,
+			CRAPload:            intPtr(1),
 			GazeCRAPload:        intPtr(0),
-			AvgContractCoverage: 50,
+			AvgContractCoverage: intPtr(50),
 			SSADegraded:         false,
 			Contractual:         1,
 			Ambiguous:           1,
@@ -928,7 +928,7 @@ func TestCompactForAI_SizeBudget(t *testing.T) {
 	})
 
 	payload := &ReportPayload{
-		Summary:  ReportSummary{CRAPload: 50, GazeCRAPload: intPtr(10), AvgContractCoverage: 50},
+		Summary:  ReportSummary{CRAPload: intPtr(50), GazeCRAPload: intPtr(10), AvgContractCoverage: intPtr(50)},
 		CRAP:     crapJSON,
 		Quality:  qualityJSON,
 		Classify: classifyJSON,

--- a/internal/aireport/payload.go
+++ b/internal/aireport/payload.go
@@ -19,7 +19,8 @@ type ReportSummary struct {
 
 	// CRAPload is the number of functions whose CRAP score meets or exceeds
 	// the configured threshold (from crap.Report.Summary.CRAPload).
-	CRAPload int
+	// Nil means the metric was not computed (e.g., CRAP step failed).
+	CRAPload *int
 
 	// GazeCRAPload is the number of Q4 functions (high complexity, low
 	// coverage) from crap.Report.Summary.GazeCRAPload. Nil means the
@@ -28,7 +29,8 @@ type ReportSummary struct {
 
 	// AvgContractCoverage is the average contract coverage percentage across
 	// all assessed packages (from quality.Summary.AvgContractCoverage).
-	AvgContractCoverage int
+	// Nil means the metric was not computed (e.g., quality step failed).
+	AvgContractCoverage *int
 
 	// SSADegraded is true when SSA construction failed for one or
 	// more packages and quality results are partial.

--- a/internal/aireport/payload_test.go
+++ b/internal/aireport/payload_test.go
@@ -16,7 +16,7 @@ func TestReportPayload_JSONRoundTrip(t *testing.T) {
 	docscanMsg := json.RawMessage(`[{"path":"README.md","content":"x","priority":2}]`)
 
 	original := &ReportPayload{
-		Summary:  ReportSummary{CRAPload: 3, GazeCRAPload: intPtr(1), AvgContractCoverage: 75},
+		Summary:  ReportSummary{CRAPload: intPtr(3), GazeCRAPload: intPtr(1), AvgContractCoverage: intPtr(75)},
 		CRAP:     crapMsg,
 		Quality:  qualityMsg,
 		Classify: classifyMsg,
@@ -58,8 +58,8 @@ func TestReportPayload_JSONRoundTrip(t *testing.T) {
 	}
 
 	// Summary is not serialised (json:"-"), so decoded.Summary should be zero.
-	if decoded.Summary.CRAPload != 0 || decoded.Summary.GazeCRAPload != nil ||
-		decoded.Summary.AvgContractCoverage != 0 || decoded.Summary.SSADegraded ||
+	if decoded.Summary.CRAPload != nil || decoded.Summary.GazeCRAPload != nil ||
+		decoded.Summary.AvgContractCoverage != nil || decoded.Summary.SSADegraded ||
 		len(decoded.Summary.SSADegradedPackages) != 0 ||
 		decoded.Summary.Contractual != 0 || decoded.Summary.Ambiguous != 0 ||
 		decoded.Summary.Incidental != 0 {
@@ -152,7 +152,7 @@ func TestPayloadErrors_NullVsNonNull(t *testing.T) {
 // from JSON output via the json:"-" tag.
 func TestReportSummary_NotSerialised(t *testing.T) {
 	p := &ReportPayload{
-		Summary: ReportSummary{CRAPload: 99, GazeCRAPload: intPtr(42), AvgContractCoverage: 55},
+		Summary: ReportSummary{CRAPload: intPtr(99), GazeCRAPload: intPtr(42), AvgContractCoverage: intPtr(55)},
 	}
 	data, err := json.Marshal(p)
 	if err != nil {

--- a/internal/aireport/pipeline_internal_test.go
+++ b/internal/aireport/pipeline_internal_test.go
@@ -17,7 +17,7 @@ func fakeSteps() pipelineStepFuncs {
 		crapStep: func(_ []string, _ string, _ string, _ io.Writer, _ crap.ContractCoverageProvider, _ bool) (*crapStepResult, error) {
 			return &crapStepResult{
 				JSON:           json.RawMessage(`{"crap":"ok"}`),
-				CRAPload:       5,
+				CRAPload:       intPtr(5),
 				GazeCRAPload:   intPtr(3),
 				TotalFunctions: 20,
 			}, nil
@@ -25,7 +25,7 @@ func fakeSteps() pipelineStepFuncs {
 		qualityStep: func(_ []string, _ string, _ io.Writer, _ ...qualityPipelineDeps) (*qualityStepResult, error) {
 			return &qualityStepResult{
 				JSON:                json.RawMessage(`{"quality":"ok"}`),
-				AvgContractCoverage: 85,
+				AvgContractCoverage: intPtr(85),
 			}, nil
 		},
 		classifyStep: func(_ []string, _ string, _ ...qualityPipelineDeps) (*classifyStepResult, error) {
@@ -105,7 +105,7 @@ func TestRunProductionPipeline_CRAPStepSSADegradation(t *testing.T) {
 	steps.crapStep = func(_ []string, _ string, _ string, _ io.Writer, _ crap.ContractCoverageProvider, _ bool) (*crapStepResult, error) {
 		return &crapStepResult{
 			JSON:                json.RawMessage(`{"crap":"ok"}`),
-			CRAPload:            5,
+			CRAPload:            intPtr(5),
 			GazeCRAPload:        intPtr(3),
 			TotalFunctions:      20,
 			SSADegradedPackages: []string{"pkg/degraded-from-crap"},
@@ -306,7 +306,7 @@ func TestRunProductionPipeline_GazeCRAPloadFlowsThroughPipeline(t *testing.T) {
 	steps.crapStep = func(_ []string, _ string, _ string, _ io.Writer, _ crap.ContractCoverageProvider, _ bool) (*crapStepResult, error) {
 		return &crapStepResult{
 			JSON:           json.RawMessage(`{"crap":"ok"}`),
-			CRAPload:       2,
+			CRAPload:       intPtr(2),
 			GazeCRAPload:   intPtr(7),
 			TotalFunctions: 15,
 		}, nil
@@ -331,14 +331,45 @@ func TestRunProductionPipeline_SummaryFields(t *testing.T) {
 		t.Fatalf("expected nil error, got: %v", err)
 	}
 
-	if payload.Summary.CRAPload != 5 {
-		t.Errorf("expected CRAPload 5, got %d", payload.Summary.CRAPload)
+	if payload.Summary.CRAPload == nil || *payload.Summary.CRAPload != 5 {
+		t.Errorf("expected CRAPload 5, got %v", payload.Summary.CRAPload)
 	}
 	if payload.Summary.GazeCRAPload == nil || *payload.Summary.GazeCRAPload != 3 {
 		t.Errorf("expected GazeCRAPload 3, got %v", payload.Summary.GazeCRAPload)
 	}
-	if payload.Summary.AvgContractCoverage != 85 {
-		t.Errorf("expected AvgContractCoverage 85, got %d", payload.Summary.AvgContractCoverage)
+	if payload.Summary.AvgContractCoverage == nil || *payload.Summary.AvgContractCoverage != 85 {
+		t.Errorf("expected AvgContractCoverage 85, got %v", payload.Summary.AvgContractCoverage)
+	}
+}
+
+// TestRunProductionPipeline_CRAPStepFails_CRAPloadIsNil verifies that when
+// the CRAP step fails, payload.Summary.CRAPload is nil (not zero). This is
+// the pipeline-level regression test for #102: the *int type ensures that
+// a failed step produces nil (unavailable) rather than the Go int zero value 0,
+// which would silently pass threshold checks.
+func TestRunProductionPipeline_CRAPStepFails_CRAPloadIsNil(t *testing.T) {
+	var stderr bytes.Buffer
+	steps := fakeSteps()
+	steps.crapStep = func(_ []string, _ string, _ string, _ io.Writer, _ crap.ContractCoverageProvider, _ bool) (*crapStepResult, error) {
+		return nil, fmt.Errorf("crap analysis failed")
+	}
+
+	payload, err := runProductionPipeline([]string{"./..."}, "/tmp", "", false, &stderr, steps)
+	if err != nil {
+		t.Fatalf("pipeline should not return error on step failure, got: %v", err)
+	}
+
+	// CRAPload must be nil (unavailable), not zero.
+	if payload.Summary.CRAPload != nil {
+		t.Errorf("expected CRAPload=nil when CRAP step failed, got %d", *payload.Summary.CRAPload)
+	}
+	// GazeCRAPload must also be nil (same step).
+	if payload.Summary.GazeCRAPload != nil {
+		t.Errorf("expected GazeCRAPload=nil when CRAP step failed, got %d", *payload.Summary.GazeCRAPload)
+	}
+	// AvgContractCoverage should be populated (quality step succeeded).
+	if payload.Summary.AvgContractCoverage == nil {
+		t.Error("expected AvgContractCoverage to be populated (quality step succeeded)")
 	}
 }
 
@@ -356,7 +387,7 @@ func TestRunProductionPipeline_TestShortThreadsToStep(t *testing.T) {
 		capturedShort = short
 		return &crapStepResult{
 			JSON:           json.RawMessage(`{"crap":"ok"}`),
-			CRAPload:       1,
+			CRAPload:       intPtr(1),
 			GazeCRAPload:   intPtr(0),
 			TotalFunctions: 5,
 		}, nil

--- a/internal/aireport/runner_steps.go
+++ b/internal/aireport/runner_steps.go
@@ -84,7 +84,7 @@ func resolveQualityDeps(deps []qualityPipelineDeps) qualityPipelineDeps {
 // crapStepResult holds the outputs of runCRAPStep.
 type crapStepResult struct {
 	JSON                json.RawMessage
-	CRAPload            int
+	CRAPload            *int
 	GazeCRAPload        *int
 	TotalFunctions      int
 	SSADegradedPackages []string
@@ -127,7 +127,7 @@ func runCRAPStep(patterns []string, moduleDir string, coverProfile string, stder
 
 	res := &crapStepResult{
 		JSON:                raw,
-		CRAPload:            rpt.Summary.CRAPload,
+		CRAPload:            intPtr(rpt.Summary.CRAPload),
 		GazeCRAPload:        rpt.Summary.GazeCRAPload,
 		TotalFunctions:      rpt.Summary.TotalFunctions,
 		SSADegradedPackages: rpt.Summary.SSADegradedPackages,
@@ -138,7 +138,7 @@ func runCRAPStep(patterns []string, moduleDir string, coverProfile string, stder
 // qualityStepResult holds the outputs of runQualityStep.
 type qualityStepResult struct {
 	JSON                json.RawMessage
-	AvgContractCoverage int
+	AvgContractCoverage *int
 	SSADegraded         bool
 	SSADegradedPackages []string
 	SkippedTests        int
@@ -201,7 +201,7 @@ func runQualityStep(patterns []string, moduleDir string, stderr io.Writer, deps 
 	}
 	return &qualityStepResult{
 		JSON:                raw,
-		AvgContractCoverage: avgCov,
+		AvgContractCoverage: intPtr(avgCov),
 		SSADegraded:         len(degradedPkgs) > 0,
 		SSADegradedPackages: degradedPkgs,
 		SkippedTests:        totalSkipped,

--- a/internal/aireport/runner_steps_test.go
+++ b/internal/aireport/runner_steps_test.go
@@ -365,8 +365,8 @@ func TestRunQualityStep_DI_MultiplePackages(t *testing.T) {
 	}
 	// AvgContractCoverage should be computed from 2 reports.
 	// Both fake reports return 80% coverage, so the average should be 80.
-	if result.AvgContractCoverage != 80 {
-		t.Errorf("expected AvgContractCoverage=80, got %d", result.AvgContractCoverage)
+	if result.AvgContractCoverage == nil || *result.AvgContractCoverage != 80 {
+		t.Errorf("expected AvgContractCoverage=80, got %v", result.AvgContractCoverage)
 	}
 }
 

--- a/internal/aireport/runner_test.go
+++ b/internal/aireport/runner_test.go
@@ -21,7 +21,7 @@ func fakeAnalyze(payload *ReportPayload, err error) func([]string, string) (*Rep
 func TestRun_JSONFormat_WritesValidPayload(t *testing.T) {
 	crapMsg := json.RawMessage(`{"scores":[],"summary":{"crapload":2}}`)
 	payload := &ReportPayload{
-		Summary: ReportSummary{CRAPload: 2},
+		Summary: ReportSummary{CRAPload: intPtr(2)},
 		CRAP:    crapMsg,
 		Errors:  PayloadErrors{},
 	}
@@ -345,7 +345,7 @@ func TestRun_TextFormat_NilAdapter_ReturnsError(t *testing.T) {
 func TestRun_ThresholdFailure_ReturnsError(t *testing.T) {
 	maxCrapload := 5
 	payload := &ReportPayload{
-		Summary: ReportSummary{TotalFunctions: 20, CRAPload: 10},
+		Summary: ReportSummary{TotalFunctions: 20, CRAPload: intPtr(10)},
 	}
 
 	var stderr bytes.Buffer
@@ -372,7 +372,7 @@ func TestRun_ThresholdFailure_ReturnsError(t *testing.T) {
 func TestRun_ThresholdPass_ReturnsNil(t *testing.T) {
 	maxCrapload := 20
 	payload := &ReportPayload{
-		Summary: ReportSummary{TotalFunctions: 20, CRAPload: 5},
+		Summary: ReportSummary{TotalFunctions: 20, CRAPload: intPtr(5)},
 	}
 
 	var stderr bytes.Buffer
@@ -423,7 +423,8 @@ func TestRun_ZeroResults_ThresholdSet_ReturnsError(t *testing.T) {
 	maxCrapload := 5
 	payload := &ReportPayload{
 		// Zero results: TotalFunctions=0, no CRAP error.
-		Summary: ReportSummary{TotalFunctions: 0, CRAPload: 0, GazeCRAPload: nil},
+		// CRAPload is intPtr(0) because the step succeeded but found no functions.
+		Summary: ReportSummary{TotalFunctions: 0, CRAPload: intPtr(0), GazeCRAPload: nil},
 		Errors:  PayloadErrors{},
 	}
 
@@ -451,7 +452,7 @@ func TestRun_ZeroResults_ThresholdSet_ReturnsError(t *testing.T) {
 // Run returns nil (no error).
 func TestRun_ZeroResults_NoThreshold_ReturnsNil(t *testing.T) {
 	payload := &ReportPayload{
-		Summary: ReportSummary{TotalFunctions: 0, CRAPload: 0, GazeCRAPload: nil},
+		Summary: ReportSummary{TotalFunctions: 0, CRAPload: intPtr(0), GazeCRAPload: nil},
 		Errors:  PayloadErrors{},
 	}
 
@@ -468,14 +469,20 @@ func TestRun_ZeroResults_NoThreshold_ReturnsNil(t *testing.T) {
 	}
 }
 
-// TestRun_ZeroResults_CRAPStepFailed_NoGate verifies that the zero-result
-// gate does NOT fire when the CRAP step itself failed (the error is already
-// captured in PayloadErrors.CRAP).
-func TestRun_ZeroResults_CRAPStepFailed_NoGate(t *testing.T) {
+// TestRun_CRAPStepFailed_ThresholdSet_ReturnsError verifies that when the
+// CRAP step fails and a CRAPload threshold is configured, Run returns a
+// non-nil error because the CRAPload metric is unavailable (nil). This is
+// the fix for #102: CI gates must not silently pass when data is missing.
+//
+// Previously this test (named TestRun_ZeroResults_CRAPStepFailed_NoGate)
+// asserted err == nil, which enshrined the bug as correct behavior.
+func TestRun_CRAPStepFailed_ThresholdSet_ReturnsError(t *testing.T) {
 	maxCrapload := 5
 	crapErr := "coverage profile failed"
 	payload := &ReportPayload{
-		Summary: ReportSummary{TotalFunctions: 0, CRAPload: 0, GazeCRAPload: nil},
+		// CRAPload is nil because the CRAP step failed — the summary field
+		// was never set. GazeCRAPload is also nil (same step).
+		Summary: ReportSummary{TotalFunctions: 0, CRAPload: nil, GazeCRAPload: nil},
 		Errors:  PayloadErrors{CRAP: &crapErr},
 	}
 
@@ -489,17 +496,49 @@ func TestRun_ZeroResults_CRAPStepFailed_NoGate(t *testing.T) {
 			MaxCrapload: &maxCrapload,
 		},
 	})
-	// The zero-result gate skips because payload.Errors.CRAP is set
-	// (the CRAP step already failed). Threshold evaluation proceeds:
-	// CRAPload(0) <= 5 passes, so Run returns nil. The key invariant
-	// is that the error is NOT "no functions analyzed" — that gate
+	// The zero-result gate still skips because payload.Errors.CRAP is set.
+	// But threshold evaluation now correctly detects CRAPload=nil (unavailable)
+	// and fails the gate. Run must return a non-nil error.
+	if err == nil {
+		t.Fatal("expected error when CRAP step failed and threshold is set (CRAPload unavailable)")
+	}
+	// The error should NOT be "no functions analyzed" — that gate
 	// must not fire when the CRAP step itself reported an error.
-	if err != nil {
-		if strings.Contains(err.Error(), "no functions analyzed") {
-			t.Errorf("zero-result gate fired despite CRAP step error: %v", err)
-		} else {
-			t.Errorf("expected nil error (CRAP step error bypasses zero-result gate, threshold passes), got: %v", err)
-		}
+	if strings.Contains(err.Error(), "no functions analyzed") {
+		t.Errorf("zero-result gate fired despite CRAP step error: %v", err)
+	}
+}
+
+// TestRun_QualityStepFailed_ContractCoverageThreshold_ReturnsError verifies
+// that when the quality step fails and MinContractCoverage is set, Run returns
+// an error because AvgContractCoverage is unavailable (nil).
+func TestRun_QualityStepFailed_ContractCoverageThreshold_ReturnsError(t *testing.T) {
+	minCov := 50
+	qualErr := "quality analysis failed"
+	payload := &ReportPayload{
+		Summary: ReportSummary{
+			// CRAP step succeeded — CRAPload is valid.
+			CRAPload:       intPtr(3),
+			TotalFunctions: 10,
+			// Quality step failed — AvgContractCoverage is nil (never set).
+			AvgContractCoverage: nil,
+		},
+		CRAP:   json.RawMessage(`{"scores":[]}`),
+		Errors: PayloadErrors{Quality: &qualErr},
+	}
+
+	err := Run(RunnerOptions{
+		Patterns:    []string{"./..."},
+		Format:      "json",
+		Stdout:      &bytes.Buffer{},
+		Stderr:      &bytes.Buffer{},
+		AnalyzeFunc: fakeAnalyze(payload, nil),
+		Thresholds: ThresholdConfig{
+			MinContractCoverage: &minCov,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error when quality step failed and MinContractCoverage is set")
 	}
 }
 
@@ -507,7 +546,7 @@ func TestRun_ZeroResults_CRAPStepFailed_NoGate(t *testing.T) {
 // not fire when TotalFunctions > 0 (functions were analyzed).
 func TestCheckZeroResultGate_NonZeroTotalFunctions(t *testing.T) {
 	payload := &ReportPayload{
-		Summary: ReportSummary{TotalFunctions: 10, CRAPload: 0},
+		Summary: ReportSummary{TotalFunctions: 10, CRAPload: intPtr(0)},
 	}
 	cfg := ThresholdConfig{MaxCrapload: intPtr(5)}
 	err := checkZeroResultGate(payload, cfg)

--- a/internal/aireport/threshold.go
+++ b/internal/aireport/threshold.go
@@ -31,16 +31,28 @@ func EvaluateThresholds(cfg ThresholdConfig, payload *ReportPayload) ([]Threshol
 
 	if cfg.MaxCrapload != nil {
 		limit := *cfg.MaxCrapload
-		passed := summary.CRAPload <= limit
-		if !passed {
+		if summary.CRAPload == nil {
+			// Metric unavailable — threshold cannot be evaluated, so it fails.
+			// CI gates must not silently pass when data is missing.
 			allPassed = false
+			results = append(results, ThresholdResult{
+				Name:   "CRAPload (unavailable)",
+				Actual: nil,
+				Limit:  limit,
+				Passed: false,
+			})
+		} else {
+			passed := *summary.CRAPload <= limit
+			if !passed {
+				allPassed = false
+			}
+			results = append(results, ThresholdResult{
+				Name:   "CRAPload",
+				Actual: summary.CRAPload,
+				Limit:  limit,
+				Passed: passed,
+			})
 		}
-		results = append(results, ThresholdResult{
-			Name:   "CRAPload",
-			Actual: intPtr(summary.CRAPload),
-			Limit:  limit,
-			Passed: passed,
-		})
 	}
 
 	if cfg.MaxGazeCrapload != nil {
@@ -71,16 +83,28 @@ func EvaluateThresholds(cfg ThresholdConfig, payload *ReportPayload) ([]Threshol
 
 	if cfg.MinContractCoverage != nil {
 		limit := *cfg.MinContractCoverage
-		passed := summary.AvgContractCoverage >= limit
-		if !passed {
+		if summary.AvgContractCoverage == nil {
+			// Metric unavailable — threshold cannot be evaluated, so it fails.
+			// CI gates must not silently pass when data is missing.
 			allPassed = false
+			results = append(results, ThresholdResult{
+				Name:   "AvgContractCoverage (unavailable)",
+				Actual: nil,
+				Limit:  limit,
+				Passed: false,
+			})
+		} else {
+			passed := *summary.AvgContractCoverage >= limit
+			if !passed {
+				allPassed = false
+			}
+			results = append(results, ThresholdResult{
+				Name:   "AvgContractCoverage",
+				Actual: summary.AvgContractCoverage,
+				Limit:  limit,
+				Passed: passed,
+			})
 		}
-		results = append(results, ThresholdResult{
-			Name:   "AvgContractCoverage",
-			Actual: intPtr(summary.AvgContractCoverage),
-			Limit:  limit,
-			Passed: passed,
-		})
 	}
 
 	return results, allPassed

--- a/internal/aireport/threshold_test.go
+++ b/internal/aireport/threshold_test.go
@@ -8,7 +8,7 @@ import (
 // result in no results and allPassed=true.
 func TestEvaluateThresholds_NilConfig(t *testing.T) {
 	payload := &ReportPayload{
-		Summary: ReportSummary{CRAPload: 10, GazeCRAPload: intPtr(5), AvgContractCoverage: 30},
+		Summary: ReportSummary{CRAPload: intPtr(10), GazeCRAPload: intPtr(5), AvgContractCoverage: intPtr(30)},
 	}
 	results, passed := EvaluateThresholds(ThresholdConfig{}, payload)
 	if !passed {
@@ -23,7 +23,7 @@ func TestEvaluateThresholds_NilConfig(t *testing.T) {
 // with actual=0 passes (zero is a valid live threshold, and 0 <= 0).
 func TestEvaluateThresholds_ZeroThresholdWithZeroActual(t *testing.T) {
 	payload := &ReportPayload{
-		Summary: ReportSummary{CRAPload: 0},
+		Summary: ReportSummary{CRAPload: intPtr(0)},
 	}
 	cfg := ThresholdConfig{MaxCrapload: intPtr(0)}
 	results, passed := EvaluateThresholds(cfg, payload)
@@ -51,7 +51,7 @@ func TestEvaluateThresholds_ZeroThresholdWithZeroActual(t *testing.T) {
 // with actual>0 fails (zero is a live threshold).
 func TestEvaluateThresholds_ZeroThresholdWithPositiveActual(t *testing.T) {
 	payload := &ReportPayload{
-		Summary: ReportSummary{CRAPload: 3},
+		Summary: ReportSummary{CRAPload: intPtr(3)},
 	}
 	cfg := ThresholdConfig{MaxCrapload: intPtr(0)}
 	results, passed := EvaluateThresholds(cfg, payload)
@@ -72,7 +72,7 @@ func TestEvaluateThresholds_ZeroThresholdWithPositiveActual(t *testing.T) {
 // TestEvaluateThresholds_BelowLimit verifies that actual < limit passes.
 func TestEvaluateThresholds_BelowLimit(t *testing.T) {
 	payload := &ReportPayload{
-		Summary: ReportSummary{CRAPload: 3},
+		Summary: ReportSummary{CRAPload: intPtr(3)},
 	}
 	cfg := ThresholdConfig{MaxCrapload: intPtr(5)}
 	results, passed := EvaluateThresholds(cfg, payload)
@@ -99,7 +99,7 @@ func TestEvaluateThresholds_BelowLimit(t *testing.T) {
 // TestEvaluateThresholds_AboveLimit verifies that actual > limit fails.
 func TestEvaluateThresholds_AboveLimit(t *testing.T) {
 	payload := &ReportPayload{
-		Summary: ReportSummary{CRAPload: 8},
+		Summary: ReportSummary{CRAPload: intPtr(8)},
 	}
 	cfg := ThresholdConfig{MaxCrapload: intPtr(5)}
 	results, passed := EvaluateThresholds(cfg, payload)
@@ -128,9 +128,9 @@ func TestEvaluateThresholds_AboveLimit(t *testing.T) {
 func TestEvaluateThresholds_AllThreeFields(t *testing.T) {
 	payload := &ReportPayload{
 		Summary: ReportSummary{
-			CRAPload:            4,
+			CRAPload:            intPtr(4),
 			GazeCRAPload:        intPtr(2),
-			AvgContractCoverage: 60,
+			AvgContractCoverage: intPtr(60),
 		},
 	}
 	cfg := ThresholdConfig{
@@ -185,7 +185,7 @@ func TestEvaluateThresholds_AllThreeFields(t *testing.T) {
 func TestEvaluateThresholds_BothCRAPloadsFail(t *testing.T) {
 	payload := &ReportPayload{
 		Summary: ReportSummary{
-			CRAPload:     10,
+			CRAPload:     intPtr(10),
 			GazeCRAPload: intPtr(7),
 		},
 	}
@@ -229,16 +229,28 @@ func TestEvaluateThresholds_GazeCRAPloadZeroLiveThreshold(t *testing.T) {
 	}
 }
 
-// TestEvaluateThresholds_NilPayload verifies graceful handling of nil payload.
+// TestEvaluateThresholds_NilPayload verifies that nil payload now correctly
+// fails thresholds because all summary fields are nil (*int zero value = nil),
+// not zero (int zero value = 0). This is the fix for #102: CI gates must not
+// silently pass when data is unavailable.
 func TestEvaluateThresholds_NilPayload(t *testing.T) {
 	cfg := ThresholdConfig{MaxCrapload: intPtr(5)}
 	results, passed := EvaluateThresholds(cfg, nil)
-	// nil payload → zero-value summary → CRAPload=0 ≤ 5 → pass
-	if !passed {
-		t.Error("expected passed=true with nil payload and limit=5")
+	// nil payload → zero-value summary → CRAPload=nil → FAIL (unavailable)
+	if passed {
+		t.Error("expected passed=false with nil payload (CRAPload is nil/unavailable)")
 	}
-	if len(results) != 1 || !results[0].Passed {
-		t.Errorf("unexpected results: %+v", results)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Passed {
+		t.Error("expected result.Passed=false")
+	}
+	if results[0].Actual != nil {
+		t.Errorf("expected Actual=nil (unavailable), got %d", *results[0].Actual)
+	}
+	if results[0].Name != "CRAPload (unavailable)" {
+		t.Errorf("expected Name='CRAPload (unavailable)', got %q", results[0].Name)
 	}
 }
 
@@ -248,7 +260,7 @@ func TestEvaluateThresholds_NilPayload(t *testing.T) {
 func TestEvaluateThresholds_MinContractCoverageDirection(t *testing.T) {
 	// Boundary: actual == limit → should pass (>= semantics).
 	payload := &ReportPayload{
-		Summary: ReportSummary{AvgContractCoverage: 60},
+		Summary: ReportSummary{AvgContractCoverage: intPtr(60)},
 	}
 	cfg := ThresholdConfig{MinContractCoverage: intPtr(60)}
 	results, passed := EvaluateThresholds(cfg, payload)
@@ -273,7 +285,7 @@ func TestEvaluateThresholds_MinContractCoverageDirection(t *testing.T) {
 
 	// Below boundary: actual < limit → should fail.
 	payload2 := &ReportPayload{
-		Summary: ReportSummary{AvgContractCoverage: 59},
+		Summary: ReportSummary{AvgContractCoverage: intPtr(59)},
 	}
 	results2, passed2 := EvaluateThresholds(cfg, payload2)
 	if passed2 {
@@ -298,7 +310,7 @@ func TestEvaluateThresholds_MinContractCoverageDirection(t *testing.T) {
 func TestEvaluateThresholds_GazeCRAPload_ThresholdSet_DataUnavailable(t *testing.T) {
 	payload := &ReportPayload{
 		Summary: ReportSummary{
-			CRAPload:     2,
+			CRAPload:     intPtr(2),
 			GazeCRAPload: nil, // metric unavailable
 		},
 	}
@@ -391,7 +403,7 @@ func TestEvaluateThresholds_GazeCRAPload_ThresholdSet_DataExceedsLimit(t *testin
 func TestEvaluateThresholds_GazeCRAPload_ThresholdNotSet_DataUnavailable(t *testing.T) {
 	payload := &ReportPayload{
 		Summary: ReportSummary{
-			CRAPload:     5,
+			CRAPload:     intPtr(5),
 			GazeCRAPload: nil,
 		},
 	}
@@ -415,7 +427,7 @@ func TestEvaluateThresholds_GazeCRAPload_ThresholdNotSet_DataUnavailable(t *test
 func TestEvaluateThresholds_GazeCRAPload_ThresholdNotSet_DataAvailable(t *testing.T) {
 	payload := &ReportPayload{
 		Summary: ReportSummary{
-			CRAPload:     5,
+			CRAPload:     intPtr(5),
 			GazeCRAPload: intPtr(3),
 		},
 	}
@@ -433,15 +445,112 @@ func TestEvaluateThresholds_GazeCRAPload_ThresholdNotSet_DataAvailable(t *testin
 	}
 }
 
+// TestEvaluateThresholds_CRAPload_Unavailable verifies that when
+// CRAPload is nil (step failed / metric unavailable) and MaxCrapload
+// is configured, the result is FAIL with Actual=nil and a descriptive
+// "(unavailable)" name. This is the core regression test for #102.
+func TestEvaluateThresholds_CRAPload_Unavailable(t *testing.T) {
+	payload := &ReportPayload{
+		Summary: ReportSummary{
+			CRAPload:     nil, // metric unavailable (step failed)
+			GazeCRAPload: intPtr(2),
+		},
+	}
+	cfg := ThresholdConfig{MaxCrapload: intPtr(5)}
+	results, passed := EvaluateThresholds(cfg, payload)
+	if passed {
+		t.Error("expected passed=false when CRAPload is nil (unavailable)")
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.Passed {
+		t.Error("expected result.Passed=false")
+	}
+	if r.Actual != nil {
+		t.Errorf("expected Actual=nil (unavailable), got %d", *r.Actual)
+	}
+	if r.Name != "CRAPload (unavailable)" {
+		t.Errorf("expected Name='CRAPload (unavailable)', got %q", r.Name)
+	}
+	if r.Limit != 5 {
+		t.Errorf("expected Limit=5, got %d", r.Limit)
+	}
+}
+
+// TestEvaluateThresholds_AvgContractCoverage_Unavailable verifies that when
+// AvgContractCoverage is nil (quality step failed) and MinContractCoverage
+// is configured, the result is FAIL with Actual=nil and "(unavailable)" name.
+func TestEvaluateThresholds_AvgContractCoverage_Unavailable(t *testing.T) {
+	payload := &ReportPayload{
+		Summary: ReportSummary{
+			CRAPload:            intPtr(3),
+			AvgContractCoverage: nil, // metric unavailable (step failed)
+		},
+	}
+	cfg := ThresholdConfig{MinContractCoverage: intPtr(50)}
+	results, passed := EvaluateThresholds(cfg, payload)
+	if passed {
+		t.Error("expected passed=false when AvgContractCoverage is nil (unavailable)")
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.Passed {
+		t.Error("expected result.Passed=false")
+	}
+	if r.Actual != nil {
+		t.Errorf("expected Actual=nil (unavailable), got %d", *r.Actual)
+	}
+	if r.Name != "AvgContractCoverage (unavailable)" {
+		t.Errorf("expected Name='AvgContractCoverage (unavailable)', got %q", r.Name)
+	}
+	if r.Limit != 50 {
+		t.Errorf("expected Limit=50, got %d", r.Limit)
+	}
+}
+
+// TestEvaluateThresholds_CRAPload_ZeroIsValid verifies that CRAPload=0 from
+// a successful analysis (intPtr(0)) passes the threshold, confirming that
+// zero-from-success is distinguishable from nil-from-failure.
+func TestEvaluateThresholds_CRAPload_ZeroIsValid(t *testing.T) {
+	payload := &ReportPayload{
+		Summary: ReportSummary{CRAPload: intPtr(0)},
+	}
+	cfg := ThresholdConfig{MaxCrapload: intPtr(5)}
+	results, passed := EvaluateThresholds(cfg, payload)
+	if !passed {
+		t.Error("expected passed=true when CRAPload=0 (valid zero) and limit=5")
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if !r.Passed {
+		t.Error("expected result.Passed=true")
+	}
+	if r.Name != "CRAPload" {
+		t.Errorf("expected Name='CRAPload' (no unavailable suffix), got %q", r.Name)
+	}
+	if r.Actual == nil {
+		t.Fatal("expected Actual=intPtr(0), got nil")
+	}
+	if *r.Actual != 0 {
+		t.Errorf("expected Actual=0, got %d", *r.Actual)
+	}
+}
+
 // BenchmarkEvaluateThresholds measures the overhead of threshold evaluation.
 // EvaluateThresholds is a pure in-memory function with no I/O; its overhead
 // must be negligible (well under 1 ms per invocation).
 func BenchmarkEvaluateThresholds(b *testing.B) {
 	payload := &ReportPayload{
 		Summary: ReportSummary{
-			CRAPload:            8,
+			CRAPload:            intPtr(8),
 			GazeCRAPload:        intPtr(3),
-			AvgContractCoverage: 72,
+			AvgContractCoverage: intPtr(72),
 		},
 	}
 	cfg := ThresholdConfig{

--- a/openspec/changes/report-step-failure-gate/.openspec.yaml
+++ b/openspec/changes/report-step-failure-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-13

--- a/openspec/changes/report-step-failure-gate/design.md
+++ b/openspec/changes/report-step-failure-gate/design.md
@@ -78,8 +78,10 @@ thresholds configured must produce a non-nil error.
 ### D4: Compact struct alignment
 
 **Decision**: Update `compactSummary.CRAPload` from `int` to `*int` and
-`compactSummary.AvgContractCoverage` to match (already `*float64` in one
-location, `int` in another — align to `*int`).
+`compactSummary.AvgContractCoverage` from `int` to `*int`. Note:
+`compactCRAPSummary.AvgContractCoverage` is `*float64` (mirrors `crap.Summary`)
+and is a different struct — it is NOT changed by this spec. Only the pipeline
+summary fields in `compactSummary` are in scope.
 
 **Rationale**: The compact structs are the JSON-serialization boundary. The
 `omitempty` tag already exists on `GazeCRAPload` and should be applied

--- a/openspec/changes/report-step-failure-gate/design.md
+++ b/openspec/changes/report-step-failure-gate/design.md
@@ -1,0 +1,116 @@
+## Context
+
+Issue #102 reports that `gaze report` exits 0 (PASS) when an analysis step
+fails and threshold flags are configured. The root cause is a type asymmetry:
+`GazeCRAPload` is `*int` (nil = unavailable, correctly fails gate per #108),
+while `CRAPload` and `AvgContractCoverage` are bare `int` (zero value = passes
+gate silently).
+
+The `ci-gate-integrity` change (issues #101, #108, #116) established the `*int`
+pattern for `GazeCRAPload` but did not extend it to `CRAPload` and
+`AvgContractCoverage`. This design completes that migration.
+
+## Goals / Non-Goals
+
+### Goals
+- Eliminate the zero-value masquerade for `CRAPload` and `AvgContractCoverage`
+  by converting both to `*int` in all pipeline structs
+- Make `EvaluateThresholds` fail when a configured threshold's metric is
+  unavailable (nil), matching existing `GazeCRAPload` behavior
+- Ensure `Run` returns non-nil error when any threshold fails due to
+  unavailable data
+- Preserve the partial-failure pipeline design — steps that fail should still
+  produce partial payloads for the AI adapter
+
+### Non-Goals
+- Changing `runProductionPipeline` to return errors on step failure (this would
+  break the intentional partial-failure design)
+- Adding new threshold flags or metrics
+- Modifying the JSON output schema for `--format=json` (the `compact.go`
+  structs need mechanical `*int` updates but the serialized field names and
+  semantics remain the same)
+
+## Decisions
+
+### D1: Mirror the GazeCRAPload `*int` pattern
+
+**Decision**: Convert `CRAPload` and `AvgContractCoverage` from `int` to `*int`
+in `ReportSummary`, `crapStepResult`, `qualityStepResult`, and the compact
+structs.
+
+**Rationale**: The `*int` pattern was proven in #108 and is already well-tested.
+It makes the nil-vs-zero distinction structural (enforced by the type system)
+rather than behavioral (enforced by error-checking conventions). The existing
+nil-check code in `EvaluateThresholds` for `GazeCRAPload` (threshold.go:48-57)
+serves as an exact template.
+
+**Alternatives rejected**:
+- **Check `payload.Errors` in `EvaluateThresholds`**: Couples threshold
+  evaluation to the error reporting structure. Requires maintaining the
+  invariant "error set implies summary field unreliable" outside the type
+  system — fragile and easy to break when adding new metrics.
+- **Make `runProductionPipeline` return error**: Breaks the intentional
+  partial-failure design. The AI adapter still benefits from classification and
+  docscan data even when CRAP fails.
+
+### D2: Set `*int` fields only in the success branch
+
+**Decision**: In `runCRAPStep` and `runQualityForPackage`, the `*int` fields
+are set only when the step succeeds. On failure, they remain `nil` (Go default
+for pointer types).
+
+**Rationale**: This is already the pattern for `GazeCRAPload` in
+`runCRAPStep`. The field is set to `&summary.GazeCRAPload` only inside the
+success path. `CRAPload` and `AvgContractCoverage` should follow the same
+pattern.
+
+### D3: Update existing bug-enshrining test
+
+**Decision**: `TestRun_ZeroResults_CRAPStepFailed_NoGate` must be updated
+from asserting `err == nil` to asserting `err != nil` with a message indicating
+threshold evaluation failure due to unavailable data.
+
+**Rationale**: This test currently documents the bug as correct behavior. The
+test name suggests it validates the zero-result gate bypass, but it actually
+validates the false-pass scenario. After the fix, a failed CRAP step with
+thresholds configured must produce a non-nil error.
+
+### D4: Compact struct alignment
+
+**Decision**: Update `compactSummary.CRAPload` from `int` to `*int` and
+`compactSummary.AvgContractCoverage` to match (already `*float64` in one
+location, `int` in another — align to `*int`).
+
+**Rationale**: The compact structs are the JSON-serialization boundary. The
+`omitempty` tag already exists on `GazeCRAPload` and should be applied
+consistently to `CRAPload` and `AvgContractCoverage` in the compact path.
+
+## Risks / Trade-offs
+
+### Risk: CI pipelines that were falsely passing will start failing
+
+**Likelihood**: Medium — any pipeline where the CRAP step intermittently fails
+(e.g., flaky compilation in analyzed packages) will see new failures.
+
+**Mitigation**: This is the correct behavior. The proposal and issue both
+identify this as the intended outcome. Release notes should call out this
+behavioral change explicitly.
+
+### Risk: `*int` type change propagation
+
+**Likelihood**: Certain — the change touches `ReportSummary`, `crapStepResult`,
+`qualityStepResult`, compact structs, and all test files that construct these
+structs.
+
+**Mitigation**: The blast radius is entirely within `internal/aireport/`. The
+`intPtr()` helper already exists. Grep for `CRAPload` and `AvgContractCoverage`
+struct literal assignments to find all callsites (Dewey learning from #108:
+"grep for all struct literals containing the field name").
+
+### Trade-off: `*int` adds nil-check complexity
+
+Every read of `CRAPload` or `AvgContractCoverage` now requires a nil check.
+This is accepted because:
+1. The alternative (bare `int`) silently passes CI gates — a worse outcome
+2. The pattern is already established for `GazeCRAPload` with no ergonomic issues
+3. The `intPtr()` helper makes construction clean

--- a/openspec/changes/report-step-failure-gate/proposal.md
+++ b/openspec/changes/report-step-failure-gate/proposal.md
@@ -1,0 +1,107 @@
+## Why
+
+`gaze report` serves as a CI quality gate via threshold flags (`--max-crapload`,
+`--max-gaze-crapload`, `--min-contract-coverage`). When an analysis step fails
+(e.g., a package does not compile), the pipeline records the error in
+`payload.Errors` but continues execution. The summary fields `CRAPload` and
+`AvgContractCoverage` remain at Go's zero value (`int` → `0`), and threshold
+evaluation proceeds against these zero values:
+
+- `CRAPload: 0 <= limit` → **PASS** (false assurance)
+- `AvgContractCoverage: 0 >= limit` → **FAIL** (misleading diagnostic —
+  reports "coverage too low" instead of "data unavailable")
+
+The `GazeCRAPload` field was already fixed in issue #108 by converting it to
+`*int`, where `nil` means "unavailable" and the threshold evaluator correctly
+fails when the metric is nil. `CRAPload` and `AvgContractCoverage` were not
+updated at the same time, creating a type asymmetry that is the root cause of
+this bug.
+
+The existing test `TestRun_ZeroResults_CRAPStepFailed_NoGate` (runner_test.go)
+enshrines this behavior as correct — it asserts `err == nil` when the CRAP step
+fails with thresholds configured.
+
+**Closes**: #102
+**Related**: #108 (GazeCRAPload *int fix), #116 (zero-result gate), #103 (sibling)
+
+## What Changes
+
+Convert `CRAPload` and `AvgContractCoverage` from `int` to `*int` throughout
+the `internal/aireport/` pipeline, mirroring the proven `GazeCRAPload` pattern
+from issue #108. When an analysis step fails and its threshold is configured,
+the gate reports FAIL with "unavailable" instead of silently passing with a
+zero value.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `threshold evaluation`: When a pipeline step fails and its corresponding
+  threshold is configured, the threshold result is FAIL with
+  `Actual: nil` and a name containing "(unavailable)" — matching the existing
+  `GazeCRAPload` behavior.
+- `exit code integrity`: `gaze report` returns non-zero exit code when any
+  configured threshold cannot be evaluated due to step failure.
+
+### Removed Capabilities
+- None
+
+## Impact
+
+**Files affected** (all within `internal/aireport/`):
+
+| File | Change |
+|------|--------|
+| `payload.go` | `CRAPload int` → `*int`, `AvgContractCoverage int` → `*int` |
+| `threshold.go` | Add nil checks for CRAPload and AvgContractCoverage, mirroring GazeCRAPload |
+| `runner_steps.go` | `crapStepResult.CRAPload` → `*int`, `qualityStepResult.AvgContractCoverage` → `*int` |
+| `compact.go` | Update nil-safe handling for serialization |
+| `runner.go` | Possibly adjust `checkZeroResultGate` |
+| `*_test.go` | ~8 new tests, 1 updated test |
+
+**Blast radius**: Entirely within `internal/aireport/` — no public API surface
+is affected. `ReportSummary` is tagged `json:"-"` and never serialized to
+external consumers.
+
+**Behavioral change**: CI pipelines that were falsely passing due to step
+failures will now correctly fail. This is the intended outcome — those pipelines
+were providing false assurance.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change is internal to the `gaze` binary and does not affect artifact-based
+communication between heroes.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The change is entirely within `internal/aireport/` and does not introduce new
+dependencies or coupling. The `*int` pattern is already established in the same
+package.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+This fix directly improves observable quality — threshold results will
+accurately distinguish "measured zero" from "data unavailable" in machine-parseable
+JSON output. The `ThresholdResult.Actual` field (already `*int`) correctly
+represents nil vs zero.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+All DI seams needed for testing already exist (`pipelineStepFuncs`, `AnalyzeFunc`,
+`fakeAnalyze`). The fix adds ~8 new tests covering the previously-missing
+composition scenario (step failure + threshold configured). The existing test
+that enshrines the bug will be corrected.

--- a/openspec/changes/report-step-failure-gate/proposal.md
+++ b/openspec/changes/report-step-failure-gate/proposal.md
@@ -1,3 +1,5 @@
+<!-- spec-review: passed -->
+
 ## Why
 
 `gaze report` serves as a CI quality gate via threshold flags (`--max-crapload`,
@@ -71,31 +73,33 @@ were providing false assurance.
 
 ## Constitution Alignment
 
-Assessed against the Unbound Force org constitution.
+Assessed against the Gaze project constitution (`.specify/memory/constitution.md`
+v1.3.0).
 
-### I. Autonomous Collaboration
+### I. Accuracy
+
+**Assessment**: PASS
+
+This fix eliminates false-pass CI gate results caused by zero-value masquerade.
+When an analysis step fails, the threshold correctly reports FAIL with
+"unavailable" instead of silently passing with a zero value. This directly serves
+the Accuracy principle: "false positives erode trust and MUST be treated as bugs."
+
+### II. Minimal Assumptions
 
 **Assessment**: N/A
 
-This change is internal to the `gaze` binary and does not affect artifact-based
-communication between heroes.
+No new assumptions are introduced. The fix is internal to `internal/aireport/`
+and does not require users to annotate or restructure their code.
 
-### II. Composability First
-
-**Assessment**: PASS
-
-The change is entirely within `internal/aireport/` and does not introduce new
-dependencies or coupling. The `*int` pattern is already established in the same
-package.
-
-### III. Observable Quality
+### III. Actionable Output
 
 **Assessment**: PASS
 
-This fix directly improves observable quality — threshold results will
-accurately distinguish "measured zero" from "data unavailable" in machine-parseable
-JSON output. The `ThresholdResult.Actual` field (already `*int`) correctly
-represents nil vs zero.
+Threshold results now accurately distinguish "measured zero" (`intPtr(0)`) from
+"data unavailable" (`nil`). The `ThresholdResult.Actual` field (already `*int`)
+correctly represents nil vs zero, making metrics comparable across runs as
+required by the constitution.
 
 ### IV. Testability
 
@@ -104,4 +108,6 @@ represents nil vs zero.
 All DI seams needed for testing already exist (`pipelineStepFuncs`, `AnalyzeFunc`,
 `fakeAnalyze`). The fix adds ~8 new tests covering the previously-missing
 composition scenario (step failure + threshold configured). The existing test
-that enshrines the bug will be corrected.
+that enshrines the bug will be corrected. Coverage strategy: unit tests for
+`EvaluateThresholds` nil-handling, integration tests for `Run` end-to-end with
+step failures + thresholds, pipeline tests for summary field propagation.

--- a/openspec/changes/report-step-failure-gate/specs/threshold-unavailability.md
+++ b/openspec/changes/report-step-failure-gate/specs/threshold-unavailability.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: CRAPload unavailability detection
+
+`EvaluateThresholds` MUST treat a nil `CRAPload` value as "metric unavailable"
+and return a FAIL result when `MaxCrapload` is configured. The result MUST
+have `Name` containing "(unavailable)", `Actual` set to `nil`, and `Passed`
+set to `false`.
+
+#### Scenario: CRAP step fails with MaxCrapload threshold configured
+
+- **GIVEN** the CRAP analysis step failed (returned an error)
+- **WHEN** `EvaluateThresholds` is called with `MaxCrapload` set to any value
+- **THEN** the result for CRAPload MUST have `Passed = false`
+- **AND** the result MUST have `Actual = nil`
+- **AND** the result MUST have `Name` containing "(unavailable)"
+
+#### Scenario: CRAPload is zero from successful analysis
+
+- **GIVEN** the CRAP analysis step succeeded with zero CRAPload functions
+- **WHEN** `EvaluateThresholds` is called with `MaxCrapload` set to 5
+- **THEN** the result for CRAPload MUST have `Passed = true`
+- **AND** the result MUST have `Actual = intPtr(0)` (not nil)
+
+### Requirement: AvgContractCoverage unavailability detection
+
+`EvaluateThresholds` MUST treat a nil `AvgContractCoverage` value as "metric
+unavailable" and return a FAIL result when `MinContractCoverage` is configured.
+The result MUST have `Name` containing "(unavailable)", `Actual` set to `nil`,
+and `Passed` set to `false`.
+
+#### Scenario: Quality step fails with MinContractCoverage threshold configured
+
+- **GIVEN** the Quality analysis step failed (returned an error)
+- **WHEN** `EvaluateThresholds` is called with `MinContractCoverage` set to any value
+- **THEN** the result for AvgContractCoverage MUST have `Passed = false`
+- **AND** the result MUST have `Actual = nil`
+- **AND** the result MUST have `Name` containing "(unavailable)"
+
+#### Scenario: AvgContractCoverage is zero from successful analysis
+
+- **GIVEN** the Quality analysis step succeeded with zero average contract coverage
+- **WHEN** `EvaluateThresholds` is called with `MinContractCoverage` set to 50
+- **THEN** the result for AvgContractCoverage MUST have `Passed = false`
+- **AND** the result MUST have `Actual = intPtr(0)` (not nil)
+
+### Requirement: Run returns error on unavailable threshold data
+
+`Run` MUST return a non-nil error when any configured threshold cannot be
+evaluated because the corresponding analysis step failed.
+
+#### Scenario: CRAP step fails with threshold flags set
+
+- **GIVEN** `gaze report` is invoked with `--max-crapload=5`
+- **AND** the CRAP analysis step fails (e.g., package does not compile)
+- **WHEN** the pipeline completes
+- **THEN** `Run` MUST return a non-nil error
+- **AND** the exit code MUST be non-zero
+
+#### Scenario: Multiple steps fail with multiple thresholds set
+
+- **GIVEN** `gaze report` is invoked with `--max-crapload=5 --min-contract-coverage=50`
+- **AND** both the CRAP and Quality steps fail
+- **WHEN** the pipeline completes
+- **THEN** `Run` MUST return a non-nil error indicating threshold evaluation failure
+
+## MODIFIED Requirements
+
+### Requirement: CRAPload type in ReportSummary
+
+`ReportSummary.CRAPload` MUST be `*int` (pointer to int) to distinguish
+"metric computed as zero" (`intPtr(0)`) from "metric unavailable" (`nil`).
+
+Previously: `CRAPload int` — zero value was ambiguous between "healthy" and
+"analysis failed".
+
+### Requirement: AvgContractCoverage type in ReportSummary
+
+`ReportSummary.AvgContractCoverage` MUST be `*int` (pointer to int) to
+distinguish "metric computed as zero" (`intPtr(0)`) from "metric unavailable"
+(`nil`).
+
+Previously: `AvgContractCoverage int` — zero value was ambiguous between
+"zero coverage" and "analysis failed".
+
+### Requirement: Pipeline step result types
+
+`crapStepResult.CRAPload` MUST be `*int`. `qualityStepResult.AvgContractCoverage`
+MUST be `*int`. These fields MUST only be set to non-nil values when their
+respective steps succeed.
+
+Previously: Both were `int`, set unconditionally.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/report-step-failure-gate/tasks.md
+++ b/openspec/changes/report-step-failure-gate/tasks.md
@@ -35,15 +35,21 @@ depend on it.
 - [ ] 1.4 Change `compactSummary.CRAPload` from `int` to `*int` and
   `compactSummary.AvgContractCoverage` from `int` to `*int` in
   `internal/aireport/compact.go` (lines 27, 29). Add `omitempty` JSON
-  tags to match `GazeCRAPload` pattern. Update `CompactForAI` and
-  `compactForFullJSON` assignment sites (lines 165, 167, 232, 237) to
-  propagate `*int` values correctly.
+  tags to match `GazeCRAPload` pattern. Update `CompactForAI`
+  assignment sites (lines 165, 167) to propagate `*int` values
+  correctly. **Note**: `compactCRAPField` (lines 232, 237) copies from
+  `crap.Summary` which has its own `CRAPload int` and
+  `AvgContractCoverage *float64` — these are different types in a
+  different package and are NOT affected by this change.
 
 - [ ] 1.5 Update `runProductionPipeline` in `internal/aireport/runner.go`
   (lines 297, 313) — the assignment `payload.Summary.CRAPload = crapRes.CRAPload`
   already lives in the success branch, so it will naturally propagate the
-  `*int`. Verify no additional changes are needed in the error branch
-  (nil default is correct). Same for `AvgContractCoverage` at line 313.
+  `*int`. Confirm that the error branch does NOT set CRAPload — the nil
+  default is the desired semantics. Same for `AvgContractCoverage` at
+  line 313. **Note**: upstream `crap.Summary.CRAPload` remains `int` — the
+  `*int` wrapper is applied at the `aireport` pipeline boundary, not in the
+  `crap` package.
 
 ## 2. Threshold evaluation: nil-check guards
 
@@ -70,29 +76,31 @@ pattern (threshold.go:48-57).
 Add unit tests for `EvaluateThresholds` covering the new nil-handling
 paths.
 
-- [ ] 3.1 [P] Add `TestEvaluateThresholds_CRAPload_Unavailable` to
+- [ ] 3.1 Add `TestEvaluateThresholds_CRAPload_Unavailable` to
   `internal/aireport/threshold_test.go`. Verify that when
   `Summary.CRAPload` is nil and `MaxCrapload` is set, the result is
   FAIL with `Actual == nil` and `Name` contains "(unavailable)".
 
-- [ ] 3.2 [P] Add `TestEvaluateThresholds_AvgContractCoverage_Unavailable`
+- [ ] 3.2 Add `TestEvaluateThresholds_AvgContractCoverage_Unavailable`
   to `internal/aireport/threshold_test.go`. Same pattern for
   `AvgContractCoverage` + `MinContractCoverage`.
 
-- [ ] 3.3 [P] Add `TestEvaluateThresholds_CRAPload_ZeroIsValid` to
+- [ ] 3.3 Add `TestEvaluateThresholds_CRAPload_ZeroIsValid` to
   `internal/aireport/threshold_test.go`. Verify that
   `CRAPload = intPtr(0)` with `MaxCrapload = 5` produces PASS with
   `Actual = intPtr(0)` — confirming zero-from-success is
   distinguishable from nil-from-failure.
 
-- [ ] 3.4 [P] Update `TestEvaluateThresholds_NilPayload` in
+- [ ] 3.4 Update `TestEvaluateThresholds_NilPayload` in
   `internal/aireport/threshold_test.go` — with nil payload, all
   summary fields are nil (not zero), so all configured thresholds
-  should now FAIL with "(unavailable)".
+  should now FAIL with "(unavailable)". Expected assertion changes:
+  `passed=true` → `passed=false`, `results[0].Passed=true` →
+  `results[0].Passed=false`, `results[0].Actual == nil`, and
+  `results[0].Name` contains "(unavailable)".
 
-  **Note**: tasks 3.1-3.4 all touch `threshold_test.go` — despite [P]
-  markers, these should be implemented as a single batch to avoid
-  conflicts.
+  **Note**: tasks 3.1-3.4 all touch `threshold_test.go` and MUST be
+  implemented as a single batch to avoid conflicts.
 
 ## 4. Tests: integration (Run end-to-end)
 

--- a/openspec/changes/report-step-failure-gate/tasks.md
+++ b/openspec/changes/report-step-failure-gate/tasks.md
@@ -16,23 +16,23 @@ Convert `CRAPload` and `AvgContractCoverage` from `int` to `*int` in all
 pipeline structs. This is the foundational change — all subsequent tasks
 depend on it.
 
-- [ ] 1.1 Change `ReportSummary.CRAPload` from `int` to `*int` and
+- [x] 1.1 Change `ReportSummary.CRAPload` from `int` to `*int` and
   `ReportSummary.AvgContractCoverage` from `int` to `*int` in
   `internal/aireport/payload.go`. Update GoDoc comments to match
   the `GazeCRAPload` pattern ("Nil means the metric was not computed").
 
-- [ ] 1.2 Change `crapStepResult.CRAPload` from `int` to `*int` in
+- [x] 1.2 Change `crapStepResult.CRAPload` from `int` to `*int` in
   `internal/aireport/runner_steps.go` (line 87). Update the
   `runCRAPStep` success path to use `intPtr(rpt.Summary.CRAPload)`
   (line 130).
 
-- [ ] 1.3 Change `qualityStepResult.AvgContractCoverage` from `int` to
+- [x] 1.3 Change `qualityStepResult.AvgContractCoverage` from `int` to
   `*int` in `internal/aireport/runner_steps.go` (line 141). Update the
   quality step success path to use `intPtr(...)` for the computed
   average. **Note**: task 1.2 and 1.3 touch the same file and MUST
   be done together.
 
-- [ ] 1.4 Change `compactSummary.CRAPload` from `int` to `*int` and
+- [x] 1.4 Change `compactSummary.CRAPload` from `int` to `*int` and
   `compactSummary.AvgContractCoverage` from `int` to `*int` in
   `internal/aireport/compact.go` (lines 27, 29). Add `omitempty` JSON
   tags to match `GazeCRAPload` pattern. Update `CompactForAI`
@@ -42,7 +42,7 @@ depend on it.
   `AvgContractCoverage *float64` — these are different types in a
   different package and are NOT affected by this change.
 
-- [ ] 1.5 Update `runProductionPipeline` in `internal/aireport/runner.go`
+- [x] 1.5 Update `runProductionPipeline` in `internal/aireport/runner.go`
   (lines 297, 313) — the assignment `payload.Summary.CRAPload = crapRes.CRAPload`
   already lives in the success branch, so it will naturally propagate the
   `*int`. Confirm that the error branch does NOT set CRAPload — the nil
@@ -57,13 +57,13 @@ Add nil-unavailability handling to `EvaluateThresholds` for `CRAPload`
 and `AvgContractCoverage`, mirroring the existing `GazeCRAPload`
 pattern (threshold.go:48-57).
 
-- [ ] 2.1 Update the `CRAPload` threshold block (threshold.go:32-44) to
+- [x] 2.1 Update the `CRAPload` threshold block (threshold.go:32-44) to
   check `summary.CRAPload == nil` first. When nil: append a FAIL result
   with `Name: "CRAPload (unavailable)"`, `Actual: nil`, `Passed: false`.
   When non-nil: dereference and compare as before, using
   `Actual: summary.CRAPload`.
 
-- [ ] 2.2 Update the `AvgContractCoverage` threshold block
+- [x] 2.2 Update the `AvgContractCoverage` threshold block
   (threshold.go:72-84) to check `summary.AvgContractCoverage == nil`
   first. When nil: append a FAIL result with
   `Name: "AvgContractCoverage (unavailable)"`, `Actual: nil`,
@@ -76,22 +76,22 @@ pattern (threshold.go:48-57).
 Add unit tests for `EvaluateThresholds` covering the new nil-handling
 paths.
 
-- [ ] 3.1 Add `TestEvaluateThresholds_CRAPload_Unavailable` to
+- [x] 3.1 Add `TestEvaluateThresholds_CRAPload_Unavailable` to
   `internal/aireport/threshold_test.go`. Verify that when
   `Summary.CRAPload` is nil and `MaxCrapload` is set, the result is
   FAIL with `Actual == nil` and `Name` contains "(unavailable)".
 
-- [ ] 3.2 Add `TestEvaluateThresholds_AvgContractCoverage_Unavailable`
+- [x] 3.2 Add `TestEvaluateThresholds_AvgContractCoverage_Unavailable`
   to `internal/aireport/threshold_test.go`. Same pattern for
   `AvgContractCoverage` + `MinContractCoverage`.
 
-- [ ] 3.3 Add `TestEvaluateThresholds_CRAPload_ZeroIsValid` to
+- [x] 3.3 Add `TestEvaluateThresholds_CRAPload_ZeroIsValid` to
   `internal/aireport/threshold_test.go`. Verify that
   `CRAPload = intPtr(0)` with `MaxCrapload = 5` produces PASS with
   `Actual = intPtr(0)` — confirming zero-from-success is
   distinguishable from nil-from-failure.
 
-- [ ] 3.4 Update `TestEvaluateThresholds_NilPayload` in
+- [x] 3.4 Update `TestEvaluateThresholds_NilPayload` in
   `internal/aireport/threshold_test.go` — with nil payload, all
   summary fields are nil (not zero), so all configured thresholds
   should now FAIL with "(unavailable)". Expected assertion changes:
@@ -107,44 +107,45 @@ paths.
 Add integration tests verifying `Run` returns error when step failure
 + threshold are combined.
 
-- [ ] 4.1 Update `TestRun_ZeroResults_CRAPStepFailed_NoGate` in
+- [x] 4.1 Update `TestRun_ZeroResults_CRAPStepFailed_NoGate` in
   `internal/aireport/runner_test.go` — change assertion from
   `err == nil` to `err != nil`. The test should verify that when the
   CRAP step fails and `MaxCrapload` is set, `Run` returns an error.
   Update the test name to reflect the new behavior (e.g.,
   `TestRun_CRAPStepFailed_ThresholdSet_ReturnsError`).
 
-- [ ] 4.2 Add `TestRun_QualityStepFailed_ContractCoverageThreshold_ReturnsError`
+- [x] 4.2 Add `TestRun_QualityStepFailed_ContractCoverageThreshold_ReturnsError`
   to `internal/aireport/runner_test.go`. Verify that when the quality
   step fails and `MinContractCoverage` is set, `Run` returns an error.
 
-- [ ] 4.3 Add `TestRun_CRAPStepFailed_NoThreshold_ReturnsNil` to
-  `internal/aireport/runner_test.go`. Verify that when the CRAP step
-  fails but NO threshold flags are set, `Run` still returns nil
-  (preserving the partial-failure design).
+- [x] 4.3 Verify that when the CRAP step fails but NO threshold flags
+  are set, `Run` still returns nil (preserving the partial-failure
+  design). **Covered by existing `TestRun_CRAPStepFailure_PartialPayload`
+  (runner_test.go:86)** — CRAP step fails, no thresholds, asserts
+  `err == nil`. No new test needed.
 
 ## 5. Tests: pipeline internal
 
 Update pipeline internal tests to reflect `*int` types.
 
-- [ ] 5.1 Update `fakeSteps` and assertions in
+- [x] 5.1 Update `fakeSteps` and assertions in
   `internal/aireport/pipeline_internal_test.go` to use `*int` for
   `CRAPload` and `AvgContractCoverage`. Verify existing tests compile
   and pass with the type changes.
 
-- [ ] 5.2 Add `TestRunProductionPipeline_CRAPStepFails_CRAPloadIsNil`
+- [x] 5.2 Add `TestRunProductionPipeline_CRAPStepFails_CRAPloadIsNil`
   to `internal/aireport/pipeline_internal_test.go`. Verify that when
   the CRAP step fails, `payload.Summary.CRAPload` is nil (not zero).
 
 ## 6. Verification
 
-- [ ] 6.1 Run `go build ./cmd/gaze` — verify clean compilation.
-- [ ] 6.2 Run `go test -race -count=1 -short ./internal/aireport/...` —
+- [x] 6.1 Run `go build ./cmd/gaze` — verify clean compilation.
+- [x] 6.2 Run `go test -race -count=1 -short ./internal/aireport/...` —
   verify all tests pass.
-- [ ] 6.3 Run `golangci-lint run` — verify no lint violations.
-- [ ] 6.4 Run `go test -race -count=1 -short ./...` — verify no
+- [x] 6.3 Run `golangci-lint run` — verify no lint violations.
+- [x] 6.4 Run `go test -race -count=1 -short ./...` — verify no
   regressions outside `internal/aireport/`.
-- [ ] 6.5 Constitution alignment verification: confirm Principle I
+- [x] 6.5 Constitution alignment verification: confirm Principle I
   (Accuracy — no false positives from zero-value masquerade),
   Principle III (Actionable Output — threshold results distinguish
   zero from unavailable), and Principle IV (Testability — all new

--- a/openspec/changes/report-step-failure-gate/tasks.md
+++ b/openspec/changes/report-step-failure-gate/tasks.md
@@ -1,0 +1,143 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Type migration: `int` → `*int`
+
+Convert `CRAPload` and `AvgContractCoverage` from `int` to `*int` in all
+pipeline structs. This is the foundational change — all subsequent tasks
+depend on it.
+
+- [ ] 1.1 Change `ReportSummary.CRAPload` from `int` to `*int` and
+  `ReportSummary.AvgContractCoverage` from `int` to `*int` in
+  `internal/aireport/payload.go`. Update GoDoc comments to match
+  the `GazeCRAPload` pattern ("Nil means the metric was not computed").
+
+- [ ] 1.2 Change `crapStepResult.CRAPload` from `int` to `*int` in
+  `internal/aireport/runner_steps.go` (line 87). Update the
+  `runCRAPStep` success path to use `intPtr(rpt.Summary.CRAPload)`
+  (line 130).
+
+- [ ] 1.3 Change `qualityStepResult.AvgContractCoverage` from `int` to
+  `*int` in `internal/aireport/runner_steps.go` (line 141). Update the
+  quality step success path to use `intPtr(...)` for the computed
+  average. **Note**: task 1.2 and 1.3 touch the same file and MUST
+  be done together.
+
+- [ ] 1.4 Change `compactSummary.CRAPload` from `int` to `*int` and
+  `compactSummary.AvgContractCoverage` from `int` to `*int` in
+  `internal/aireport/compact.go` (lines 27, 29). Add `omitempty` JSON
+  tags to match `GazeCRAPload` pattern. Update `CompactForAI` and
+  `compactForFullJSON` assignment sites (lines 165, 167, 232, 237) to
+  propagate `*int` values correctly.
+
+- [ ] 1.5 Update `runProductionPipeline` in `internal/aireport/runner.go`
+  (lines 297, 313) — the assignment `payload.Summary.CRAPload = crapRes.CRAPload`
+  already lives in the success branch, so it will naturally propagate the
+  `*int`. Verify no additional changes are needed in the error branch
+  (nil default is correct). Same for `AvgContractCoverage` at line 313.
+
+## 2. Threshold evaluation: nil-check guards
+
+Add nil-unavailability handling to `EvaluateThresholds` for `CRAPload`
+and `AvgContractCoverage`, mirroring the existing `GazeCRAPload`
+pattern (threshold.go:48-57).
+
+- [ ] 2.1 Update the `CRAPload` threshold block (threshold.go:32-44) to
+  check `summary.CRAPload == nil` first. When nil: append a FAIL result
+  with `Name: "CRAPload (unavailable)"`, `Actual: nil`, `Passed: false`.
+  When non-nil: dereference and compare as before, using
+  `Actual: summary.CRAPload`.
+
+- [ ] 2.2 Update the `AvgContractCoverage` threshold block
+  (threshold.go:72-84) to check `summary.AvgContractCoverage == nil`
+  first. When nil: append a FAIL result with
+  `Name: "AvgContractCoverage (unavailable)"`, `Actual: nil`,
+  `Passed: false`. When non-nil: dereference and compare as before.
+  **Note**: tasks 2.1 and 2.2 touch the same file and MUST be done
+  together.
+
+## 3. Tests: threshold unavailability
+
+Add unit tests for `EvaluateThresholds` covering the new nil-handling
+paths.
+
+- [ ] 3.1 [P] Add `TestEvaluateThresholds_CRAPload_Unavailable` to
+  `internal/aireport/threshold_test.go`. Verify that when
+  `Summary.CRAPload` is nil and `MaxCrapload` is set, the result is
+  FAIL with `Actual == nil` and `Name` contains "(unavailable)".
+
+- [ ] 3.2 [P] Add `TestEvaluateThresholds_AvgContractCoverage_Unavailable`
+  to `internal/aireport/threshold_test.go`. Same pattern for
+  `AvgContractCoverage` + `MinContractCoverage`.
+
+- [ ] 3.3 [P] Add `TestEvaluateThresholds_CRAPload_ZeroIsValid` to
+  `internal/aireport/threshold_test.go`. Verify that
+  `CRAPload = intPtr(0)` with `MaxCrapload = 5` produces PASS with
+  `Actual = intPtr(0)` — confirming zero-from-success is
+  distinguishable from nil-from-failure.
+
+- [ ] 3.4 [P] Update `TestEvaluateThresholds_NilPayload` in
+  `internal/aireport/threshold_test.go` — with nil payload, all
+  summary fields are nil (not zero), so all configured thresholds
+  should now FAIL with "(unavailable)".
+
+  **Note**: tasks 3.1-3.4 all touch `threshold_test.go` — despite [P]
+  markers, these should be implemented as a single batch to avoid
+  conflicts.
+
+## 4. Tests: integration (Run end-to-end)
+
+Add integration tests verifying `Run` returns error when step failure
++ threshold are combined.
+
+- [ ] 4.1 Update `TestRun_ZeroResults_CRAPStepFailed_NoGate` in
+  `internal/aireport/runner_test.go` — change assertion from
+  `err == nil` to `err != nil`. The test should verify that when the
+  CRAP step fails and `MaxCrapload` is set, `Run` returns an error.
+  Update the test name to reflect the new behavior (e.g.,
+  `TestRun_CRAPStepFailed_ThresholdSet_ReturnsError`).
+
+- [ ] 4.2 Add `TestRun_QualityStepFailed_ContractCoverageThreshold_ReturnsError`
+  to `internal/aireport/runner_test.go`. Verify that when the quality
+  step fails and `MinContractCoverage` is set, `Run` returns an error.
+
+- [ ] 4.3 Add `TestRun_CRAPStepFailed_NoThreshold_ReturnsNil` to
+  `internal/aireport/runner_test.go`. Verify that when the CRAP step
+  fails but NO threshold flags are set, `Run` still returns nil
+  (preserving the partial-failure design).
+
+## 5. Tests: pipeline internal
+
+Update pipeline internal tests to reflect `*int` types.
+
+- [ ] 5.1 Update `fakeSteps` and assertions in
+  `internal/aireport/pipeline_internal_test.go` to use `*int` for
+  `CRAPload` and `AvgContractCoverage`. Verify existing tests compile
+  and pass with the type changes.
+
+- [ ] 5.2 Add `TestRunProductionPipeline_CRAPStepFails_CRAPloadIsNil`
+  to `internal/aireport/pipeline_internal_test.go`. Verify that when
+  the CRAP step fails, `payload.Summary.CRAPload` is nil (not zero).
+
+## 6. Verification
+
+- [ ] 6.1 Run `go build ./cmd/gaze` — verify clean compilation.
+- [ ] 6.2 Run `go test -race -count=1 -short ./internal/aireport/...` —
+  verify all tests pass.
+- [ ] 6.3 Run `golangci-lint run` — verify no lint violations.
+- [ ] 6.4 Run `go test -race -count=1 -short ./...` — verify no
+  regressions outside `internal/aireport/`.
+- [ ] 6.5 Constitution alignment verification: confirm Principle I
+  (Accuracy — no false positives from zero-value masquerade),
+  Principle III (Actionable Output — threshold results distinguish
+  zero from unavailable), and Principle IV (Testability — all new
+  paths are covered by tests).


### PR DESCRIPTION
## Summary

Fixes #102 — `gaze report` (the CI gate) exits 0 / "PASS" when an analysis step fails because `CRAPload` and `AvgContractCoverage` are `int`, and Go's zero value `0` passes threshold checks (`0 <= limit`).

## Root Cause

Type asymmetry: `GazeCRAPload` was already `*int` (nil = unavailable, correctly fails gate per #108), but `CRAPload` and `AvgContractCoverage` remained bare `int` (zero = indistinguishable from "analysis failed").

## Fix

Convert `CRAPload` and `AvgContractCoverage` from `int` to `*int` in `ReportSummary`, `crapStepResult`, `qualityStepResult`, and `compactSummary`. Add nil-check guards to `EvaluateThresholds` mirroring the existing `GazeCRAPload` pattern.

When a threshold is configured but the metric is nil (step failed), the result is FAIL with `Name: "CRAPload (unavailable)"`, `Actual: nil`.

## Changed Files

- `internal/aireport/payload.go` — `CRAPload int` → `*int`, `AvgContractCoverage int` → `*int`
- `internal/aireport/threshold.go` — nil-check guards for CRAPload and AvgContractCoverage
- `internal/aireport/runner_steps.go` — step result types → `*int`
- `internal/aireport/compact.go` — `compactSummary` fields → `*int` with `omitempty`
- `cmd/gaze/main.go` — wraps `int` → `*int` at external analyzer boundary
- 7 test files — 5 new tests, 2 bug-enshrining tests fixed, mechanical `intPtr()` wrapping

## Testing

- 5 new tests covering unavailable metrics, zero-from-success, quality step failure + threshold
- 2 bug-enshrining tests corrected (previously asserted `err == nil` on the exact bug scenario)
- All packages pass with `-race -count=1 -short`
- 0 lint issues

Closes #102
Related: #108, #116, #103