### PR TITLE
chore: add DCP config for protect tag preservation

### DIFF
--- a/.opencode/dcp.jsonc
+++ b/.opencode/dcp.jsonc
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Opencode-DCP/opencode-dynamic-context-pruning/master/dcp.schema.json",
+  // Enable <protect> tag preservation during DCP compression.
+  // Slash command files in .opencode/commands/ use <protect> tags
+  // to mark execution-critical sections (guardrails, checklists,
+  // mandatory gates) that must survive context pruning.
+  "compress": {
+    "protectTags": true
+  }
+}


### PR DESCRIPTION
Adds `.opencode/dcp.jsonc` configuration file to enable `<protect>` tag preservation during DCP context compression.

Slash command files in `.opencode/commands/` use `<protect>` tags to mark execution-critical sections (guardrails, checklists, mandatory gates) that must survive context pruning. This config ensures DCP respects those tags.