### PR TITLE
chore: mark prerelease tags automatically in GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,6 +28,7 @@ checksum:
   name_template: checksums.txt
 
 release:
+  prerelease: auto
   extra_files:
     - glob: dist/homebrew/Casks/gaze.rb
 


### PR DESCRIPTION
## Summary

Add `prerelease: auto` to `.goreleaser.yaml` so GoReleaser automatically detects semver prerelease suffixes (`-rc.N`, `-alpha.N`, `-beta.N`) and sets the GitHub release `prerelease` flag accordingly.

## Problem

The `v1.7.0-rc.1` release was published as a full release despite having a prerelease suffix. This means `brew upgrade` would install it as the latest stable version, and the GitHub releases page shows it alongside stable releases without distinction.

## Change

One-line addition to the existing `release:` block in `.goreleaser.yaml`.Stable tags (e.g., `v1.7.0`) continue to be marked as full releases.