### PR TITLE
chore: sync release workflow with replicator template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
       skip_semver_check: ${{ inputs.skip_semver_check }}
       skip_ci_checks: ${{ inputs.skip_ci_checks }}
       skip_unreleased_check: ${{ inputs.skip_unreleased_check }}
+      allow_prerelease: true
     permissions:
       contents: write
       checks: read
@@ -322,3 +323,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Cleanup signing materials
+        if: always()
+        run: |
+          rm -f "$RUNNER_TEMP/cert.p12" "$RUNNER_TEMP/notary_key.p8"
+          if [ -f "$RUNNER_TEMP/app-signing.keychain-db" ]; then
+            security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" 2>/dev/null || true
+          fi


### PR DESCRIPTION
## Summary

Syncs safe improvements from the replicator release workflow template
(unbound-force/replicator#61) and dewey's recent sync (unbound-force/dewey#104).

## Changes

1. **Add `allow_prerelease: true` to preflight inputs** — enables prerelease
   tags (e.g., `v1.7.0-rc.1`) to pass the org-infra semver ordering check.
   Without this, the preflight reusable workflow rejects prerelease tags.

2. **Add cleanup signing materials step to `sign-macos` job** — removes the
   P12 certificate, notary key, and temporary keychain from the runner even
   if earlier steps fail (`if: always()`). Defense-in-depth for secret
   material hygiene on macOS runners.

## Not included

- **Concurrency deadlock fix** (dewey#105): Gaze's `release.yml` has no
  top-level `concurrency:` block, so this issue doesn't apply.
- **`check-secrets` output key renaming**: Gaze already uses consistent
  naming (`has_signing_secrets` / `has_secrets`).