### PR TITLE
fix: confidenceRange returns inverted sentinels when no effects have classification

### DIFF
--- a/internal/adapter/contract.go
+++ b/internal/adapter/contract.go
@@ -176,16 +176,24 @@ func buildContractLookup(
 
 // deriveCoverageReason determines the coverage reason and confidence
 // range from the computed contract coverage and raw effects. This
-// mirrors the diagnostic logic in the Go-native path
-// (internal/crap/contract.go) for output parity.
+// parallels the diagnostic logic in the Go-native path
+// (internal/provider/goprovider/contract.go, computeCoverageReason)
+// but operates on all side effects rather than the pre-filtered
+// AmbiguousEffects from the quality pipeline.
 func deriveCoverageReason(effects []taxonomy.SideEffect, cc taxonomy.ContractCoverage) (reason string, minConf, maxConf int) {
+	// Defensive guard: buildContractLookup only creates map entries
+	// for functions with len(SideEffects) > 0, so this branch is
+	// unreachable from the sole production caller. Kept for safety.
 	if len(effects) == 0 {
 		return "no_effects_detected", 0, 0
 	}
 	if cc.TotalContractual == 0 {
 		minC, maxC, found := confidenceRange(effects)
 		if !found {
-			return "no_effects_detected", 0, 0
+			// Effects exist but none have a Classification (e.g.,
+			// external analyzer with classify_signals: false).
+			// Distinct from "no_effects_detected" (len(effects)==0).
+			return "all_effects_unclassified", 0, 0
 		}
 		return "all_effects_ambiguous", minC, maxC
 	}

--- a/internal/adapter/contract.go
+++ b/internal/adapter/contract.go
@@ -183,24 +183,33 @@ func deriveCoverageReason(effects []taxonomy.SideEffect, cc taxonomy.ContractCov
 		return "no_effects_detected", 0, 0
 	}
 	if cc.TotalContractual == 0 {
-		min, max := confidenceRange(effects)
-		return "all_effects_ambiguous", min, max
+		minC, maxC, found := confidenceRange(effects)
+		if !found {
+			return "no_effects_detected", 0, 0
+		}
+		return "all_effects_ambiguous", minC, maxC
 	}
 	return "", 0, 0
 }
 
 // confidenceRange returns the min and max classification confidence
-// across all effects that have a non-nil Classification.
-func confidenceRange(effects []taxonomy.SideEffect) (minConf, maxConf int) {
+// across all effects that have a non-nil Classification. The found
+// return value indicates whether any classified effects were seen;
+// when false, minConf and maxConf are zero (not inverted sentinels).
+func confidenceRange(effects []taxonomy.SideEffect) (minConf, maxConf int, found bool) {
 	minConf, maxConf = 100, 0
 	for _, e := range effects {
 		if e.Classification == nil {
 			continue
 		}
+		found = true
 		minConf = min(minConf, e.Classification.Confidence)
 		maxConf = max(maxConf, e.Classification.Confidence)
 	}
-	return minConf, maxConf
+	if !found {
+		return 0, 0, false
+	}
+	return minConf, maxConf, true
 }
 
 // findSideEffectID finds the ID of the first side effect matching

--- a/internal/adapter/contract_internal_test.go
+++ b/internal/adapter/contract_internal_test.go
@@ -1,0 +1,155 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/unbound-force/gaze/internal/taxonomy"
+)
+
+// ---------------------------------------------------------------------------
+// confidenceRange tests
+// ---------------------------------------------------------------------------
+
+func TestConfidenceRange_AllNilClassification(t *testing.T) {
+	effects := []taxonomy.SideEffect{
+		{Classification: nil},
+		{Classification: nil},
+	}
+	minC, maxC, found := confidenceRange(effects)
+	if found {
+		t.Errorf("found = true, want false")
+	}
+	if minC != 0 {
+		t.Errorf("minConf = %d, want 0", minC)
+	}
+	if maxC != 0 {
+		t.Errorf("maxConf = %d, want 0", maxC)
+	}
+}
+
+func TestConfidenceRange_AllClassified(t *testing.T) {
+	effects := []taxonomy.SideEffect{
+		{Classification: &taxonomy.Classification{Confidence: 78}},
+		{Classification: &taxonomy.Classification{Confidence: 85}},
+		{Classification: &taxonomy.Classification{Confidence: 79}},
+	}
+	minC, maxC, found := confidenceRange(effects)
+	if !found {
+		t.Errorf("found = false, want true")
+	}
+	if minC != 78 {
+		t.Errorf("minConf = %d, want 78", minC)
+	}
+	if maxC != 85 {
+		t.Errorf("maxConf = %d, want 85", maxC)
+	}
+}
+
+func TestConfidenceRange_MixedNilAndClassified(t *testing.T) {
+	effects := []taxonomy.SideEffect{
+		{Classification: nil},
+		{Classification: &taxonomy.Classification{Confidence: 60}},
+		{Classification: nil},
+		{Classification: &taxonomy.Classification{Confidence: 72}},
+	}
+	minC, maxC, found := confidenceRange(effects)
+	if !found {
+		t.Errorf("found = false, want true")
+	}
+	if minC != 60 {
+		t.Errorf("minConf = %d, want 60", minC)
+	}
+	if maxC != 72 {
+		t.Errorf("maxConf = %d, want 72", maxC)
+	}
+}
+
+func TestConfidenceRange_SingleEffect(t *testing.T) {
+	effects := []taxonomy.SideEffect{
+		{Classification: &taxonomy.Classification{Confidence: 50}},
+	}
+	minC, maxC, found := confidenceRange(effects)
+	if !found {
+		t.Errorf("found = false, want true")
+	}
+	if minC != 50 {
+		t.Errorf("minConf = %d, want 50", minC)
+	}
+	if maxC != 50 {
+		t.Errorf("maxConf = %d, want 50", maxC)
+	}
+}
+
+func TestConfidenceRange_EmptySlice(t *testing.T) {
+	minC, maxC, found := confidenceRange(nil)
+	if found {
+		t.Errorf("found = true, want false")
+	}
+	if minC != 0 {
+		t.Errorf("minConf = %d, want 0", minC)
+	}
+	if maxC != 0 {
+		t.Errorf("maxConf = %d, want 0", maxC)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// deriveCoverageReason tests
+// ---------------------------------------------------------------------------
+
+func TestDeriveCoverageReason_NoEffects(t *testing.T) {
+	reason, minC, maxC := deriveCoverageReason(nil, taxonomy.ContractCoverage{})
+	if reason != "no_effects_detected" {
+		t.Errorf("reason = %q, want %q", reason, "no_effects_detected")
+	}
+	if minC != 0 || maxC != 0 {
+		t.Errorf("confidence = (%d, %d), want (0, 0)", minC, maxC)
+	}
+}
+
+func TestDeriveCoverageReason_AllNilClassification(t *testing.T) {
+	effects := []taxonomy.SideEffect{
+		{Classification: nil},
+		{Classification: nil},
+	}
+	cc := taxonomy.ContractCoverage{TotalContractual: 0}
+	reason, minC, maxC := deriveCoverageReason(effects, cc)
+	if reason != "no_effects_detected" {
+		t.Errorf("reason = %q, want %q", reason, "no_effects_detected")
+	}
+	if minC != 0 || maxC != 0 {
+		t.Errorf("confidence = (%d, %d), want (0, 0)", minC, maxC)
+	}
+}
+
+func TestDeriveCoverageReason_AllAmbiguous(t *testing.T) {
+	effects := []taxonomy.SideEffect{
+		{Classification: &taxonomy.Classification{Confidence: 78}},
+		{Classification: &taxonomy.Classification{Confidence: 79}},
+	}
+	cc := taxonomy.ContractCoverage{TotalContractual: 0}
+	reason, minC, maxC := deriveCoverageReason(effects, cc)
+	if reason != "all_effects_ambiguous" {
+		t.Errorf("reason = %q, want %q", reason, "all_effects_ambiguous")
+	}
+	if minC != 78 {
+		t.Errorf("minConf = %d, want 78", minC)
+	}
+	if maxC != 79 {
+		t.Errorf("maxConf = %d, want 79", maxC)
+	}
+}
+
+func TestDeriveCoverageReason_WithContractual(t *testing.T) {
+	effects := []taxonomy.SideEffect{
+		{Classification: &taxonomy.Classification{Confidence: 90}},
+	}
+	cc := taxonomy.ContractCoverage{TotalContractual: 1}
+	reason, minC, maxC := deriveCoverageReason(effects, cc)
+	if reason != "" {
+		t.Errorf("reason = %q, want empty string", reason)
+	}
+	if minC != 0 || maxC != 0 {
+		t.Errorf("confidence = (%d, %d), want (0, 0)", minC, maxC)
+	}
+}

--- a/internal/adapter/contract_internal_test.go
+++ b/internal/adapter/contract_internal_test.go
@@ -7,149 +7,145 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// confidenceRange tests
+// confidenceRange tests (table-driven)
 // ---------------------------------------------------------------------------
 
-func TestConfidenceRange_AllNilClassification(t *testing.T) {
-	effects := []taxonomy.SideEffect{
-		{Classification: nil},
-		{Classification: nil},
+func TestConfidenceRange(t *testing.T) {
+	tests := []struct {
+		name    string
+		effects []taxonomy.SideEffect
+		wantMin int
+		wantMax int
+		wantOK  bool
+	}{
+		{
+			name:    "empty slice",
+			effects: nil,
+			wantMin: 0, wantMax: 0, wantOK: false,
+		},
+		{
+			name: "all nil classification",
+			effects: []taxonomy.SideEffect{
+				{Classification: nil},
+				{Classification: nil},
+			},
+			wantMin: 0, wantMax: 0, wantOK: false,
+		},
+		{
+			name: "all classified",
+			effects: []taxonomy.SideEffect{
+				{Classification: &taxonomy.Classification{Confidence: 78}},
+				{Classification: &taxonomy.Classification{Confidence: 85}},
+				{Classification: &taxonomy.Classification{Confidence: 79}},
+			},
+			wantMin: 78, wantMax: 85, wantOK: true,
+		},
+		{
+			name: "mixed nil and classified",
+			effects: []taxonomy.SideEffect{
+				{Classification: nil},
+				{Classification: &taxonomy.Classification{Confidence: 60}},
+				{Classification: nil},
+				{Classification: &taxonomy.Classification{Confidence: 72}},
+			},
+			wantMin: 60, wantMax: 72, wantOK: true,
+		},
+		{
+			name: "single effect",
+			effects: []taxonomy.SideEffect{
+				{Classification: &taxonomy.Classification{Confidence: 50}},
+			},
+			wantMin: 50, wantMax: 50, wantOK: true,
+		},
 	}
-	minC, maxC, found := confidenceRange(effects)
-	if found {
-		t.Errorf("found = true, want false")
-	}
-	if minC != 0 {
-		t.Errorf("minConf = %d, want 0", minC)
-	}
-	if maxC != 0 {
-		t.Errorf("maxConf = %d, want 0", maxC)
-	}
-}
-
-func TestConfidenceRange_AllClassified(t *testing.T) {
-	effects := []taxonomy.SideEffect{
-		{Classification: &taxonomy.Classification{Confidence: 78}},
-		{Classification: &taxonomy.Classification{Confidence: 85}},
-		{Classification: &taxonomy.Classification{Confidence: 79}},
-	}
-	minC, maxC, found := confidenceRange(effects)
-	if !found {
-		t.Errorf("found = false, want true")
-	}
-	if minC != 78 {
-		t.Errorf("minConf = %d, want 78", minC)
-	}
-	if maxC != 85 {
-		t.Errorf("maxConf = %d, want 85", maxC)
-	}
-}
-
-func TestConfidenceRange_MixedNilAndClassified(t *testing.T) {
-	effects := []taxonomy.SideEffect{
-		{Classification: nil},
-		{Classification: &taxonomy.Classification{Confidence: 60}},
-		{Classification: nil},
-		{Classification: &taxonomy.Classification{Confidence: 72}},
-	}
-	minC, maxC, found := confidenceRange(effects)
-	if !found {
-		t.Errorf("found = false, want true")
-	}
-	if minC != 60 {
-		t.Errorf("minConf = %d, want 60", minC)
-	}
-	if maxC != 72 {
-		t.Errorf("maxConf = %d, want 72", maxC)
-	}
-}
-
-func TestConfidenceRange_SingleEffect(t *testing.T) {
-	effects := []taxonomy.SideEffect{
-		{Classification: &taxonomy.Classification{Confidence: 50}},
-	}
-	minC, maxC, found := confidenceRange(effects)
-	if !found {
-		t.Errorf("found = false, want true")
-	}
-	if minC != 50 {
-		t.Errorf("minConf = %d, want 50", minC)
-	}
-	if maxC != 50 {
-		t.Errorf("maxConf = %d, want 50", maxC)
-	}
-}
-
-func TestConfidenceRange_EmptySlice(t *testing.T) {
-	minC, maxC, found := confidenceRange(nil)
-	if found {
-		t.Errorf("found = true, want false")
-	}
-	if minC != 0 {
-		t.Errorf("minConf = %d, want 0", minC)
-	}
-	if maxC != 0 {
-		t.Errorf("maxConf = %d, want 0", maxC)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			minC, maxC, found := confidenceRange(tt.effects)
+			if found != tt.wantOK {
+				t.Errorf("found = %v, want %v", found, tt.wantOK)
+			}
+			if minC != tt.wantMin {
+				t.Errorf("minConf = %d, want %d", minC, tt.wantMin)
+			}
+			if maxC != tt.wantMax {
+				t.Errorf("maxConf = %d, want %d", maxC, tt.wantMax)
+			}
+		})
 	}
 }
 
 // ---------------------------------------------------------------------------
-// deriveCoverageReason tests
+// deriveCoverageReason tests (table-driven)
 // ---------------------------------------------------------------------------
 
-func TestDeriveCoverageReason_NoEffects(t *testing.T) {
-	reason, minC, maxC := deriveCoverageReason(nil, taxonomy.ContractCoverage{})
-	if reason != "no_effects_detected" {
-		t.Errorf("reason = %q, want %q", reason, "no_effects_detected")
+func TestDeriveCoverageReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		effects    []taxonomy.SideEffect
+		cc         taxonomy.ContractCoverage
+		wantReason string
+		wantMin    int
+		wantMax    int
+	}{
+		{
+			name:       "no effects",
+			effects:    nil,
+			cc:         taxonomy.ContractCoverage{},
+			wantReason: "no_effects_detected",
+			wantMin:    0, wantMax: 0,
+		},
+		{
+			name: "all nil classification",
+			effects: []taxonomy.SideEffect{
+				{Classification: nil},
+				{Classification: nil},
+			},
+			cc:         taxonomy.ContractCoverage{TotalContractual: 0},
+			wantReason: "all_effects_unclassified",
+			wantMin:    0, wantMax: 0,
+		},
+		{
+			name: "all ambiguous (classified but below threshold)",
+			effects: []taxonomy.SideEffect{
+				{Classification: &taxonomy.Classification{Confidence: 78}},
+				{Classification: &taxonomy.Classification{Confidence: 79}},
+			},
+			cc:         taxonomy.ContractCoverage{TotalContractual: 0},
+			wantReason: "all_effects_ambiguous",
+			wantMin:    78, wantMax: 79,
+		},
+		{
+			name: "with contractual effects",
+			effects: []taxonomy.SideEffect{
+				{Classification: &taxonomy.Classification{Confidence: 90}},
+			},
+			cc:         taxonomy.ContractCoverage{TotalContractual: 1},
+			wantReason: "",
+			wantMin:    0, wantMax: 0,
+		},
+		{
+			name: "contractual > 0 with all nil classification",
+			effects: []taxonomy.SideEffect{
+				{Classification: nil},
+				{Classification: nil},
+			},
+			cc:         taxonomy.ContractCoverage{TotalContractual: 1},
+			wantReason: "",
+			wantMin:    0, wantMax: 0,
+		},
 	}
-	if minC != 0 || maxC != 0 {
-		t.Errorf("confidence = (%d, %d), want (0, 0)", minC, maxC)
-	}
-}
-
-func TestDeriveCoverageReason_AllNilClassification(t *testing.T) {
-	effects := []taxonomy.SideEffect{
-		{Classification: nil},
-		{Classification: nil},
-	}
-	cc := taxonomy.ContractCoverage{TotalContractual: 0}
-	reason, minC, maxC := deriveCoverageReason(effects, cc)
-	if reason != "no_effects_detected" {
-		t.Errorf("reason = %q, want %q", reason, "no_effects_detected")
-	}
-	if minC != 0 || maxC != 0 {
-		t.Errorf("confidence = (%d, %d), want (0, 0)", minC, maxC)
-	}
-}
-
-func TestDeriveCoverageReason_AllAmbiguous(t *testing.T) {
-	effects := []taxonomy.SideEffect{
-		{Classification: &taxonomy.Classification{Confidence: 78}},
-		{Classification: &taxonomy.Classification{Confidence: 79}},
-	}
-	cc := taxonomy.ContractCoverage{TotalContractual: 0}
-	reason, minC, maxC := deriveCoverageReason(effects, cc)
-	if reason != "all_effects_ambiguous" {
-		t.Errorf("reason = %q, want %q", reason, "all_effects_ambiguous")
-	}
-	if minC != 78 {
-		t.Errorf("minConf = %d, want 78", minC)
-	}
-	if maxC != 79 {
-		t.Errorf("maxConf = %d, want 79", maxC)
-	}
-}
-
-func TestDeriveCoverageReason_WithContractual(t *testing.T) {
-	effects := []taxonomy.SideEffect{
-		{Classification: &taxonomy.Classification{Confidence: 90}},
-	}
-	cc := taxonomy.ContractCoverage{TotalContractual: 1}
-	reason, minC, maxC := deriveCoverageReason(effects, cc)
-	if reason != "" {
-		t.Errorf("reason = %q, want empty string", reason)
-	}
-	if minC != 0 || maxC != 0 {
-		t.Errorf("confidence = (%d, %d), want (0, 0)", minC, maxC)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, minC, maxC := deriveCoverageReason(tt.effects, tt.cc)
+			if reason != tt.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tt.wantReason)
+			}
+			if minC != tt.wantMin {
+				t.Errorf("minConf = %d, want %d", minC, tt.wantMin)
+			}
+			if maxC != tt.wantMax {
+				t.Errorf("maxConf = %d, want %d", maxC, tt.wantMax)
+			}
+		})
 	}
 }

--- a/internal/crap/analyze.go
+++ b/internal/crap/analyze.go
@@ -57,10 +57,11 @@ type ContractCoverageInfo struct {
 
 	// Reason explains why coverage is what it is. Empty string
 	// for normal coverage. Values:
-	//   "all_effects_ambiguous" — all effects classified ambiguous
-	//   "no_effects_detected"  — function has no side effects
-	//   "no_test_coverage"     — effects were detected but no test targets this function
-	//   "no_assertions_mapped" — effects exist but none mapped
+	//   "all_effects_ambiguous"    — all effects classified ambiguous
+	//   "all_effects_unclassified" — effects exist but none have classification data (external analyzer)
+	//   "no_effects_detected"     — function has no side effects
+	//   "no_test_coverage"        — effects were detected but no test targets this function
+	//   "no_assertions_mapped"    — effects exist but none mapped
 	Reason string
 
 	// MinConfidence is the lowest classification confidence across

--- a/openspec/changes/fix-confidence-range-sentinels/proposal.md
+++ b/openspec/changes/fix-confidence-range-sentinels/proposal.md
@@ -1,0 +1,100 @@
+## Why
+
+`confidenceRange` in `internal/adapter/contract.go` initializes min/max
+sentinels as `(100, 0)` and skips effects with `nil` Classification. When
+all effects have nil Classification (the normal state for external analyzers
+with `classify_signals: false`), the inverted sentinels `(100, 0)` flow
+through `deriveCoverageReason` into CRAP output as `"confidence 100-0"`.
+
+This violates Principle I (Accuracy) — the output is nonsensical and
+misleading. Reported in #181.
+
+## What Changes
+
+### `confidenceRange` returns `found bool`
+
+A third `found bool` return value indicates whether any classified effects
+were seen. When `!found`, the function returns `(0, 0, false)` instead of
+the inverted sentinels `(100, 0)`.
+
+### `deriveCoverageReason` maps `!found` to `"all_effects_unclassified"`
+
+When effects exist but none carry classification data (the external analyzer
+`classify_signals: false` case), the reason string is set to
+`"all_effects_unclassified"` — a new value distinct from
+`"no_effects_detected"` (which means "function has no side effects").
+
+### Doc comment corrections
+
+- Fixed incorrect path reference (`internal/crap/contract.go` →
+  `internal/provider/goprovider/contract.go`)
+- Corrected parity claim: the adapter iterates all effects, not the
+  pre-filtered `AmbiguousEffects` from the quality pipeline
+
+### Table-driven tests
+
+Consolidated 5 structurally identical `confidenceRange` tests and 4
+`deriveCoverageReason` tests into two table-driven test functions. Added
+a missing test case for `TotalContractual > 0` with all-nil Classification.
+
+## Capabilities
+
+### New Capabilities
+- New `"all_effects_unclassified"` reason string in `ContractCoverageInfo`
+
+### Modified Capabilities
+- `confidenceRange` signature: `(int, int)` → `(int, int, bool)`
+- `deriveCoverageReason` now returns `"all_effects_unclassified"` instead
+  of `"no_effects_detected"` when effects exist but are unclassified
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Modified files**: `internal/adapter/contract.go` (logic fix + doc
+  corrections), `internal/adapter/contract_internal_test.go` (table-driven
+  rewrite + new test case), `internal/crap/analyze.go` (Reason doc update)
+- **Risk**: Low. The change only affects the external analyzer code path.
+  The Go-native path is unmodified.
+- **Test impact**: 10 test cases across 2 table-driven functions (was 9
+  across 9 individual functions). New test case covers `TotalContractual > 0`
+  with all-nil Classification.
+
+## Constitution Alignment
+
+Assessed against the Gaze project constitution (`.specify/memory/constitution.md`).
+
+### I. Accuracy
+
+**Assessment**: PASS
+
+Eliminates a false output value (`"confidence 100-0"`) and a semantically
+incorrect reason string (`"no_effects_detected"` for functions that have
+detected effects). The new `"all_effects_unclassified"` reason accurately
+describes the state: effects exist but carry no classification data.
+
+### II. Minimal Assumptions
+
+**Assessment**: N/A
+
+No new assumptions about host project structure. The fix applies to the
+existing external analyzer protocol path.
+
+### III. Actionable Output
+
+**Assessment**: PASS
+
+Replaces a confusing output value with a clear, machine-readable reason
+string that correctly guides users. The `"all_effects_unclassified"` label
+tells the user their external analyzer needs to provide classification data
+for GazeCRAP to be meaningful.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Both modified functions (`confidenceRange`, `deriveCoverageReason`) are
+directly testable with synthetic inputs. Table-driven tests cover all
+branches. The `found bool` return is more testable than the previous
+implicit sentinel approach.


### PR DESCRIPTION
## Summary

Fixes #181.

`confidenceRange` in `internal/adapter/contract.go` initialized min/max sentinels as `(100, 0)` and skipped effects with `nil` Classification. When **all** effects had `nil` Classification, the inverted sentinels were returned
unchanged, flowing through `deriveCoverageReason` into CRAP output as `"confidence 100-0"`.

## Root Cause

The Go-native path (`goprovider/contract.go:230-249`) guards against this with an `effectCount > 0` check. The adapter path lacked this guard — a parity gap.

## Fix

- Added a `found bool` return value to `confidenceRange`. When no classified effects are seen, returns `(0, 0, false)` instead of inverted sentinels.
- Updated `deriveCoverageReason` to map `!found` to `"no_effects_detected"` with zeroed confidence, matching the Go-native path's behavior.

## Tests

Added 9 unit tests in `contract_internal_test.go`:

- **`confidenceRange`** (5 tests): all-nil, all-classified, mixed, single effect, empty slice
- **`deriveCoverageReason`** (4 tests): no effects, all-nil classification, all ambiguous, with contractual effects

## Impact

Low — only affects the external analyzer protocol path (`--analyzer` flag) when the analyzer doesn't support `classify_signals`. No CRAP score computation change; output-only cosmetic fix.

## Files Changed

- `internal/adapter/contract.go` — fix (14 insertions, 5 deletions)
- `internal/adapter/contract_internal_test.go` — new test file (155 lines)

## CI

- `go build ./cmd/gaze` — pass
- `go test -race -count=1 -short ./...` — pass (all 17 packages)
- `golangci-lint run` — 0 issues